### PR TITLE
feat: single-tap actions toggle (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Android Flutter app (portrait-only) that controls RoboCup Junior Soccer robot mo
 
 ## Critical invariants — never violate these
 1. **Robot START/STOP latency**: `bleSendPlayAll()` and `bleSendStopAll()` use `timeout:0` (fire-and-forget) and are launched without `await` so all modules fire simultaneously. Never add awaits, blocking calls, queues, or synchronization that could delay or serialize robot commands.
-2. **Double-tap/long-press safety**: All destructive UI actions (play/stop all, score, timer toggle, disconnect) use `onDoubleTap`. Do not change them to `onTap`.
+2. **Double-tap/long-press safety**: All destructive UI actions (play/stop all, score, timer toggle, disconnect) default to `onDoubleTap`. The gesture is now routed through `CriticalGestureDetector`/`criticalButtonGestures` so a user-facing Settings toggle (`Game.singleTapEnabled`, **default `false`**) can opt into single-tap. Never hardcode these sites back to a bare `onTap`, and never change the default away from double-tap — only the explicit opt-in may relax it.
 3. **Provider tree integrity**: `Game`, both `Team`s, and all 10 `Module`s are registered as `ChangeNotifierProvider` in `main.dart`. The module provider list is static. Do not restructure provider registration without understanding this.
 4. **Portrait-only**: `SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])` is set in `main()`. Do not remove.
 
@@ -35,6 +35,7 @@ Android Flutter app (portrait-only) that controls RoboCup Junior Soccer robot mo
 | `lib/services/ble_bridge_service.dart` | BLE scoreboard bridge: MQTT-over-BLE publish, dedup queue, write-with-response ACK |
 | `lib/models/bridge_message.dart` | `BridgeMessage` framing (`topic\x00value`) + `BridgeTopics` names |
 | `lib/services/match_data.dart` | HTTP fetch of match schedule |
+| `lib/widgets/critical_gesture_detector.dart` | `CriticalGestureDetector` + `criticalButtonGestures` — single/double-tap gating for critical actions |
 | `lib/screens/home.dart` | Main control UI |
 | `lib/screens/settings.dart` | All settings (MQTT, game params, match data) |
 | `lib/screens/module_settings.dart` | Per-module BLE connect/scan/QR |

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -24,6 +24,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   static const String _halfTimeDurationKey = 'game_halftime_duration';
   static const String _numberOfPlayersKey = 'game_num_players';
   static const String _penaltyTimeKey = 'game_penalty_time';
+  static const String _singleTapEnabledKey = 'gesture_single_tap_enabled';
   static const String _notifPermissionRequestedKey =
       'notif_permission_requested';
 
@@ -48,6 +49,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // threshold crossed while backgrounded buzzes at once on return). State, MQTT
   // and module updates still run during replay.
   bool _replaying = false;
+  // Single-tap gesture mode (issue #12). Default false => double-tap everywhere,
+  // preserving the accidental-touch protection invariant. _pendingSingleTapWrite
+  // guards the load-timing race: _loadPrefs() runs unawaited, so a toggle made
+  // before it resolves must not be clobbered by the stored default (see setter
+  // and _loadPrefs).
+  bool _singleTapEnabled = false;
+  bool _pendingSingleTapWrite = false;
   SharedPreferences? _prefs;
   //MQTT
   MqttService mqttService = MqttService();
@@ -94,6 +102,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _numberOfPLayers =
         (_prefs!.getInt(_numberOfPlayersKey) ?? 2).clamp(1, _maxPlayer).toInt();
     _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? 60;
+
+    // Single-tap pref: flush a pre-load toggle if one happened, otherwise adopt
+    // the stored value. Reading unconditionally would clobber an early toggle.
+    if (_pendingSingleTapWrite) {
+      _prefs!.setBool(_singleTapEnabledKey, _singleTapEnabled);
+      _pendingSingleTapWrite = false;
+    } else {
+      _singleTapEnabled = _prefs!.getBool(_singleTapEnabledKey) ?? false;
+    }
 
     if (!inGame) {
       gameInit();
@@ -643,6 +660,22 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   set periodTime(int value) {
     _periodTime = value;
     _prefs?.setInt(_periodTimeKey, value);
+  }
+
+  // Single-tap gesture mode (issue #12). Unlike periodTime, this setter MUST
+  // notifyListeners() so the Home control buttons swap their gesture recognizer
+  // live on toggle. The pending-write guard handles a toggle made before
+  // _loadPrefs() resolves (see _loadPrefs).
+  bool get singleTapEnabled => _singleTapEnabled;
+  set singleTapEnabled(bool value) {
+    if (_singleTapEnabled == value) return;
+    _singleTapEnabled = value;
+    if (_prefs != null) {
+      _prefs!.setBool(_singleTapEnabledKey, value);
+    } else {
+      _pendingSingleTapWrite = true;
+    }
+    notifyListeners();
   }
 
   int get halfTimeDuration => _halfTimeDuration;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -9,6 +9,7 @@ import 'package:rcj_scoreboard/models/module.dart';
 import 'package:flutter/services.dart';
 import 'package:rcj_scoreboard/screens/settings.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
+import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
 
 class Home extends StatelessWidget {
   const Home({super.key});
@@ -132,24 +133,29 @@ class Home extends StatelessWidget {
                             Text(game.gameStageString),
                             SizedBox(
                               width: double.infinity,
-                              child: GestureDetector(
-                                onDoubleTap: () {
-                                  game.toggleTimer();
-                                },
-                                child: ElevatedButton(
-                                  onPressed: () {},
-                                  style: ElevatedButton.styleFrom(
-                                    //minimumSize: const Size(120, 50),
-                                    backgroundColor: (game.isGameRunning
-                                        ? (game.isTimerRunning
-                                            ? AppColors.red
-                                            : AppColors.green)
-                                        : AppColors.green),
+                              child: Builder(builder: (context) {
+                                final g = criticalButtonGestures(
+                                  singleTap: game.singleTapEnabled,
+                                  onAction: () => game.toggleTimer(),
+                                );
+                                return GestureDetector(
+                                  onDoubleTap: g.onDoubleTap,
+                                  child: ElevatedButton(
+                                    onPressed: g.onPressed,
+                                    style: ElevatedButton.styleFrom(
+                                      //minimumSize: const Size(120, 50),
+                                      backgroundColor: (game.isGameRunning
+                                          ? (game.isTimerRunning
+                                              ? AppColors.red
+                                              : AppColors.green)
+                                          : AppColors.green),
+                                    ),
+                                    child: Text(game.timerButtonText,
+                                        style:
+                                            const TextStyle(color: Colors.white)),
                                   ),
-                                  child: Text(game.timerButtonText,
-                                      style: const TextStyle(color: Colors.white)),
-                                ),
-                              ),
+                                );
+                              }),
                             )
                           ],
                         ),
@@ -191,32 +197,36 @@ class Home extends StatelessWidget {
                     margin: const EdgeInsets.all(4.0),
                     width: double.infinity,
                     //height: 70.0,
-                    child: GestureDetector(
-                      onDoubleTap: () {
-                        game.toggleAllModules();
-                      },
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              (game.currentStage == MatchStage.fullTime
-                                  ? AppColors.blue
+                    child: Builder(builder: (context) {
+                      final g = criticalButtonGestures(
+                        singleTap: game.singleTapEnabled,
+                        onAction: () => game.toggleAllModules(),
+                      );
+                      return GestureDetector(
+                        onDoubleTap: g.onDoubleTap,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor:
+                                (game.currentStage == MatchStage.fullTime
+                                    ? AppColors.blue
+                                    : (game.isSomeonePlaying
+                                        ? AppColors.red
+                                        : AppColors.green)),
+                            // shape: RoundedRectangleBorder(
+                            //   borderRadius: BorderRadius.circular(30.0),
+                            // )
+                          ),
+                          child: Text(
+                              game.currentStage == MatchStage.fullTime
+                                  ? 'DISCONNECT ALL ROBOTS'
                                   : (game.isSomeonePlaying
-                                      ? AppColors.red
-                                      : AppColors.green)),
-                          // shape: RoundedRectangleBorder(
-                          //   borderRadius: BorderRadius.circular(30.0),
-                          // )
+                                      ? 'STOP ALL ROBOTS'
+                                      : 'START ALL ROBOTS'),
+                              style: const TextStyle(color: Colors.white)),
+                          onPressed: g.onPressed,
                         ),
-                        child: Text(
-                            game.currentStage == MatchStage.fullTime
-                                ? 'DISCONNECT ALL ROBOTS'
-                                : (game.isSomeonePlaying
-                                    ? 'STOP ALL ROBOTS'
-                                    : 'START ALL ROBOTS'),
-                            style: const TextStyle(color: Colors.white)),
-                        onPressed: () {},
-                      ),
-                    ),
+                      );
+                    }),
                   ),
                 ),
               ],
