### PR TITLE
test: add integration_test harness + single-tap smoke test

### DIFF
--- a/integration_test/app_smoke_test.dart
+++ b/integration_test/app_smoke_test.dart
@@ -1,0 +1,89 @@
+// On-device/emulator smoke test for the single-tap actions feature (#12/#26)
+// integrated with the bluetooth-banner UI (#17).
+//
+// Run on a booted emulator or device:
+//   flutter test integration_test/app_smoke_test.dart -d <device-id>
+//
+// These cover what desk widget tests can't fully exercise: the real gesture
+// arena on a real surface, and the Settings → toggle → Home wiring end to end.
+// (BLE/MQTT hardware paths are intentionally NOT asserted here — those still
+// need a real device + module/broker.)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/main.dart';
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/screens/home.dart';
+import 'package:rcj_scoreboard/screens/widgets/bluetooth_banner.dart';
+import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // Team A's score control is the first CriticalGestureDetector in the tree
+  // (Home builds team A, then the timer column, then team B, then modules).
+  Finder teamAScore() => find.byType(CriticalGestureDetector).first;
+
+  Future<void> doubleTap(WidgetTester tester, Finder f) async {
+    await tester.tap(f);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(f);
+    // Let the double-tap recognizer resolve past kDoubleTapTimeout (~300ms).
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Home renders with the bluetooth banner', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final game = Game();
+    await tester.pumpWidget(MyApp(game: game));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Home), findsOneWidget);
+    expect(find.byType(BluetoothBanner), findsOneWidget,
+        reason: 'BLE status banner (#17) must render above the controls');
+  });
+
+  testWidgets('default mode: single tap is ignored, double tap scores',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({}); // singleTapEnabled defaults false
+    final game = Game();
+    await tester.pumpWidget(MyApp(game: game));
+    await tester.pumpAndSettle();
+
+    expect(game.singleTapEnabled, isFalse);
+    expect(game.teams[0].score, 0);
+
+    // A single tap must NOT score (accidental-touch protection).
+    await tester.tap(teamAScore());
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+    expect(game.teams[0].score, 0,
+        reason: 'single tap must be ignored while double-tap mode is active');
+
+    // A double tap scores.
+    await doubleTap(tester, teamAScore());
+    expect(game.teams[0].score, 1);
+  });
+
+  testWidgets('single-tap mode: a single tap scores', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final game = Game();
+    await tester.pumpWidget(MyApp(game: game));
+    await tester.pumpAndSettle();
+
+    // Flip the preference (as the Settings toggle does) and let the
+    // CriticalGestureDetector rebuild into single-tap mode.
+    game.singleTapEnabled = true;
+    await tester.pumpAndSettle();
+    expect(game.singleTapEnabled, isTrue);
+
+    final before = game.teams[0].score;
+    await tester.tap(teamAScore());
+    await tester.pumpAndSettle();
+    expect(game.teams[0].score, before + 1,
+        reason: 'in single-tap mode one tap must score');
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,6 +238,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -312,6 +317,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   html:
     dependency: transitive
     description:
@@ -344,6 +354,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   json_annotation:
     dependency: transitive
     description:
@@ -520,6 +535,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: "direct main"
     description:
@@ -629,6 +652,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -733,6 +764,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## What

Adds Flutter's first-party **`integration_test`** package and a first on-device/emulator smoke test, so UI/gesture/flow behaviour can be verified automatically on an emulator (and, optionally later, in CI) instead of only by hand on a phone.

## Why

We just validated the single-tap feature (#26) manually on a device. This makes that kind of check **repeatable and reusable** — it's the rig for testing the pending fix PRs (#40/#43/#44) on an emulator, and a regression guard for the accidental-touch safety invariant (CLAUDE.md invariant #2) going forward.

## The first test (`integration_test/app_smoke_test.dart`)

Runs the real app and asserts against the live `Game` instance:

- **Home renders with the `BluetoothBanner`** — confirms single-tap (#26) and the bluetooth-banner UI (#17) coexist.
- **default mode: a single tap is ignored, a double tap scores** — directly guards the double-tap safety invariant.
- **single-tap mode: one tap scores.**

## Scope / non-goals

- **BLE and MQTT hardware paths are intentionally not asserted** — an emulator has no Bluetooth radio, so those still need a real device + module/broker.
- This PR does **not** add a CI emulator job (that costs CI minutes); the tests run locally today via:
  ```
  flutter test integration_test/app_smoke_test.dart -d <device-id>
  ```
  Wiring it into the existing "Analyze, Test & Build" workflow can be a follow-up if the team wants automated gating.

## Verification

Green on a **Pixel 6 / Android 14 (API 34)** emulator (3/3 passed). `flutter analyze` clean.