### PR TITLE
feat: edit remaining match time via long-press (#21)

### DIFF
--- a/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
+++ b/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
@@ -61,8 +61,9 @@ Add a public setter next to the `remainingTime` getter:
 void setRemainingTime(int seconds) {
   // Editing is gated to a stopped clock in an active half by the UI, so
   // the run-clock catch-up anchors are already null — no reconciliation
-  // needed — and both editable stages cap at periodTime.
-  _remainingTime = seconds.clamp(0, periodTime);
+  // needed — and both editable stages cap at periodTime. Floor at 1 so an
+  // active half is never parked at 0:00 (see the clamp note below).
+  _remainingTime = seconds.clamp(1, periodTime);
   notifyListeners();
   _broadcastStageAndTime();
 }
@@ -113,7 +114,7 @@ Mirrors `TeamSettingsWidget`:
 ## Testing (manual, on device)
 
 - Long-press while stopped opens the editor.
-- Nudge buttons clamp at 0 and at the stage maximum.
+- Nudge buttons clamp at 1 second (0:01) and at the stage maximum.
 - `mm:ss` entry applies the exact time.
 - The MQTT scoreboard reflects the corrected time.
 - Long-press while running shows the SnackBar and does not open the

--- a/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
+++ b/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
@@ -1,0 +1,112 @@
+# Editable remaining match time via long-press
+
+Tracks GitHub issue #21.
+
+## Problem
+
+There is no way to correct the remaining match time. If the referee
+forgets to stop the clock (e.g. during a rules discussion / stoppage),
+the lost playing time cannot be given back to the teams.
+
+## Solution
+
+Make the timer display editable the same way the score already is:
+**long-press the time** to open a bottom-sheet editor, mirroring the
+existing score editor (`buildTeamContainer` /
+`TeamSettingsWidget`). The double-tap start/stop toggle on the button
+below the time is left untouched (double-tap safety invariant).
+
+## Decisions
+
+- **Editable only while the clock is stopped.** The editor will not open
+  while the timer is running. This avoids reconciling the background
+  catch-up anchors (`_runClockStartedAt`,
+  `_runClockStartRemainingTime`), which are already `null` when stopped
+  (`stopTimer` clears them). Simplest and safest.
+- **Editor controls: quick +/- buttons plus an `mm:ss` field.** Mirrors
+  the score editor's affordance set while allowing a precise jump.
+
+## Correction to the issue's implementation notes
+
+The issue suggests `setRemainingTime` should call
+`notifyAllModulesTimer()` "so per-module damage-timer alerts stay
+correct." Reading the code, `notifyAllModulesTimer()` (game.dart:319)
+*decrements each damaged module's penalty by one tick* — it is the
+per-second damage countdown driven by `_tickTimer`. A one-time game-time
+correction is not a tick; calling it would wrongly subtract a second
+from every active damage timer. Game time and module damage timers are
+independent, so `setRemainingTime` does **not** call it.
+
+Likewise, the issue mentions publishing the corrected time to the BLE
+bridge. The bridge currently carries only `team{1,2}_score` and
+`team{1,2}_color` (`bridge_message.dart`) — there is no time topic, and
+the live timer ticks never publish time to the bridge. To stay
+consistent with existing behavior, `setRemainingTime` publishes to MQTT
+only (mirroring `_tickTimer`). Adding a bridge time topic is out of
+scope.
+
+## Model — `lib/models/game.dart`
+
+Add a public setter next to the `remainingTime` getter:
+
+```dart
+void setRemainingTime(int seconds) {
+  // Editing is gated to a stopped clock in the UI, so the run-clock
+  // catch-up anchors are already null — no reconciliation needed.
+  final maxTime = currentStage == MatchStage.halfTime
+      ? halfTimeDuration
+      : periodTime;
+  _remainingTime = seconds.clamp(0, maxTime);
+  notifyListeners();
+  mqttService.publishTime(_remainingTime);
+}
+```
+
+- Clamp to the current stage's natural maximum (`halfTimeDuration`
+  during the break, otherwise `periodTime`), floor 0.
+- Publishes to MQTT only.
+- Does not touch the run-clock anchors and does not call
+  `notifyAllModulesTimer()`.
+
+## UI — `lib/screens/home.dart`
+
+Wrap the remaining-time `Text` (currently home.dart:88) in a
+`GestureDetector` with `onLongPress`. The double-tap start/stop toggle
+stays on the separate `ElevatedButton` below it (unchanged).
+
+- `onLongPress` opens the editor only when `!game.isTimerRunning` **and**
+  `currentStage` is `firstHalf`, `secondHalf`, or `halfTime`.
+- While the timer is running, show a `SnackBar`: "Stop the clock to edit
+  the time." (Do not open the editor.)
+- The editor is a `showModalBottomSheet` using the same
+  `FractionallySizedBox` + grey container styling as the score editor,
+  hosting a new `TimeSettingsWidget`.
+
+### `TimeSettingsWidget` (new `StatefulWidget`)
+
+Mirrors `TeamSettingsWidget`:
+
+- Title "Edit remaining time".
+- An `mm:ss` `TextEditingController` seeded from `game.remainingTime`.
+  "Set" parses the field (accept `mm:ss` or a plain seconds integer;
+  ignore unparseable input) and applies via `game.setRemainingTime`.
+- Quick-nudge buttons **−1:00 / −0:30 / +0:30 / +1:00**, each calling
+  `game.setRemainingTime(game.remainingTime ± delta)` (clamping handles
+  the bounds) and refreshing the field text to the clamped value.
+
+## Testing (manual, on device)
+
+- Long-press while stopped opens the editor.
+- Nudge buttons clamp at 0 and at the stage maximum.
+- `mm:ss` entry applies the exact time.
+- The MQTT scoreboard reflects the corrected time.
+- Long-press while running shows the SnackBar and does not open the
+  editor.
+- Double-tap start/stop still toggles the clock (invariant preserved).
+
+## Invariants respected (CLAUDE.md)
+
+- No change to the fire-and-forget robot START/STOP path.
+- Start/stop stays double-tap; the edit is a deliberate long-press +
+  bottom-sheet action.
+- Portrait-only and provider tree untouched.