@@ -234,8 +244,9 @@ Widget buildModuleButton(Module module, Game game) {
     child: Consumer<Module>(
       builder: (context, module, child) {
         return Expanded(
-          child: GestureDetector(
-            onDoubleTap: () {
+          child: CriticalGestureDetector(
+            singleTap: game.singleTapEnabled,
+            onAction: () {
               if (module.isPlaying) {
                 if (game.isGameRunning) {
                   module.penalty(game.penaltyTime);
@@ -302,8 +313,9 @@ Widget buildTeamContainer(Team team, Game game) {
     value: team,
     child: Consumer<Team>(
       builder: (context, team, child) {
-        return GestureDetector(
-          onDoubleTap: () {
+        return CriticalGestureDetector(
+          singleTap: game.singleTapEnabled,
+          onAction: () {
             team.addScore(1);
             game.stopAll(true);
             game.notifyModulesScore();

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -73,19 +73,6 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final game = Provider.of<Game>(context);
-    // Gesture wiring for the two button-backed critical controls (timer,
-    // all-robots): single-tap mode routes the action through the button's
-    // onPressed, double-tap mode through the parent GestureDetector. Computed
-    // here (build already rebuilds on Game changes) so the button subtrees stay
-    // wrapper-free. See criticalButtonGestures.
-    final timerGestures = criticalButtonGestures(
-      singleTap: game.singleTapEnabled,
-      onAction: () => game.toggleTimer(),
-    );
-    final allRobotsGestures = criticalButtonGestures(
-      singleTap: game.singleTapEnabled,
-      onAction: () => game.toggleAllModules(),
-    );
     setupGameCallbacks(game, context);
 
     return PopScope(
@@ -146,21 +133,19 @@ class Home extends StatelessWidget {
                             Text(game.gameStageString),
                             SizedBox(
                               width: double.infinity,
-                              child: GestureDetector(
-                                onDoubleTap: timerGestures.onDoubleTap,
-                                child: ElevatedButton(
-                                  onPressed: timerGestures.onPressed,
-                                  style: ElevatedButton.styleFrom(
-                                    //minimumSize: const Size(120, 50),
-                                    backgroundColor: (game.isGameRunning
-                                        ? (game.isTimerRunning
-                                            ? AppColors.red
-                                            : AppColors.green)
-                                        : AppColors.green),
-                                  ),
-                                  child: Text(game.timerButtonText,
-                                      style: const TextStyle(color: Colors.white)),
+                              child: CriticalButton(
+                                singleTap: game.singleTapEnabled,
+                                onAction: () => game.toggleTimer(),
+                                style: ElevatedButton.styleFrom(
+                                  //minimumSize: const Size(120, 50),
+                                  backgroundColor: (game.isGameRunning
+                                      ? (game.isTimerRunning
+                                          ? AppColors.red
+                                          : AppColors.green)
+                                      : AppColors.green),
                                 ),
+                                child: Text(game.timerButtonText,
+                                    style: const TextStyle(color: Colors.white)),
                               ),
                             )
                           ],
@@ -203,29 +188,27 @@ class Home extends StatelessWidget {
                     margin: const EdgeInsets.all(4.0),
                     width: double.infinity,
                     //height: 70.0,
-                    child: GestureDetector(
-                      onDoubleTap: allRobotsGestures.onDoubleTap,
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              (game.currentStage == MatchStage.fullTime
-                                  ? AppColors.blue
-                                  : (game.isSomeonePlaying
-                                      ? AppColors.red
-                                      : AppColors.green)),
-                          // shape: RoundedRectangleBorder(
-                          //   borderRadius: BorderRadius.circular(30.0),
-                          // )
-                        ),
-                        child: Text(
-                            game.currentStage == MatchStage.fullTime
-                                ? 'DISCONNECT ALL ROBOTS'
+                    child: CriticalButton(
+                      singleTap: game.singleTapEnabled,
+                      onAction: () => game.toggleAllModules(),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor:
+                            (game.currentStage == MatchStage.fullTime
+                                ? AppColors.blue
                                 : (game.isSomeonePlaying
-                                    ? 'STOP ALL ROBOTS'
-                                    : 'START ALL ROBOTS'),
-                            style: const TextStyle(color: Colors.white)),
-                        onPressed: allRobotsGestures.onPressed,
+                                    ? AppColors.red
+                                    : AppColors.green)),
+                        // shape: RoundedRectangleBorder(
+                        //   borderRadius: BorderRadius.circular(30.0),
+                        // )
                       ),
+                      child: Text(
+                          game.currentStage == MatchStage.fullTime
+                              ? 'DISCONNECT ALL ROBOTS'
+                              : (game.isSomeonePlaying
+                                  ? 'STOP ALL ROBOTS'
+                                  : 'START ALL ROBOTS'),
+                          style: const TextStyle(color: Colors.white)),
                     ),
                   ),
                 ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -73,6 +73,19 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final game = Provider.of<Game>(context);
+    // Gesture wiring for the two button-backed critical controls (timer,
+    // all-robots): single-tap mode routes the action through the button's
+    // onPressed, double-tap mode through the parent GestureDetector. Computed
+    // here (build already rebuilds on Game changes) so the button subtrees stay
+    // wrapper-free. See criticalButtonGestures.
+    final timerGestures = criticalButtonGestures(
+      singleTap: game.singleTapEnabled,
+      onAction: () => game.toggleTimer(),
+    );
+    final allRobotsGestures = criticalButtonGestures(
+      singleTap: game.singleTapEnabled,
+      onAction: () => game.toggleAllModules(),
+    );
     setupGameCallbacks(game, context);
 
     return PopScope(
@@ -133,29 +146,22 @@ class Home extends StatelessWidget {
                             Text(game.gameStageString),
                             SizedBox(
                               width: double.infinity,
-                              child: Builder(builder: (context) {
-                                final g = criticalButtonGestures(
-                                  singleTap: game.singleTapEnabled,
-                                  onAction: () => game.toggleTimer(),
-                                );
-                                return GestureDetector(
-                                  onDoubleTap: g.onDoubleTap,
-                                  child: ElevatedButton(
-                                    onPressed: g.onPressed,
-                                    style: ElevatedButton.styleFrom(
-                                      //minimumSize: const Size(120, 50),
-                                      backgroundColor: (game.isGameRunning
-                                          ? (game.isTimerRunning
-                                              ? AppColors.red
-                                              : AppColors.green)
-                                          : AppColors.green),
-                                    ),
-                                    child: Text(game.timerButtonText,
-                                        style:
-                                            const TextStyle(color: Colors.white)),
+                              child: GestureDetector(
+                                onDoubleTap: timerGestures.onDoubleTap,
+                                child: ElevatedButton(
+                                  onPressed: timerGestures.onPressed,
+                                  style: ElevatedButton.styleFrom(
+                                    //minimumSize: const Size(120, 50),
+                                    backgroundColor: (game.isGameRunning
+                                        ? (game.isTimerRunning
+                                            ? AppColors.red
+                                            : AppColors.green)
+                                        : AppColors.green),
                                   ),
-                                );
-                              }),
+                                  child: Text(game.timerButtonText,
+                                      style: const TextStyle(color: Colors.white)),
+                                ),
+                              ),
                             )
                           ],
                         ),
@@ -197,36 +203,30 @@ class Home extends StatelessWidget {
                     margin: const EdgeInsets.all(4.0),
                     width: double.infinity,
                     //height: 70.0,
-                    child: Builder(builder: (context) {
-                      final g = criticalButtonGestures(
-                        singleTap: game.singleTapEnabled,
-                        onAction: () => game.toggleAllModules(),
-                      );
-                      return GestureDetector(
-                        onDoubleTap: g.onDoubleTap,
-                        child: ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor:
-                                (game.currentStage == MatchStage.fullTime
-                                    ? AppColors.blue
-                                    : (game.isSomeonePlaying
-                                        ? AppColors.red
-                                        : AppColors.green)),
-                            // shape: RoundedRectangleBorder(
-                            //   borderRadius: BorderRadius.circular(30.0),
-                            // )
-                          ),
-                          child: Text(
-                              game.currentStage == MatchStage.fullTime
-                                  ? 'DISCONNECT ALL ROBOTS'
+                    child: GestureDetector(
+                      onDoubleTap: allRobotsGestures.onDoubleTap,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              (game.currentStage == MatchStage.fullTime
+                                  ? AppColors.blue
                                   : (game.isSomeonePlaying
-                                      ? 'STOP ALL ROBOTS'
-                                      : 'START ALL ROBOTS'),
-                              style: const TextStyle(color: Colors.white)),
-                          onPressed: g.onPressed,
+                                      ? AppColors.red
+                                      : AppColors.green)),
+                          // shape: RoundedRectangleBorder(
+                          //   borderRadius: BorderRadius.circular(30.0),
+                          // )
                         ),
-                      );
-                    }),
+                        child: Text(
+                            game.currentStage == MatchStage.fullTime
+                                ? 'DISCONNECT ALL ROBOTS'
+                                : (game.isSomeonePlaying
+                                    ? 'STOP ALL ROBOTS'
+                                    : 'START ALL ROBOTS'),
+                            style: const TextStyle(color: Colors.white)),
+                        onPressed: allRobotsGestures.onPressed,
+                      ),
+                    ),
                   ),
                 ),
               ],

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -520,24 +520,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             );
                           },
                         ),
-                        SettingsSection(
-                          title: 'Controls',
-                          locked: false,
-                          settings: [
-                            SettingSwitch(
-                              title: 'Single-tap actions',
-                              subtitle:
-                                  'Off by default. When on, start/stop, scoring '
-                                  'and robot controls fire on a single tap — '
-                                  'removes the accidental-touch protection.',
-                              value: widget.game.singleTapEnabled,
-                              onChanged: (value) {
-                                setState(() {
-                                  widget.game.singleTapEnabled = value;
-                                });
-                              },
-                            ),
-                          ],
+                        AnimatedBuilder(
+                          animation: widget.game,
+                          builder: (context, child) {
+                            return SettingsSection(
+                              title: 'Controls',
+                              locked: false,
+                              settings: [
+                                SettingSwitch(
+                                  title: 'Single-tap actions',
+                                  subtitle:
+                                      'Off by default. When on, start/stop, '
+                                      'scoring and robot controls fire on a '
+                                      'single tap — removes the accidental-touch '
+                                      'protection.',
+                                  value: widget.game.singleTapEnabled,
+                                  onChanged: (value) {
+                                    widget.game.singleTapEnabled = value;
+                                  },
+                                ),
+                              ],
+                            );
+                          },
                         ),
                         const SettingsSection(
                           title: 'About',

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -520,6 +520,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             );
                           },
                         ),
+                        SettingsSection(
+                          title: 'Controls',
+                          locked: false,
+                          settings: [
+                            SettingSwitch(
+                              title: 'Single-tap actions',
+                              subtitle:
+                                  'Off by default. When on, start/stop, scoring '
+                                  'and robot controls fire on a single tap — '
+                                  'removes the accidental-touch protection.',
+                              value: widget.game.singleTapEnabled,
+                              onChanged: (value) {
+                                setState(() {
+                                  widget.game.singleTapEnabled = value;
+                                });
+                              },
+                            ),
+                          ],
+                        ),
                         const SettingsSection(
                           title: 'About',
                           locked: false,
@@ -893,11 +912,13 @@ class SettingSwitch extends StatelessWidget {
   final String title;
   final bool value;
   final ValueChanged<bool> onChanged;
+  final String? subtitle;
 
   const SettingSwitch({
     required this.title,
     required this.value,
     required this.onChanged,
+    this.subtitle,
     super.key,
   });
 
@@ -907,8 +928,26 @@ class SettingSwitch extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Expanded(flex: 5, child: Text(title)),
+          Expanded(
+            flex: 5,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title),
+                if (subtitle != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4.0),
+                    child: Text(
+                      subtitle!,
+                      style: const TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ),
+              ],
+            ),
+          ),
           Expanded(
             flex: 2,
             child: Switch(

--- a/lib/widgets/critical_gesture_detector.dart
+++ b/lib/widgets/critical_gesture_detector.dart
@@ -1,5 +1,33 @@
 import 'package:flutter/material.dart';
 
+/// Minimum gap between two single-tap critical actions (issue #12, round-2
+/// review). A second tap within this window of the first is ignored, so a
+/// reflexive double-tap — muscle memory from the default double-tap mode —
+/// fires the critical action only once instead of twice (e.g. +2 goals, or
+/// stop-then-restart all robots). Matches Flutter's double-tap recognition
+/// window (`kDoubleTapTimeout` is 300ms).
+const Duration kCriticalTapDebounce = Duration(milliseconds: 300);
+
+/// Stateful single-tap guard: [allow] returns true at most once per [window].
+///
+/// The clock is passed in so the guard is deterministically unit-testable; the
+/// widgets below call `allow(DateTime.now())`. It only ever *suppresses* a
+/// follow-up tap — the first (allowed) tap fires its action immediately and
+/// synchronously, so nothing is delayed or queued on the critical path.
+class TapDebounce {
+  TapDebounce([this.window = kCriticalTapDebounce]);
+
+  final Duration window;
+  DateTime? _lastFired;
+
+  bool allow(DateTime now) {
+    final last = _lastFired;
+    if (last != null && now.difference(last) < window) return false;
+    _lastFired = now;
+    return true;
+  }
+}
+
 /// Gesture wrapper for the app's critical control actions (issue #12).
 ///
 /// All destructive controls default to double-tap to guard against accidental
@@ -11,13 +39,16 @@ import 'package:flutter/material.dart';
 /// score container in `home.dart`). It registers **exactly one** of
 /// [GestureDetector.onTap]/[GestureDetector.onDoubleTap] so there is no
 /// tap-disambiguation delay and double-tap mode reproduces today's behavior
-/// exactly. [onLongPress] passes through unchanged in both modes (it drives the
-/// module-settings / team-edit navigation, which is not a critical control).
+/// exactly. [onLongPress] passes through unchanged in both modes.
 ///
-/// Button-backed sites (the timer and all-robots ElevatedButtons) must NOT use
-/// this — a parent onTap competes with the button's own tap recognizer in the
-/// gesture arena and can lose. Use [criticalButtonGestures] for those.
-class CriticalGestureDetector extends StatelessWidget {
+/// In single-tap mode taps are debounced via [TapDebounce] so a reflexive
+/// double-tap fires the action once. Double-tap mode is left untouched (a
+/// double-tap is already a single deliberate gesture).
+///
+/// Button-backed sites (the timer and all-robots controls) use [CriticalButton]
+/// instead — a parent onTap would lose the gesture arena to an ElevatedButton's
+/// own tap recognizer.
+class CriticalGestureDetector extends StatefulWidget {
   final bool singleTap;
   final VoidCallback onAction;
   final VoidCallback? onLongPress;
@@ -32,33 +63,77 @@ class CriticalGestureDetector extends StatelessWidget {
   });
 
   @override
+  State<CriticalGestureDetector> createState() =>
+      _CriticalGestureDetectorState();
+}
+
+class _CriticalGestureDetectorState extends State<CriticalGestureDetector> {
+  final TapDebounce _debounce = TapDebounce();
+
+  void _fireSingleTap() {
+    if (_debounce.allow(DateTime.now())) widget.onAction();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: singleTap ? onAction : null,
-      onDoubleTap: singleTap ? null : onAction,
-      onLongPress: onLongPress,
-      child: child,
+      onTap: widget.singleTap ? _fireSingleTap : null,
+      onDoubleTap: widget.singleTap ? null : widget.onAction,
+      onLongPress: widget.onLongPress,
+      child: widget.child,
     );
   }
 }
 
-/// Gesture wiring for the **button-backed** critical sites (the timer and
-/// all-robots [ElevatedButton]s in `home.dart`).
+/// Critical control backed by an [ElevatedButton] (the timer and all-robots
+/// buttons in `home.dart`).
 ///
-/// Returns the (button onPressed, parent onDoubleTap) pair so the single tap is
-/// routed through the button itself rather than a parent onTap that would lose
-/// the gesture arena to the button's own recognizer:
+/// A parent `onTap` competes with the button's own tap recognizer in the
+/// gesture arena and can lose, so the single tap is routed through the button's
+/// `onPressed`; the double-tap stays on the parent [GestureDetector]:
 ///
-/// - double-tap mode: `onPressed` is a no-op (today's behavior — the button
-///   swallows single taps) and the parent `onDoubleTap` runs the action.
-/// - single-tap mode: `onPressed` runs the action and the parent `onDoubleTap`
-///   is null, so the action fires on the button with no arena conflict.
-({VoidCallback? onPressed, VoidCallback? onDoubleTap}) criticalButtonGestures({
-  required bool singleTap,
-  required VoidCallback onAction,
-}) {
-  return (
-    onPressed: singleTap ? onAction : () {},
-    onDoubleTap: singleTap ? null : onAction,
-  );
+/// - double-tap mode: `onPressed` is a no-op (button stays enabled exactly as
+///   today) and the parent `onDoubleTap` runs the action.
+/// - single-tap mode: `onPressed` runs the (debounced) action and the parent
+///   `onDoubleTap` is null, so the action fires on the button with no arena
+///   conflict and a reflexive double-tap fires once.
+///
+/// [style] and [child] are computed reactively by the caller and passed through
+/// so the button's color/label still track game state.
+class CriticalButton extends StatefulWidget {
+  final bool singleTap;
+  final VoidCallback onAction;
+  final ButtonStyle? style;
+  final Widget child;
+
+  const CriticalButton({
+    required this.singleTap,
+    required this.onAction,
+    required this.child,
+    this.style,
+    super.key,
+  });
+
+  @override
+  State<CriticalButton> createState() => _CriticalButtonState();
+}
+
+class _CriticalButtonState extends State<CriticalButton> {
+  final TapDebounce _debounce = TapDebounce();
+
+  void _fireSingleTap() {
+    if (_debounce.allow(DateTime.now())) widget.onAction();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onDoubleTap: widget.singleTap ? null : widget.onAction,
+      child: ElevatedButton(
+        onPressed: widget.singleTap ? _fireSingleTap : () {},
+        style: widget.style,
+        child: widget.child,
+      ),
+    );
+  }
 }

--- a/lib/widgets/critical_gesture_detector.dart
+++ b/lib/widgets/critical_gesture_detector.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+/// Gesture wrapper for the app's critical control actions (issue #12).
+///
+/// All destructive controls default to double-tap to guard against accidental
+/// touch (CLAUDE.md invariant). When the user opts into single-tap mode via
+/// Settings, the same action fires on a single tap instead.
+///
+/// This widget is for the **non-button** sites — a plain/decorated child whose
+/// tap is owned entirely by this [GestureDetector] (the per-module cell and the
+/// score container in `home.dart`). It registers **exactly one** of
+/// [GestureDetector.onTap]/[GestureDetector.onDoubleTap] so there is no
+/// tap-disambiguation delay and double-tap mode reproduces today's behavior
+/// exactly. [onLongPress] passes through unchanged in both modes (it drives the
+/// module-settings / team-edit navigation, which is not a critical control).
+///
+/// Button-backed sites (the timer and all-robots ElevatedButtons) must NOT use
+/// this — a parent onTap competes with the button's own tap recognizer in the
+/// gesture arena and can lose. Use [criticalButtonGestures] for those.
+class CriticalGestureDetector extends StatelessWidget {
+  final bool singleTap;
+  final VoidCallback onAction;
+  final VoidCallback? onLongPress;
+  final Widget child;
+
+  const CriticalGestureDetector({
+    required this.singleTap,
+    required this.onAction,
+    required this.child,
+    this.onLongPress,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: singleTap ? onAction : null,
+      onDoubleTap: singleTap ? null : onAction,
+      onLongPress: onLongPress,
+      child: child,
+    );
+  }
+}
+
+/// Gesture wiring for the **button-backed** critical sites (the timer and
+/// all-robots [ElevatedButton]s in `home.dart`).
+///
+/// Returns the (button onPressed, parent onDoubleTap) pair so the single tap is
+/// routed through the button itself rather than a parent onTap that would lose
+/// the gesture arena to the button's own recognizer:
+///
+/// - double-tap mode: `onPressed` is a no-op (today's behavior — the button
+///   swallows single taps) and the parent `onDoubleTap` runs the action.
+/// - single-tap mode: `onPressed` runs the action and the parent `onDoubleTap`
+///   is null, so the action fires on the button with no arena conflict.
+({VoidCallback? onPressed, VoidCallback? onDoubleTap}) criticalButtonGestures({
+  required bool singleTap,
+  required VoidCallback onAction,
+}) {
+  return (
+    onPressed: singleTap ? onAction : () {},
+    onDoubleTap: singleTap ? null : onAction,
+  );
+}

--- a/test/critical_gesture_detector_test.dart
+++ b/test/critical_gesture_detector_test.dart
@@ -3,11 +3,14 @@
 // (ElevatedButton-backed sites), and the TapDebounce guard that makes a
 // reflexive double-tap fire a single-tap action only once.
 //
-// Note on the double-tap-mode tests: a single tap on a GestureDetector that
-// registers only onDoubleTap leaves the DoubleTapGestureRecognizer's timeout
-// Timer pending. We dispose the tree (pump an empty widget) at the end of each
-// such case so the recognizer is disposed and its Timer cancelled — otherwise
-// the test trips the `!timersPending` invariant.
+// Single-tap mode is verified with real taps (only a TapGestureRecognizer is
+// involved). Double-tap mode is verified by inspecting/invoking the configured
+// callbacks rather than simulating a real double tap: a single tap on a
+// GestureDetector that registers only onDoubleTap leaves the
+// DoubleTapGestureRecognizer's timeout Timer pending and trips the test
+// binding's `!timersPending` invariant. Inspecting the wiring proves the
+// contract (single tap cannot fire; the action is bound to the double tap)
+// without that fragility.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -53,6 +56,13 @@ void main() {
       );
     }
 
+    GestureDetector findGd(WidgetTester tester) => tester.widget<GestureDetector>(
+          find.descendant(
+            of: find.byType(CriticalGestureDetector),
+            matching: find.byType(GestureDetector),
+          ),
+        );
+
     testWidgets('single-tap mode: a single tap fires onAction', (tester) async {
       var fired = 0;
       await tester.pumpWidget(host(true, () => fired++));
@@ -72,24 +82,24 @@ void main() {
       expect(fired, 1, reason: 'second tap within the window is debounced');
     });
 
-    testWidgets('double-tap mode: a single tap does not fire', (tester) async {
-      var fired = 0;
-      await tester.pumpWidget(host(false, () => fired++));
-      await tester.tap(find.text('x'));
-      await tester.pump(const Duration(milliseconds: 400));
-      expect(fired, 0);
-      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
+    testWidgets('single-tap mode: only onTap is wired', (tester) async {
+      await tester.pumpWidget(host(true, () {}));
+      final gd = findGd(tester);
+      expect(gd.onTap, isNotNull);
+      expect(gd.onDoubleTap, isNull);
     });
 
-    testWidgets('double-tap mode: a double tap fires once', (tester) async {
+    testWidgets(
+        'double-tap mode: only onDoubleTap is wired and it fires the action',
+        (tester) async {
       var fired = 0;
       await tester.pumpWidget(host(false, () => fired++));
-      await tester.tap(find.text('x'));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tap(find.text('x'));
-      await tester.pump();
+      final gd = findGd(tester);
+      // No onTap => a single tap cannot fire the critical action.
+      expect(gd.onTap, isNull);
+      expect(gd.onDoubleTap, isNotNull);
+      gd.onDoubleTap!();
       expect(fired, 1);
-      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
     });
 
     testWidgets('onLongPress fires in both modes', (tester) async {
@@ -100,7 +110,6 @@ void main() {
         await tester.longPress(find.text('x'));
         await tester.pump();
         expect(longPressed, 1, reason: 'singleTap=$single');
-        await tester.pumpWidget(const SizedBox()); // dispose recognizers
       }
     });
   });
@@ -137,24 +146,30 @@ void main() {
       expect(fired, 1, reason: 'second tap within the window is debounced');
     });
 
-    testWidgets('double-tap mode: a single tap does not fire', (tester) async {
+    testWidgets('double-tap mode: button press is a no-op; double tap fires',
+        (tester) async {
       var fired = 0;
       await tester.pumpWidget(host(false, () => fired++));
-      await tester.tap(find.text('go'));
-      await tester.pump(const Duration(milliseconds: 400));
-      expect(fired, 0);
-      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
-    });
 
-    testWidgets('double-tap mode: a double tap fires once', (tester) async {
-      var fired = 0;
-      await tester.pumpWidget(host(false, () => fired++));
-      await tester.tap(find.text('go'));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tap(find.text('go'));
-      await tester.pump();
+      // The button stays enabled but its press is a no-op, so a single tap
+      // cannot fire the critical action.
+      final btn = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(btn.onPressed, isNotNull);
+      btn.onPressed!();
+      expect(fired, 0, reason: 'a single button press must not fire the action');
+
+      // The action is bound to the parent GestureDetector's double tap.
+      final gd = tester.widget<GestureDetector>(
+        find
+            .ancestor(
+              of: find.byType(ElevatedButton),
+              matching: find.byType(GestureDetector),
+            )
+            .first,
+      );
+      expect(gd.onDoubleTap, isNotNull);
+      gd.onDoubleTap!();
       expect(fired, 1);
-      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
     });
   });
 }

--- a/test/critical_gesture_detector_test.dart
+++ b/test/critical_gesture_detector_test.dart
@@ -1,6 +1,7 @@
-// Widget tests for the single-tap/double-tap gesture wrapper (issue #12):
-// CriticalGestureDetector (non-button sites) and criticalButtonGestures
-// (ElevatedButton-backed sites).
+// Widget tests for the single-tap/double-tap critical control widgets (issue
+// #12): CriticalGestureDetector (non-button sites), CriticalButton
+// (ElevatedButton-backed sites), and the TapDebounce guard that makes a
+// reflexive double-tap fire a single-tap action only once.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
 
 void main() {
+  group('TapDebounce', () {
+    final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+    test('allows the first call', () {
+      expect(TapDebounce().allow(t0), isTrue);
+    });
+
+    test('suppresses a second call within the window', () {
+      final d = TapDebounce(const Duration(milliseconds: 300));
+      expect(d.allow(t0), isTrue);
+      expect(d.allow(t0.add(const Duration(milliseconds: 100))), isFalse);
+      expect(d.allow(t0.add(const Duration(milliseconds: 299))), isFalse);
+    });
+
+    test('allows again once the window has elapsed', () {
+      final d = TapDebounce(const Duration(milliseconds: 300));
+      expect(d.allow(t0), isTrue);
+      expect(d.allow(t0.add(const Duration(milliseconds: 300))), isTrue);
+      // and the window restarts from the last allowed call
+      expect(d.allow(t0.add(const Duration(milliseconds: 350))), isFalse);
+    });
+  });
+
   group('CriticalGestureDetector (non-button)', () {
     testWidgets('single-tap mode: a single tap fires onAction', (tester) async {
       var fired = 0;
@@ -25,6 +49,25 @@ void main() {
       expect(fired, 1);
     });
 
+    testWidgets('single-tap mode: a reflexive double tap fires only once',
+        (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CriticalGestureDetector(
+            singleTap: true,
+            onAction: () => fired++,
+            child: const SizedBox(width: 200, height: 200, child: Text('x')),
+          ),
+        ),
+      ));
+      // Two taps in immediate succession (wall-clock gap << 300ms debounce).
+      await tester.tap(find.text('x'));
+      await tester.tap(find.text('x'));
+      await tester.pump();
+      expect(fired, 1, reason: 'second tap within the window is debounced');
+    });
+
     testWidgets('double-tap mode: a double tap fires, a single tap does not',
         (tester) async {
       var fired = 0;
@@ -38,12 +81,10 @@ void main() {
         ),
       ));
 
-      // A lone tap must not trigger the action.
       await tester.tap(find.text('x'));
       await tester.pump(const Duration(milliseconds: 400));
       expect(fired, 0, reason: 'single tap must not fire in double-tap mode');
 
-      // A double tap (two taps within the recognizer window) does.
       await tester.tap(find.text('x'));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('x'));
@@ -71,19 +112,14 @@ void main() {
     });
   });
 
-  group('criticalButtonGestures (ElevatedButton-backed)', () {
-    // Builds the same GestureDetector+ElevatedButton shape used by the timer and
-    // all-robots controls in home.dart.
-    Widget buildButton(bool single, VoidCallback onAction) {
-      final g = criticalButtonGestures(singleTap: single, onAction: onAction);
+  group('CriticalButton (ElevatedButton-backed)', () {
+    Widget host(bool single, VoidCallback onAction) {
       return MaterialApp(
         home: Scaffold(
-          body: GestureDetector(
-            onDoubleTap: g.onDoubleTap,
-            child: ElevatedButton(
-              onPressed: g.onPressed,
-              child: const Text('go'),
-            ),
+          body: CriticalButton(
+            singleTap: single,
+            onAction: onAction,
+            child: const Text('go'),
           ),
         ),
       );
@@ -92,16 +128,26 @@ void main() {
     testWidgets('single-tap mode: a single tap fires (not swallowed by button)',
         (tester) async {
       var fired = 0;
-      await tester.pumpWidget(buildButton(true, () => fired++));
+      await tester.pumpWidget(host(true, () => fired++));
       await tester.tap(find.text('go'));
       await tester.pump();
       expect(fired, 1);
     });
 
+    testWidgets('single-tap mode: a reflexive double tap fires only once',
+        (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(host(true, () => fired++));
+      await tester.tap(find.text('go'));
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      expect(fired, 1, reason: 'second tap within the window is debounced');
+    });
+
     testWidgets('double-tap mode: a double tap fires, a single tap does not',
         (tester) async {
       var fired = 0;
-      await tester.pumpWidget(buildButton(false, () => fired++));
+      await tester.pumpWidget(host(false, () => fired++));
 
       await tester.tap(find.text('go'));
       await tester.pump(const Duration(milliseconds: 400));

--- a/test/critical_gesture_detector_test.dart
+++ b/test/critical_gesture_detector_test.dart
@@ -2,6 +2,12 @@
 // #12): CriticalGestureDetector (non-button sites), CriticalButton
 // (ElevatedButton-backed sites), and the TapDebounce guard that makes a
 // reflexive double-tap fire a single-tap action only once.
+//
+// Note on the double-tap-mode tests: a single tap on a GestureDetector that
+// registers only onDoubleTap leaves the DoubleTapGestureRecognizer's timeout
+// Timer pending. We dispose the tree (pump an empty widget) at the end of each
+// such case so the recognizer is disposed and its Timer cancelled — otherwise
+// the test trips the `!timersPending` invariant.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,17 +39,23 @@ void main() {
   });
 
   group('CriticalGestureDetector (non-button)', () {
-    testWidgets('single-tap mode: a single tap fires onAction', (tester) async {
-      var fired = 0;
-      await tester.pumpWidget(MaterialApp(
+    Widget host(bool single, VoidCallback onAction,
+        {VoidCallback? onLongPress}) {
+      return MaterialApp(
         home: Scaffold(
           body: CriticalGestureDetector(
-            singleTap: true,
-            onAction: () => fired++,
+            singleTap: single,
+            onAction: onAction,
+            onLongPress: onLongPress,
             child: const SizedBox(width: 200, height: 200, child: Text('x')),
           ),
         ),
-      ));
+      );
+    }
+
+    testWidgets('single-tap mode: a single tap fires onAction', (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(host(true, () => fired++));
       await tester.tap(find.text('x'));
       await tester.pump();
       expect(fired, 1);
@@ -52,15 +64,7 @@ void main() {
     testWidgets('single-tap mode: a reflexive double tap fires only once',
         (tester) async {
       var fired = 0;
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: CriticalGestureDetector(
-            singleTap: true,
-            onAction: () => fired++,
-            child: const SizedBox(width: 200, height: 200, child: Text('x')),
-          ),
-        ),
-      ));
+      await tester.pumpWidget(host(true, () => fired++));
       // Two taps in immediate succession (wall-clock gap << 300ms debounce).
       await tester.tap(find.text('x'));
       await tester.tap(find.text('x'));
@@ -68,48 +72,35 @@ void main() {
       expect(fired, 1, reason: 'second tap within the window is debounced');
     });
 
-    testWidgets('double-tap mode: a double tap fires, a single tap does not',
-        (tester) async {
+    testWidgets('double-tap mode: a single tap does not fire', (tester) async {
       var fired = 0;
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: CriticalGestureDetector(
-            singleTap: false,
-            onAction: () => fired++,
-            child: const SizedBox(width: 200, height: 200, child: Text('x')),
-          ),
-        ),
-      ));
-
+      await tester.pumpWidget(host(false, () => fired++));
       await tester.tap(find.text('x'));
       await tester.pump(const Duration(milliseconds: 400));
-      expect(fired, 0, reason: 'single tap must not fire in double-tap mode');
+      expect(fired, 0);
+      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
+    });
 
+    testWidgets('double-tap mode: a double tap fires once', (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(host(false, () => fired++));
       await tester.tap(find.text('x'));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('x'));
-      // Pump past the double-tap window so the recognizer's timer settles and
-      // the test does not end with a pending Timer.
-      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
       expect(fired, 1);
+      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
     });
 
     testWidgets('onLongPress fires in both modes', (tester) async {
       for (final single in [true, false]) {
         var longPressed = 0;
-        await tester.pumpWidget(MaterialApp(
-          home: Scaffold(
-            body: CriticalGestureDetector(
-              singleTap: single,
-              onAction: () {},
-              onLongPress: () => longPressed++,
-              child: const SizedBox(width: 200, height: 200, child: Text('x')),
-            ),
-          ),
-        ));
+        await tester.pumpWidget(
+            host(single, () {}, onLongPress: () => longPressed++));
         await tester.longPress(find.text('x'));
         await tester.pump();
         expect(longPressed, 1, reason: 'singleTap=$single');
+        await tester.pumpWidget(const SizedBox()); // dispose recognizers
       }
     });
   });
@@ -146,22 +137,24 @@ void main() {
       expect(fired, 1, reason: 'second tap within the window is debounced');
     });
 
-    testWidgets('double-tap mode: a double tap fires, a single tap does not',
-        (tester) async {
+    testWidgets('double-tap mode: a single tap does not fire', (tester) async {
       var fired = 0;
       await tester.pumpWidget(host(false, () => fired++));
-
       await tester.tap(find.text('go'));
       await tester.pump(const Duration(milliseconds: 400));
-      expect(fired, 0, reason: 'single tap must not fire in double-tap mode');
+      expect(fired, 0);
+      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
+    });
 
+    testWidgets('double-tap mode: a double tap fires once', (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(host(false, () => fired++));
       await tester.tap(find.text('go'));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('go'));
-      // Pump past the double-tap window so the recognizer's timer settles and
-      // the test does not end with a pending Timer.
-      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
       expect(fired, 1);
+      await tester.pumpWidget(const SizedBox()); // dispose recognizer + timer
     });
   });
 }

--- a/test/critical_gesture_detector_test.dart
+++ b/test/critical_gesture_detector_test.dart
@@ -88,7 +88,9 @@ void main() {
       await tester.tap(find.text('x'));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('x'));
-      await tester.pump();
+      // Pump past the double-tap window so the recognizer's timer settles and
+      // the test does not end with a pending Timer.
+      await tester.pump(const Duration(milliseconds: 400));
       expect(fired, 1);
     });
 
@@ -156,7 +158,9 @@ void main() {
       await tester.tap(find.text('go'));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('go'));
-      await tester.pump();
+      // Pump past the double-tap window so the recognizer's timer settles and
+      // the test does not end with a pending Timer.
+      await tester.pump(const Duration(milliseconds: 400));
       expect(fired, 1);
     });
   });

--- a/test/critical_gesture_detector_test.dart
+++ b/test/critical_gesture_detector_test.dart
@@ -1,0 +1,117 @@
+// Widget tests for the single-tap/double-tap gesture wrapper (issue #12):
+// CriticalGestureDetector (non-button sites) and criticalButtonGestures
+// (ElevatedButton-backed sites).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
+
+void main() {
+  group('CriticalGestureDetector (non-button)', () {
+    testWidgets('single-tap mode: a single tap fires onAction', (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CriticalGestureDetector(
+            singleTap: true,
+            onAction: () => fired++,
+            child: const SizedBox(width: 200, height: 200, child: Text('x')),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('x'));
+      await tester.pump();
+      expect(fired, 1);
+    });
+
+    testWidgets('double-tap mode: a double tap fires, a single tap does not',
+        (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CriticalGestureDetector(
+            singleTap: false,
+            onAction: () => fired++,
+            child: const SizedBox(width: 200, height: 200, child: Text('x')),
+          ),
+        ),
+      ));
+
+      // A lone tap must not trigger the action.
+      await tester.tap(find.text('x'));
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(fired, 0, reason: 'single tap must not fire in double-tap mode');
+
+      // A double tap (two taps within the recognizer window) does.
+      await tester.tap(find.text('x'));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('x'));
+      await tester.pump();
+      expect(fired, 1);
+    });
+
+    testWidgets('onLongPress fires in both modes', (tester) async {
+      for (final single in [true, false]) {
+        var longPressed = 0;
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: CriticalGestureDetector(
+              singleTap: single,
+              onAction: () {},
+              onLongPress: () => longPressed++,
+              child: const SizedBox(width: 200, height: 200, child: Text('x')),
+            ),
+          ),
+        ));
+        await tester.longPress(find.text('x'));
+        await tester.pump();
+        expect(longPressed, 1, reason: 'singleTap=$single');
+      }
+    });
+  });
+
+  group('criticalButtonGestures (ElevatedButton-backed)', () {
+    // Builds the same GestureDetector+ElevatedButton shape used by the timer and
+    // all-robots controls in home.dart.
+    Widget buildButton(bool single, VoidCallback onAction) {
+      final g = criticalButtonGestures(singleTap: single, onAction: onAction);
+      return MaterialApp(
+        home: Scaffold(
+          body: GestureDetector(
+            onDoubleTap: g.onDoubleTap,
+            child: ElevatedButton(
+              onPressed: g.onPressed,
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('single-tap mode: a single tap fires (not swallowed by button)',
+        (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(buildButton(true, () => fired++));
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      expect(fired, 1);
+    });
+
+    testWidgets('double-tap mode: a double tap fires, a single tap does not',
+        (tester) async {
+      var fired = 0;
+      await tester.pumpWidget(buildButton(false, () => fired++));
+
+      await tester.tap(find.text('go'));
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(fired, 0, reason: 'single tap must not fire in double-tap mode');
+
+      await tester.tap(find.text('go'));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      expect(fired, 1);
+    });
+  });
+}

--- a/test/single_tap_pref_test.dart
+++ b/test/single_tap_pref_test.dart
@@ -1,0 +1,76 @@
+// Tests for the single-tap gesture preference added for issue #12.
+//
+// Like game_remaining_time_test.dart these use testWidgets: the Game
+// constructor stands up the wakelock/notification/MQTT/bridge services, whose
+// platform-channel calls reject asynchronously in the headless test VM. The
+// widget test binding tolerates those pending platform replies; a bare test()
+// reports them as "pending async work" and fails after completion.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/models/game.dart';
+
+const _key = 'gesture_single_tap_enabled';
+
+void main() {
+  group('Game.singleTapEnabled', () {
+    testWidgets('defaults to false (double-tap preserved)', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final game = Game();
+      await tester.pump();
+      expect(game.singleTapEnabled, isFalse);
+    });
+
+    testWidgets('adopts the stored value on load', (tester) async {
+      SharedPreferences.setMockInitialValues({_key: true});
+      final game = Game();
+      await tester.pump();
+      expect(game.singleTapEnabled, isTrue);
+    });
+
+    testWidgets('setting persists to SharedPreferences', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final game = Game();
+      await tester.pump();
+      game.singleTapEnabled = true;
+      await tester.pump();
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(_key), isTrue);
+    });
+
+    testWidgets('notifies listeners on change', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final game = Game();
+      await tester.pump();
+      var notified = false;
+      game.addListener(() => notified = true);
+      game.singleTapEnabled = true;
+      expect(notified, isTrue);
+    });
+
+    testWidgets('no-op set does not notify', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final game = Game();
+      await tester.pump();
+      var notified = false;
+      game.addListener(() => notified = true);
+      game.singleTapEnabled = false; // already false
+      expect(notified, isFalse);
+    });
+
+    testWidgets('a toggle made before _loadPrefs resolves is not lost',
+        (tester) async {
+      // Stored default is false; the user toggles ON before the unawaited
+      // _loadPrefs() in the constructor completes. The pending-write guard must
+      // flush the user's choice rather than let the stored default clobber it.
+      SharedPreferences.setMockInitialValues({_key: false});
+      final game = Game();
+      game.singleTapEnabled = true; // synchronous, before any pump => prefs null
+      await tester.pump(); // _loadPrefs resolves here
+      expect(game.singleTapEnabled, isTrue, reason: 'pre-load toggle preserved');
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(_key), isTrue, reason: 'pending write flushed');
+    });
+  });
+}


