### PR TITLE
fix(wakelock): await/catchError async WakelockPlus calls (#24)

### DIFF
--- a/lib/services/wakelock_service.dart
+++ b/lib/services/wakelock_service.dart
@@ -30,10 +30,12 @@ class WakelockService with ChangeNotifier {
     notifyListeners();
   }
 
-  void _applyWakelock() {
+  Future<void> _applyWakelock() async {
     if (kIsWeb) return;
+    // WakelockPlus.toggle returns a Future whose PlatformException surfaces
+    // asynchronously, so it must be awaited inside the try to be caught.
     try {
-      WakelockPlus.toggle(enable: _enabled);
+      await WakelockPlus.toggle(enable: _enabled);
     } catch (e) {
       debugPrint('WakelockService: toggle(enable: $_enabled) failed: $e');
     }
@@ -42,11 +44,11 @@ class WakelockService with ChangeNotifier {
   @override
   void dispose() {
     if (!kIsWeb) {
-      try {
-        WakelockPlus.disable();
-      } catch (e) {
-        debugPrint('WakelockService: disable() on dispose failed: $e');
-      }
+      // dispose() can't be async/awaited, so attach catchError to swallow the
+      // asynchronously-delivered PlatformException instead of a sync try/catch.
+      WakelockPlus.disable().catchError(
+        (e) => debugPrint('WakelockService: disable() on dispose failed: $e'),
+      );
     }
     super.dispose();
   }


### PR DESCRIPTION
Closes #24.

## What & why
`WakelockService._applyWakelock()` and `dispose()` wrapped **async** `WakelockPlus` calls in a **synchronous** `try/catch`. Since `toggle()`/`disable()` return a `Future` whose `PlatformException` is delivered asynchronously, the `catch` was dead code — failures escaped as unhandled future errors and logged nowhere. This is also what forced PR #23 to run its `setRemainingTime` tests under `testWidgets` to tolerate the leaked async rejection in the headless test VM.

## How
- `_applyWakelock()` → now `async`, `await WakelockPlus.toggle(...)` inside the `try`.
- `dispose()` → can't be async, so `WakelockPlus.disable().catchError((e) => debugPrint(...))`.

## Testing
- `flutter analyze lib/services/wakelock_service.dart` → no issues.
- `flutter test` → 31/31 pass with no uncaught async wakelock error (the environment that previously exhibited the bug).
- On-device (Pixel 10, release): wakelock enable/disable/rapid-toggle/background all work, no regression, clean logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)