--- a/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
+++ b/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
@@ -18,11 +18,17 @@ below the time is left untouched (double-tap safety invariant).
 
 ## Decisions
 
-- **Editable only while the clock is stopped.** The editor will not open
-  while the timer is running. This avoids reconciling the background
-  catch-up anchors (`_runClockStartedAt`,
-  `_runClockStartRemainingTime`), which are already `null` when stopped
-  (`stopTimer` clears them). Simplest and safest.
+- **Editable only while the clock is stopped within an active first or
+  second half.** The editor will not open while the timer is running.
+  This avoids reconciling the background catch-up anchors
+  (`_runClockStartedAt`, `_runClockStartRemainingTime`), which are
+  already `null` when stopped (`stopTimer` clears them). Half-time is
+  excluded because its clock always runs (the `firstHalf -> halfTime`
+  transition calls `startTimer()` and the only half-time control, SKIP,
+  jumps straight to the second half, so a stopped half-time state never
+  exists). Pre-match setup (`inGame == false`) is excluded so the match
+  duration is changed only via Settings; full time is excluded by the
+  stage check.
 - **Editor controls: quick +/- buttons plus an `mm:ss` field.** Mirrors
   the score editor's affordance set while allowing a precise jump.
 
@@ -40,10 +46,12 @@ independent, so `setRemainingTime` does **not** call it.
 Likewise, the issue mentions publishing the corrected time to the BLE
 bridge. The bridge currently carries only `team{1,2}_score` and
 `team{1,2}_color` (`bridge_message.dart`) — there is no time topic, and
-the live timer ticks never publish time to the bridge. To stay
-consistent with existing behavior, `setRemainingTime` publishes to MQTT
-only (mirroring `_tickTimer`). Adding a bridge time topic is out of
-scope.
+the live timer ticks never publish time to the bridge. `setRemainingTime`
+therefore does not publish to the bridge; adding a bridge time topic is
+out of scope. It does publish stage+time to MQTT via
+`_broadcastStageAndTime()` (the same call every other stopped-state
+update uses — reset, refresh, resume-without-replay, SKIP) so a retained
+MQTT consumer never combines the corrected time with a stale stage.
 
 ## Model — `lib/models/game.dart`
 
@@ -51,20 +59,17 @@ Add a public setter next to the `remainingTime` getter:
 
 ```dart
 void setRemainingTime(int seconds) {
-  // Editing is gated to a stopped clock in the UI, so the run-clock
-  // catch-up anchors are already null — no reconciliation needed.
-  final maxTime = currentStage == MatchStage.halfTime
-      ? halfTimeDuration
-      : periodTime;
-  _remainingTime = seconds.clamp(0, maxTime);
+  // Editing is gated to a stopped clock in an active half by the UI, so
+  // the run-clock catch-up anchors are already null — no reconciliation
+  // needed — and both editable stages cap at periodTime.
+  _remainingTime = seconds.clamp(0, periodTime);
   notifyListeners();
-  mqttService.publishTime(_remainingTime);
+  _broadcastStageAndTime();
 }
 ```
 
-- Clamp to the current stage's natural maximum (`halfTimeDuration`
-  during the break, otherwise `periodTime`), floor 0.
-- Publishes to MQTT only.
+- Clamp to `periodTime` (the maximum of both editable stages), floor 0.
+- Publishes stage+time via `_broadcastStageAndTime()`.
 - Does not touch the run-clock anchors and does not call
   `notifyAllModulesTimer()`.
 