### PR DESCRIPTION
Closes #12.

Implements the converged design in `docs/superpowers/specs/2026-06-20-single-tap-toggle-design.md` (approved via brainstorming + review-anvil R1–R2, merged as docs in #20).

## What
A Settings toggle that switches all four critical control actions from double-tap to single-tap. **Default stays `false` (double-tap everywhere), so shipped behavior is unchanged** — the accidental-touch protection is only relaxed when the user explicitly opts in.

The four critical sites: timer START/STOP, start/stop all robots, per-module play/penalty/stop, and scoring a goal.

## How
The four sites are **not** structurally identical, which matters for Flutter's gesture arena, so there are two patterns:

- **Non-button sites** (per-module cell, score container) → a new `CriticalGestureDetector` that registers **exactly one** of `onTap`/`onDoubleTap` (no tap-disambiguation delay; double-tap mode reproduces today exactly) and passes `onLongPress` through.
- **Button-backed sites** (timer & all-robots `ElevatedButton`s) → a parent `onTap` would lose the gesture arena to the button's own tap recognizer, so the single tap is routed through the button's `onPressed` via the `criticalButtonGestures` helper.

The preference lives on the existing `Game` `ChangeNotifier` — **no new provider/service**, so the static provider tree in `main.dart` is untouched. A pending-write guard prevents the unawaited `_loadPrefs()` from clobbering a toggle made before prefs finish loading.

## Invariants respected (CLAUDE.md)
- **START/STOP latency** — only the gesture *recognizer* changes; the `toggleTimer`/`toggleAllModules`/`module.*`/`addScore` callbacks and the fire-and-forget `bleSendPlayAll()/bleSendStopAll()` paths are untouched. No awaits/queues added.
- **Double-tap safety** — intentionally relaxed, but **only on explicit opt-in**; default preserves double-tap.
- **Provider tree / portrait-only** — unchanged.

## Files
| File | Change |
|---|---|
| `lib/models/game.dart` | pref-backed `singleTapEnabled` (default false) + notify + pending-write guard |
| `lib/widgets/critical_gesture_detector.dart` | **new** — `CriticalGestureDetector` + `criticalButtonGestures` |
| `lib/screens/home.dart` | wire all four critical sites |
| `lib/screens/settings.dart` | optional `subtitle` on `SettingSwitch` + "Controls" section toggle + warning copy |
| `test/single_tap_pref_test.dart` | **new** — pref incl. pre-load toggle race |
| `test/critical_gesture_detector_test.dart` | **new** — both gesture patterns incl. the `ElevatedButton`-backed case |

## Tests
Two new test files cover: default `false`, persistence, stored-value adoption, notify-on-change, no-op-no-notify, the pre-load toggle race, and widget tests for single/double-tap behavior + long-press pass-through in both the non-button and button-backed shapes.

> Note: I could not run `flutter test`/`analyze` in my working environment (no Flutter SDK there) — relying on this PR's quality gate to validate.