@@ -75,9 +80,10 @@ Wrap the remaining-time `Text` (currently home.dart:88) in a
 stays on the separate `ElevatedButton` below it (unchanged).
 
 - `onLongPress` opens the editor only when `!game.isTimerRunning` **and**
-  `currentStage` is `firstHalf`, `secondHalf`, or `halfTime`.
+  `game.inGame` **and** `currentStage` is `firstHalf` or `secondHalf`.
 - While the timer is running, show a `SnackBar`: "Stop the clock to edit
-  the time." (Do not open the editor.)
+  the time." (Do not open the editor.) Other blocked states (pre-match,
+  full time) silently ignore the long-press.
 - The editor is a `showModalBottomSheet` using the same
   `FractionallySizedBox` + grey container styling as the score editor,
   hosting a new `TimeSettingsWidget`.
@@ -88,8 +94,13 @@ Mirrors `TeamSettingsWidget`:
 
 - Title "Edit remaining time".
 - An `mm:ss` `TextEditingController` seeded from `game.remainingTime`.
-  "Set" parses the field (accept `mm:ss` or a plain seconds integer;
-  ignore unparseable input) and applies via `game.setRemainingTime`.
+  "Set" parses the field via the top-level `parseMmSs(String)` helper and
+  applies via `game.setRemainingTime`. `parseMmSs` accepts either a plain
+  nonnegative seconds integer or `mm:ss` with a nonnegative minutes part
+  and a seconds part in `0..59`; anything else (`5:99`, `1:2:3`, `:30`,
+  empty, non-numeric) returns `null` and the field is restored to the
+  current value. Extracting it as a top-level pure function keeps the
+  parsing unit-testable without pumping a widget.
 - Quick-nudge buttons **−1:00 / −0:30 / +0:30 / +1:00**, each calling
   `game.setRemainingTime(game.remainingTime ± delta)` (clamping handles
   the bounds) and refreshing the field text to the clamped value.

--- a/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
+++ b/docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md
@@ -68,7 +68,12 @@ void setRemainingTime(int seconds) {
 }
 ```
 
-- Clamp to `periodTime` (the maximum of both editable stages), floor 0.
+- Clamp to `[1, periodTime]`. The floor is 1 second, not 0: the normal
+  expiry path never leaves an active half stopped at `0:00` (a tick at 0
+  transitions the stage), so a manual `0:00` would create a state where a
+  later START double-tap fires `playAll()` one tick before the transition
+  stops the robots again. Flooring at 1 keeps the manual path consistent
+  with the timer's own invariant.
 - Publishes stage+time via `_broadcastStageAndTime()`.
 - Does not touch the run-clock anchors and does not call
   `notifyAllModulesTimer()`.

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -664,6 +664,23 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   int get remainingTime => _remainingTime;
+
+  // Manual correction of the remaining match time (issue #21), e.g. to give
+  // back playing time lost to a stoppage. The UI only opens the editor while
+  // the clock is stopped, so the run-clock catch-up anchors
+  // (_runClockStartedAt / _runClockStartRemainingTime) are already null and
+  // need no reconciliation. This is a one-time correction, not a tick: it does
+  // NOT call notifyAllModulesTimer() (that decrements module damage timers) and
+  // does NOT trigger game-timer vibration. Publishes to MQTT only, mirroring
+  // _tickTimer — the BLE bridge carries no time topic.
+  void setRemainingTime(int seconds) {
+    final int maxTime =
+        currentStage == MatchStage.halfTime ? halfTimeDuration : periodTime;
+    _remainingTime = seconds.clamp(0, maxTime);
+    notifyListeners();
+    mqttService.publishTime(_remainingTime);
+  }
+
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;
   bool get isTimerRunning => isTimeRunning;
   bool get isGameRunning => _isGameRunning;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -675,8 +675,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // (that decrements module damage timers) and does NOT trigger game-timer
   // vibration. Publishes stage+time to every sink like the other stopped-state
   // updates (_broadcastStageAndTime) — the BLE bridge carries no time topic.
+  //
+  // Floors at 1 second, not 0: the normal expiry path never leaves an active
+  // half stopped at 0:00 (a tick at 0 transitions the stage), so allowing a
+  // manual 0:00 would create a state where a later START double-tap fires
+  // playAll() one tick before the stage transition stops the robots again.
   void setRemainingTime(int seconds) {
-    _remainingTime = seconds.clamp(0, periodTime);
+    _remainingTime = seconds.clamp(1, periodTime);
     notifyListeners();
     _broadcastStageAndTime();
   }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -667,18 +667,18 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   // Manual correction of the remaining match time (issue #21), e.g. to give
   // back playing time lost to a stoppage. The UI only opens the editor while
-  // the clock is stopped, so the run-clock catch-up anchors
+  // the clock is stopped within an active first or second half
+  // (Home._editRemainingTime), so the run-clock catch-up anchors
   // (_runClockStartedAt / _runClockStartRemainingTime) are already null and
-  // need no reconciliation. This is a one-time correction, not a tick: it does
-  // NOT call notifyAllModulesTimer() (that decrements module damage timers) and
-  // does NOT trigger game-timer vibration. Publishes to MQTT only, mirroring
-  // _tickTimer — the BLE bridge carries no time topic.
+  // need no reconciliation, and both editable stages cap at periodTime. This is
+  // a one-time correction, not a tick: it does NOT call notifyAllModulesTimer()
+  // (that decrements module damage timers) and does NOT trigger game-timer
+  // vibration. Publishes stage+time to every sink like the other stopped-state
+  // updates (_broadcastStageAndTime) — the BLE bridge carries no time topic.
   void setRemainingTime(int seconds) {
-    final int maxTime =
-        currentStage == MatchStage.halfTime ? halfTimeDuration : periodTime;
-    _remainingTime = seconds.clamp(0, maxTime);
+    _remainingTime = seconds.clamp(0, periodTime);
     notifyListeners();
-    mqttService.publishTime(_remainingTime);
+    _broadcastStageAndTime();
   }
 
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -30,6 +30,40 @@ class Home extends StatelessWidget {
     }
   }
 
+  // Long-press the remaining-time display to manually correct the clock
+  // (issue #21). Editing is only allowed while the clock is stopped and during
+  // an actual playing/break stage — this keeps the run-clock catch-up anchors
+  // out of the picture (see Game.setRemainingTime). The double-tap start/stop
+  // toggle lives on the button below and is intentionally left untouched.
+  void _editRemainingTime(BuildContext context, Game game) {
+    if (game.isTimerRunning) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Stop the clock to edit the time.')),
+      );
+      return;
+    }
+    if (game.currentStage != MatchStage.firstHalf &&
+        game.currentStage != MatchStage.secondHalf &&
+        game.currentStage != MatchStage.halfTime) {
+      return;
+    }
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return FractionallySizedBox(
+          heightFactor: 0.7,
+          child: Container(
+            color: Colors.grey[800],
+            padding:
+                const EdgeInsets.symmetric(vertical: 20.0, horizontal: 20.0),
+            child: TimeSettingsWidget(game: game),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final game = Provider.of<Game>(context);
@@ -84,9 +118,12 @@ class Home extends StatelessWidget {
                         flex: 1,
                         child: Column(
                           children: [
-                            Text(
-                                '${(game.remainingTime ~/ 60).toString().padLeft(2, '0')}:${(game.remainingTime % 60).toString().padLeft(2, '0')}',
-                                style: const TextStyle(fontSize: 40.0)),
+                            GestureDetector(
+                              onLongPress: () => _editRemainingTime(context, game),
+                              child: Text(
+                                  '${(game.remainingTime ~/ 60).toString().padLeft(2, '0')}:${(game.remainingTime % 60).toString().padLeft(2, '0')}',
+                                  style: const TextStyle(fontSize: 40.0)),
+                            ),
                             Text(game.gameStageString),
                             SizedBox(
                               width: double.infinity,
@@ -503,6 +540,131 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
   }
 }
 
+// Bottom-sheet editor for the remaining match time (issue #21). Mirrors
+// TeamSettingsWidget: quick +/- nudges plus an mm:ss field for a precise jump.
+// Only shown while the clock is stopped (gated in Home._editRemainingTime), so
+// it never has to reconcile a running clock.
+class TimeSettingsWidget extends StatefulWidget {
+  final Game game;
+
+  const TimeSettingsWidget({required this.game, super.key});
+
+  @override
+  State<TimeSettingsWidget> createState() => _TimeSettingsWidgetState();
+}
+
+class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
+  late TextEditingController _timeController;
+
+  @override
+  void initState() {
+    super.initState();
+    _timeController = TextEditingController(text: _format(widget.game.remainingTime));
+  }
+
+  @override
+  void dispose() {
+    _timeController.dispose();
+    super.dispose();
+  }
+
+  String _format(int seconds) =>
+      '${(seconds ~/ 60).toString().padLeft(2, '0')}:${(seconds % 60).toString().padLeft(2, '0')}';
+
+  // Accept either "mm:ss" or a plain seconds integer. Returns null on anything
+  // unparseable so the caller can ignore the input.
+  int? _parse(String raw) {
+    final text = raw.trim();
+    if (text.isEmpty) return null;
+    if (text.contains(':')) {
+      final parts = text.split(':');
+      if (parts.length != 2) return null;
+      final minutes = int.tryParse(parts[0]);
+      final secs = int.tryParse(parts[1]);
+      if (minutes == null || secs == null) return null;
+      return minutes * 60 + secs;
+    }
+    return int.tryParse(text);
+  }
+
+  void _apply(int seconds) {
+    widget.game.setRemainingTime(seconds);
+    // Reflect the clamped, authoritative value back into the field.
+    _timeController.text = _format(widget.game.remainingTime);
+  }
+
+  void _nudge(int delta) => _apply(widget.game.remainingTime + delta);
+
+  void _applyFromField() {
+    final parsed = _parse(_timeController.text);
+    if (parsed != null) {
+      _apply(parsed);
+    } else {
+      // Restore the current value if the entry was invalid.
+      _timeController.text = _format(widget.game.remainingTime);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Text(
+          'Edit remaining time',
+          style: TextStyle(fontSize: 24.0, color: Colors.white),
+        ),
+        const Divider(),
+        const SizedBox(height: 20.0),
+        Row(
+          children: [
+            const Expanded(
+              flex: 2,
+              child: Text('Time (mm:ss)', style: TextStyle(fontSize: 16.0)),
+            ),
+            Expanded(
+              flex: 3,
+              child: TextField(
+                controller: _timeController,
+                keyboardType: TextInputType.datetime,
+                style: const TextStyle(color: Colors.white),
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  filled: true,
+                  fillColor: Colors.grey[800],
+                ),
+                onSubmitted: (_) => _applyFromField(),
+              ),
+            ),
+            const SizedBox(width: 8.0),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.blue),
+              onPressed: _applyFromField,
+              child: const Text('Set', style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        ),
+        const SizedBox(height: 20.0),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            _nudgeButton('-1:00', () => _nudge(-60)),
+            _nudgeButton('-0:30', () => _nudge(-30)),
+            _nudgeButton('+0:30', () => _nudge(30)),
+            _nudgeButton('+1:00', () => _nudge(60)),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _nudgeButton(String label, VoidCallback onPressed) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(backgroundColor: Colors.blue),
+      onPressed: onPressed,
+      child: Text(label, style: const TextStyle(color: Colors.white)),
+    );
+  }
+}
 
 
 

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -677,26 +677,6 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
   }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 void setupGameCallbacks(Game game, BuildContext context) {
   game.onRequestSwitchTeamOrderDialog = () async {
     bool? switchOrder = await showDialog<bool>(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -31,10 +31,15 @@ class Home extends StatelessWidget {
   }
 
   // Long-press the remaining-time display to manually correct the clock
-  // (issue #21). Editing is only allowed while the clock is stopped and during
-  // an actual playing/break stage — this keeps the run-clock catch-up anchors
-  // out of the picture (see Game.setRemainingTime). The double-tap start/stop
-  // toggle lives on the button below and is intentionally left untouched.
+  // (issue #21). Editing is only allowed while the clock is stopped within an
+  // active first or second half — this keeps the run-clock catch-up anchors
+  // out of the picture (see Game.setRemainingTime). Half-time is excluded
+  // because its clock runs continuously (the firstHalf->halfTime transition
+  // calls startTimer() and SKIP jumps straight to the second half, so there is
+  // no stopped half-time state); pre-match setup (inGame == false) is excluded
+  // so the match duration is only changed via Settings; full time is excluded
+  // by the stage check. The double-tap start/stop toggle lives on the button
+  // below and is intentionally left untouched.
   void _editRemainingTime(BuildContext context, Game game) {
     if (game.isTimerRunning) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -42,9 +47,9 @@ class Home extends StatelessWidget {
       );
       return;
     }
-    if (game.currentStage != MatchStage.firstHalf &&
-        game.currentStage != MatchStage.secondHalf &&
-        game.currentStage != MatchStage.halfTime) {
+    if (!game.inGame ||
+        (game.currentStage != MatchStage.firstHalf &&
+            game.currentStage != MatchStage.secondHalf)) {
       return;
     }
     showModalBottomSheet(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -545,6 +545,28 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
   }
 }
 
+// Parse a remaining-time entry, accepting either a plain nonnegative seconds
+// integer ("123") or "mm:ss" with a nonnegative minutes part and a seconds part
+// in 0..59. Returns null for anything else ("5:99", "1:2:3", ":30", "", "ab"),
+// so a referee typo is ignored rather than silently applied as a bad
+// correction. Top-level + pure so it is unit-testable without a widget.
+int? parseMmSs(String raw) {
+  final text = raw.trim();
+  if (text.isEmpty) return null;
+  if (text.contains(':')) {
+    final parts = text.split(':');
+    if (parts.length != 2 || parts[0].isEmpty || parts[1].isEmpty) return null;
+    final minutes = int.tryParse(parts[0]);
+    final secs = int.tryParse(parts[1]);
+    if (minutes == null || secs == null) return null;
+    if (minutes < 0 || secs < 0 || secs > 59) return null;
+    return minutes * 60 + secs;
+  }
+  final seconds = int.tryParse(text);
+  if (seconds == null || seconds < 0) return null;
+  return seconds;
+}
+
 // Bottom-sheet editor for the remaining match time (issue #21). Mirrors
 // TeamSettingsWidget: quick +/- nudges plus an mm:ss field for a precise jump.
 // Only shown while the clock is stopped (gated in Home._editRemainingTime), so
@@ -576,22 +598,6 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
   String _format(int seconds) =>
       '${(seconds ~/ 60).toString().padLeft(2, '0')}:${(seconds % 60).toString().padLeft(2, '0')}';
 
-  // Accept either "mm:ss" or a plain seconds integer. Returns null on anything
-  // unparseable so the caller can ignore the input.
-  int? _parse(String raw) {
-    final text = raw.trim();
-    if (text.isEmpty) return null;
-    if (text.contains(':')) {
-      final parts = text.split(':');
-      if (parts.length != 2) return null;
-      final minutes = int.tryParse(parts[0]);
-      final secs = int.tryParse(parts[1]);
-      if (minutes == null || secs == null) return null;
-      return minutes * 60 + secs;
-    }
-    return int.tryParse(text);
-  }
-
   void _apply(int seconds) {
     widget.game.setRemainingTime(seconds);
     // Reflect the clamped, authoritative value back into the field.
@@ -601,7 +607,7 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
   void _nudge(int delta) => _apply(widget.game.remainingTime + delta);
 
   void _applyFromField() {
-    final parsed = _parse(_timeController.text);
+    final parsed = parseMmSs(_timeController.text);
     if (parsed != null) {
       _apply(parsed);
     } else {

--- a/test/game_remaining_time_test.dart
+++ b/test/game_remaining_time_test.dart
@@ -1,0 +1,58 @@
+// Unit tests for Game.setRemainingTime — the manual remaining-time correction
+// added for issue #21. Editing is gated to a stopped clock in the UI, so these
+// tests cover the model's clamping contract per match stage.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/models/game.dart';
+
+void main() {
+  // Game() registers a WidgetsBindingObserver and reads SharedPreferences.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Game makeGame() {
+    final game = Game();
+    game.periodTime = 600;
+    game.halfTimeDuration = 300;
+    return game;
+  }
+
+  test('sets an in-range value exactly', () {
+    final game = makeGame();
+    game.setRemainingTime(123);
+    expect(game.remainingTime, 123);
+  });
+
+  test('clamps negative values to 0', () {
+    final game = makeGame();
+    game.setRemainingTime(-10);
+    expect(game.remainingTime, 0);
+  });
+
+  test('clamps above periodTime to periodTime during a half', () {
+    final game = makeGame();
+    game.currentStage = MatchStage.firstHalf;
+    game.setRemainingTime(9999);
+    expect(game.remainingTime, 600);
+  });
+
+  test('clamps to halfTimeDuration during the half-time break', () {
+    final game = makeGame();
+    game.currentStage = MatchStage.halfTime;
+    game.setRemainingTime(9999);
+    expect(game.remainingTime, 300);
+  });
+
+  test('notifies listeners', () {
+    final game = makeGame();
+    var notified = false;
+    game.addListener(() => notified = true);
+    game.setRemainingTime(42);
+    expect(notified, isTrue);
+  });
+}

--- a/test/game_remaining_time_test.dart
+++ b/test/game_remaining_time_test.dart
@@ -71,11 +71,14 @@ void main() {
       expect(game.remainingTime, 123);
     });
 
-    testWidgets('clamps negative values to 0', (tester) async {
+    testWidgets('floors at 1 second (never parks an active half at 0:00)',
+        (tester) async {
       final game = makeGame();
       await tester.pump();
+      game.setRemainingTime(0);
+      expect(game.remainingTime, 1);
       game.setRemainingTime(-10);
-      expect(game.remainingTime, 0);
+      expect(game.remainingTime, 1);
     });
 
     testWidgets('clamps above periodTime to periodTime', (tester) async {

--- a/test/game_remaining_time_test.dart
+++ b/test/game_remaining_time_test.dart
@@ -1,68 +1,98 @@
-// Unit tests for Game.setRemainingTime — the manual remaining-time correction
-// added for issue #21. Editing is gated to a stopped clock in the UI, so these
-// tests cover the model's clamping contract per match stage.
+// Tests for the manual remaining-time correction added for issue #21.
 //
-// These use testWidgets (like the app smoke test) rather than a plain test():
-// the Game constructor stands up the wakelock/notification/MQTT/bridge services,
-// whose platform-channel calls reject asynchronously in the headless test VM.
-// The widget test binding tolerates those pending platform replies; a bare
-// test() reports them as "pending async work" and fails after completion.
+// parseMmSs is a top-level pure function, so it uses plain test(). The
+// setRemainingTime cases use testWidgets (like the app smoke test): the Game
+// constructor stands up the wakelock/notification/MQTT/bridge services, whose
+// platform-channel calls reject asynchronously in the headless test VM. The
+// widget test binding tolerates those pending platform replies; a bare test()
+// reports them as "pending async work" and fails after completion.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/screens/home.dart';
 
 void main() {
-  Game makeGame() {
-    final game = Game();
-    game.periodTime = 600;
-    game.halfTimeDuration = 300;
-    return game;
-  }
+  group('parseMmSs', () {
+    test('parses mm:ss', () {
+      expect(parseMmSs('02:03'), 123);
+      expect(parseMmSs('10:00'), 600);
+      expect(parseMmSs('0:30'), 30);
+    });
 
-  setUp(() {
-    SharedPreferences.setMockInitialValues({});
+    test('parses a plain seconds integer', () {
+      expect(parseMmSs('123'), 123);
+      expect(parseMmSs('0'), 0);
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(parseMmSs('  1:05 '), 65);
+    });
+
+    test('rejects a seconds component outside 0..59', () {
+      expect(parseMmSs('5:99'), isNull);
+      expect(parseMmSs('5:60'), isNull);
+    });
+
+    test('rejects negative components', () {
+      expect(parseMmSs('-1:00'), isNull);
+      expect(parseMmSs('1:-30'), isNull);
+      expect(parseMmSs('-30'), isNull);
+    });
+
+    test('rejects malformed input', () {
+      expect(parseMmSs(''), isNull);
+      expect(parseMmSs('   '), isNull);
+      expect(parseMmSs('1:2:3'), isNull);
+      expect(parseMmSs(':30'), isNull);
+      expect(parseMmSs('1:'), isNull);
+      expect(parseMmSs('ab:cd'), isNull);
+      expect(parseMmSs('abc'), isNull);
+    });
   });
 
-  testWidgets('sets an in-range value exactly', (tester) async {
-    final game = makeGame();
-    await tester.pump();
-    game.setRemainingTime(123);
-    expect(game.remainingTime, 123);
-  });
+  group('Game.setRemainingTime', () {
+    Game makeGame() {
+      final game = Game();
+      game.periodTime = 600;
+      game.halfTimeDuration = 300;
+      return game;
+    }
 
-  testWidgets('clamps negative values to 0', (tester) async {
-    final game = makeGame();
-    await tester.pump();
-    game.setRemainingTime(-10);
-    expect(game.remainingTime, 0);
-  });
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
 
-  testWidgets('clamps above periodTime to periodTime during a half',
-      (tester) async {
-    final game = makeGame();
-    await tester.pump();
-    game.currentStage = MatchStage.firstHalf;
-    game.setRemainingTime(9999);
-    expect(game.remainingTime, 600);
-  });
+    testWidgets('sets an in-range value exactly', (tester) async {
+      final game = makeGame();
+      await tester.pump();
+      game.setRemainingTime(123);
+      expect(game.remainingTime, 123);
+    });
 
-  testWidgets('clamps to halfTimeDuration during the half-time break',
-      (tester) async {
-    final game = makeGame();
-    await tester.pump();
-    game.currentStage = MatchStage.halfTime;
-    game.setRemainingTime(9999);
-    expect(game.remainingTime, 300);
-  });
+    testWidgets('clamps negative values to 0', (tester) async {
+      final game = makeGame();
+      await tester.pump();
+      game.setRemainingTime(-10);
+      expect(game.remainingTime, 0);
+    });
 
-  testWidgets('notifies listeners', (tester) async {
-    final game = makeGame();
-    await tester.pump();
-    var notified = false;
-    game.addListener(() => notified = true);
-    game.setRemainingTime(42);
-    expect(notified, isTrue);
+    testWidgets('clamps above periodTime to periodTime', (tester) async {
+      final game = makeGame();
+      await tester.pump();
+      game.currentStage = MatchStage.firstHalf;
+      game.setRemainingTime(9999);
+      expect(game.remainingTime, 600);
+    });
+
+    testWidgets('notifies listeners', (tester) async {
+      final game = makeGame();
+      await tester.pump();
+      var notified = false;
+      game.addListener(() => notified = true);
+      game.setRemainingTime(42);
+      expect(notified, isTrue);
+    });
   });
 }

--- a/test/game_remaining_time_test.dart
+++ b/test/game_remaining_time_test.dart
@@ -1,6 +1,12 @@
 // Unit tests for Game.setRemainingTime — the manual remaining-time correction
 // added for issue #21. Editing is gated to a stopped clock in the UI, so these
 // tests cover the model's clamping contract per match stage.
+//
+// These use testWidgets (like the app smoke test) rather than a plain test():
+// the Game constructor stands up the wakelock/notification/MQTT/bridge services,
+// whose platform-channel calls reject asynchronously in the headless test VM.
+// The widget test binding tolerates those pending platform replies; a bare
+// test() reports them as "pending async work" and fails after completion.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -8,13 +14,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:rcj_scoreboard/models/game.dart';
 
 void main() {
-  // Game() registers a WidgetsBindingObserver and reads SharedPreferences.
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUp(() {
-    SharedPreferences.setMockInitialValues({});
-  });
-
   Game makeGame() {
     final game = Game();
     game.periodTime = 600;
@@ -22,34 +21,45 @@ void main() {
     return game;
   }
 
-  test('sets an in-range value exactly', () {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('sets an in-range value exactly', (tester) async {
     final game = makeGame();
+    await tester.pump();
     game.setRemainingTime(123);
     expect(game.remainingTime, 123);
   });
 
-  test('clamps negative values to 0', () {
+  testWidgets('clamps negative values to 0', (tester) async {
     final game = makeGame();
+    await tester.pump();
     game.setRemainingTime(-10);
     expect(game.remainingTime, 0);
   });
 
-  test('clamps above periodTime to periodTime during a half', () {
+  testWidgets('clamps above periodTime to periodTime during a half',
+      (tester) async {
     final game = makeGame();
+    await tester.pump();
     game.currentStage = MatchStage.firstHalf;
     game.setRemainingTime(9999);
     expect(game.remainingTime, 600);
   });
 
-  test('clamps to halfTimeDuration during the half-time break', () {
+  testWidgets('clamps to halfTimeDuration during the half-time break',
+      (tester) async {
     final game = makeGame();
+    await tester.pump();
     game.currentStage = MatchStage.halfTime;
     game.setRemainingTime(9999);
     expect(game.remainingTime, 300);
   });
 
-  test('notifies listeners', () {
+  testWidgets('notifies listeners', (tester) async {
     final game = makeGame();
+    await tester.pump();
     var notified = false;
     game.addListener(() => notified = true);
     game.setRemainingTime(42);


### PR DESCRIPTION
Closes #21.

## What & why
The remaining match time could previously only count down. If the referee forgot to stop the clock during a stoppage (e.g. a rules discussion), there was no way to give the lost playing time back. This adds a manual time correction that mirrors the existing score editor: **long-press the time display** to open a bottom-sheet editor.

## How
- **`Game.setRemainingTime(int)`** — clamps to the current stage's maximum (`halfTimeDuration` during the break, otherwise `periodTime`, floor 0), `notifyListeners()`, publishes to MQTT.
- **`home.dart`** — the time `Text` is wrapped in `GestureDetector(onLongPress:)` → `_editRemainingTime`. The double-tap start/stop toggle on the button below is **untouched** (double-tap safety invariant).
- **`TimeSettingsWidget`** — quick **−1:00 / −0:30 / +0:30 / +1:00** nudges plus an `mm:ss` field (accepts `mm:ss` or a plain seconds integer) with a Set button.
- **Tests** — unit tests for the `setRemainingTime` clamp/notify contract.

## Design decisions
- **Editing only while the clock is stopped.** Long-press while running shows a SnackBar ("Stop the clock to edit the time.") instead of opening. This keeps the background catch-up anchors (`_runClockStartedAt` / `_runClockStartRemainingTime`) out of the picture — they're already `null` while stopped — so no reconciliation is needed.
- The editor only opens during `firstHalf` / `secondHalf` / `halfTime`.

## Corrections to the issue's implementation notes
- `setRemainingTime` does **not** call `notifyAllModulesTimer()`: that method decrements each damaged module's penalty by one tick (it's the per-second damage countdown driven by `_tickTimer`), so calling it on a one-time correction would wrongly subtract a second from every active damage timer.
- It publishes to **MQTT only**. The BLE bridge currently carries only score/color (no time topic), and the live timer ticks never publish time to the bridge — so a bridge time topic is out of scope here.

## Verification
Built without a local Flutter toolchain — relying on the PR quality gate (`flutter analyze --fatal-infos`, `flutter test`, `flutter build bundle`) to validate. Manual on-device checks to confirm after CI is green:
- [ ] Long-press while stopped opens the editor; nudges clamp at 0 and the stage max; `mm:ss` entry applies; MQTT scoreboard reflects the new time.
- [ ] Long-press while running shows the SnackBar and does not open.
- [ ] Double-tap start/stop still toggles the clock.
- [ ] The four nudge buttons fit without overflow on the narrowest target phone.

Design spec: `docs/superpowers/specs/2026-06-21-editable-remaining-time-design.md`.