### PR TITLE
feat: match cold-resume (crash/kill recovery) (#45)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-match-cold-resume.md
+++ b/docs/superpowers/plans/2026-06-22-match-cold-resume.md
@@ -1,0 +1,100 @@
+# Match Cold-Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a cold kill/crash mid-match, relaunching the app detects the in-progress match and offers Resume (restore full state, freeze the clock, robots stay STOPPED) or Discard (fresh start).
+
+**Architecture:** A new `MatchStateStore` serializes one versioned `MatchSnapshot` to a single `SharedPreferences` key with serialized+coalesced writes and a tombstone-generation guard. `Game` marks state dirty off the robot-command hot path and flushes via a ~5 s heartbeat + discrete events. On cold launch `Game._loadPrefs()` loads the snapshot **before** the bootstrap `gameInit()` and, if a match is in progress, fires a draining `onRequestResumeMatch` callback that `home.dart` renders as a non-dismissible dialog.
+
+**Tech Stack:** Flutter 3.44 / Dart 3.12, `provider`, `shared_preferences` (no new packages).
+
+## Global Constraints (verbatim from spec + CLAUDE.md)
+
+- **START/STOP latency invariant:** never add awaits/blocking/queues on `bleSendPlayAll()`/`bleSendStopAll()` or the `playAll`/`stopAll` fan-out. Snapshot build + `jsonEncode` must be OFF those paths.
+- **Double-tap safety:** the resume prompt is a non-destructive dialog; Discard requires a deliberate confirm (second dialog), never one stray tap. Resuming play still requires the existing double-tap START.
+- **Provider tree:** no new providers. `MatchStateStore` is a plain dependency of `Game`.
+- **Portrait-only**, **no new packages**.
+- **Never auto-PLAY on cold resume.** Robots stay STOPPED until referee double-taps START.
+- **v1 scope:** NO web-binding fields (`loadedFromWeb`/`scoreboardMatchId`) and NO clock-anchor fields (`runClockStartedAtMs`/`runClockStartRemainingTime`). Both deferred. Snapshot `version = 1`.
+- **Dart privacy is per-file:** `Module` cannot call `Game._markDirty()`. Use a **public** `Game.markMatchStateDirty()`.
+
+---
+
+## Current-code grounding (dev @ 178c672)
+
+- `game.dart`: `gameInit()` calls `stopTimer()` (`game.dart:117`). Constructor calls `gameInit()` then `unawaited(_loadPrefs())` (`:88-89`). `_loadPrefs()` re-runs `gameInit()` when `!inGame` (`:100-102`). `_tickTimer` decrement branch is `if (_remainingTime > 0)` (`:180`); stage transitions in the `<= 0` block (`:187-221`), secondHalf→fullTime at `:210-215`. `toggleTimer` GAME-OVER branch calls `gameInit()` (`:278`). `toggleAllModules` start uses `playAll(true)` (`:309`). `loadMatchData()` sets `teams[0].name =` directly (`:712`). Team-name edit is in `_TeamSettingsWidgetState` (`home.dart:524-526` → `team.name = value; game.notifyMQTT();`). Dialog callbacks registered in `setupGameCallbacks` (`home.dart:698`), called from `Home.build` (`home.dart:80`).
+- `module.dart`: `bleNotify()` sends `bleSendPlay()` when `_state==play` (`:86-89`). `Module.stop()` switches on `_lastState`, default→`debugPrint('Wrong last ModuleState')` no-op (`:431-441`). `applyPresetConfig(String macAddress, String label)` (`:581`) → `setLabel`, `setBleDevice(BluetoothDevice.fromId)`, `bleConnect()` if enabled. `bleInitModule()`→`bleSendCurrentState()`→`bleNotify()` runs on the connected event, **seconds after** restore returns (`:189-195`, `:546`).
+
+---
+
+### Task 1: `MatchStateStore` + snapshot models
+
+**Files:**
+- Create: `lib/services/match_state_store.dart`
+- Test: `test/match_state_store_test.dart`
+
+**Interfaces produced:**
+- `const int kMatchSnapshotVersion = 1;`
+- `class TeamSnapshot { final String id; final String name; final int score; ... toJson()/fromJson() }`
+- `class ModuleSnapshot { final int moduleId; final bool isEnabled; final String macAddress; final String? customLabel; final String state; final String lastState; final int penaltyTime; ... }`
+- `class MatchSnapshot { final int version; final String stage; final int remainingTime; final bool isTimeRunning; final bool inGame; final String timerButtonText; final List<TeamSnapshot> teams; final List<ModuleSnapshot> modules; final int savedAtMs; ... }`
+- `class MatchStateStore { MatchStateStore(SharedPreferences prefs); Future<void> save(MatchSnapshot s); MatchSnapshot? load(); Future<void> clear(); }`
+
+**Design:** single serialized op stream + coalescing (latest-wins pending slot) + monotonic `generation`. `clear()` bumps generation, persists a tombstone key, drops pending save. `save` stamps the snapshot with the current generation. `load()` returns null on missing/parse-fail/version-mismatch, and rejects any snapshot whose `generation < tombstone`.
+
+- [ ] **Step 1: Write failing tests** (`test/match_state_store_test.dart`): round-trip save/load (incl. per-module macAddress/customLabel/penaltyTime/state/lastState); `load()` null on missing key, corrupt JSON, version mismatch; `clear()` removes; a stale older `save` completing after a `clear()` does NOT resurrect (generation/tombstone); a `save` after `clear()` IS loadable.
+- [ ] **Step 2:** Implement the store + models (see code in repo; mirrors Interfaces above).
+- [ ] **Step 3:** `flutter test test/match_state_store_test.dart` (run in CI).
+- [ ] **Step 4: Commit** `feat(recovery): add MatchStateStore versioned snapshot with coalesced writes`.
+
+### Task 2: `Module` snapshot + restore
+
+**Files:** Modify `lib/models/module.dart`; tests folded into `test/game_recovery_test.dart` (Task 4).
+
+**Interfaces produced:**
+- `ModuleSnapshot toSnapshot()` — captures moduleId, isEnabled, macAddress, customLabel (`_label`), `_state.name`, `_lastState.name`, `_penaltyTime`.
+- `void restoreFromSnapshot(ModuleSnapshot s)` — order: (1) apply `isEnabled` (`enable()`/`disable()`); (2) set `_label`, `_penaltyTime`, **normalized** `_state`/`_lastState` (map `play`/`halfTime`/`fullTime`→`stop` for BOTH; preserve `damage`/`stop`); set `_suppressNextRestoreNotify = true`; (3) re-establish device via `applyPresetConfig(s.macAddress, s.customLabel ?? '')` (which reconnects enabled+non-empty-MAC).
+- per-module `bool _suppressNextRestoreNotify` consumed (clear-on-consume in `finally`) by the **first** post-restore `bleNotify()`, which then sends at most STOP (+ name/score via `bleSendCurrentState`), never play/damage.
+
+- [ ] **Step 1:** Add `toSnapshot()`/`restoreFromSnapshot()` + a private normalizer + `_suppressNextRestoreNotify` flag; guard `bleNotify()` to consume it.
+- [ ] **Step 2: Commit** `feat(recovery): add Module snapshot/restore with restore-notify one-shot`.
+
+### Task 3: `Game` persistence wiring
+
+**Files:** Modify `lib/models/game.dart`; `lib/screens/home.dart` (team-name route).
+
+**Interfaces produced:** `void markMatchStateDirty()`; `Future<void> setTeamName(Team team, String value)`; private `_persistMatchState()`, `_clearMatchState()`, `_buildSnapshot()`, `bool _suppressPersist`, `bool _dirty`, `MatchStateStore? _stateStore`.
+
+- [ ] Hold `MatchStateStore? _stateStore`, construct in `_loadPrefs()` after `_prefs` is set.
+- [ ] `markMatchStateDirty()` = `_dirty = true` (trivial, hot-path-safe). `_persistMatchState()` = no-op unless `_dirty && _stateStore != null && !_suppressPersist`; builds snapshot and `_stateStore!.save(...)`, scheduled via `scheduleMicrotask` after fan-outs.
+- [ ] Discrete dirty sources: `startTimer`, `stopTimer`, `toggleTimer` SKIP branch, `_tickTimer` stage transitions, `notifyModulesScore`, `toggleTeamOrder`, `loadMatchData`, `setTeamName`; Module mutations call `markMatchStateDirty()`.
+- [ ] Heartbeat: in `_tickTimer` decrement branch (`_remainingTime > 0`), when `!_replaying && _remainingTime % 5 == 0` → `markMatchStateDirty(); _persistMatchState()`. One post-catch-up flush after the `resumed` replay loop.
+- [ ] `_suppressPersist` scope around bootstrap `gameInit()` in `_loadPrefs()` (wrap so the bootstrap `stopTimer()` can't overwrite the snapshot).
+- [ ] `_clearMatchState()` (enqueues tombstone) at: secondHalf→fullTime in `_tickTimer`, GAME-OVER branch of `toggleTimer`, and `discardPendingMatch` (Task 4). NOT in `gameInit()`.
+- [ ] **Penalty-preserve fix:** `toggleAllModules` start `playAll(true)` → `playAll(false)`. STOP path unchanged.
+- [ ] `setTeamName(team, value)` sets name + `notifyMQTT()` + dirty; route `home.dart:524-526` and `loadMatchData` through it.
+- [ ] **Commit** `feat(recovery): wire Game persistence + penalty-preserve fix`.
+
+### Task 4: Cold-resume flow + dialog
+
+**Files:** Modify `lib/models/game.dart`, `lib/screens/home.dart`; Create `test/game_recovery_test.dart`.
+
+**Interfaces produced:** `void Function()? onRequestResumeMatch` (draining setter); `MatchSnapshot? get pendingResume`; `void resumePendingMatch()`; `void discardPendingMatch()`; `bool _resumePrompted`, `MatchSnapshot? _pendingResume`.
+
+- [ ] `_loadPrefs()`: load snapshot into a local **before** the `if (!inGame) gameInit()` bootstrap (suppress-wrapped). If `inGame == true && stage != fullTime`, stash `_pendingResume`, call drain.
+- [ ] `onRequestResumeMatch` as a draining setter: on assign, if `_pendingResume != null && !_resumePrompted`, invoke immediately; guard `_resumePrompted` so it fires once.
+- [ ] `resumePendingMatch()` under `_suppressPersist = true`: restore stage/scores/inGame/`_remainingTime`=freeze point; restore team order by `id` (reverse live list if `teams[0].id=='B'`, then assign by id); per-module `restoreFromSnapshot`; for firstHalf/secondHalf freeze (`isTimeRunning=false`, `_isGameRunning=false`, `_runClockStartedAt=null`, `timerButtonText='START'`); for halfTime resume the break running (`startTimer()` for halfTime stage, `timerButtonText='SKIP'`); `_broadcastFullState()`; close suppress scope; `markMatchStateDirty(); _persistMatchState()` once; `notifyListeners()`.
+- [ ] `discardPendingMatch()` → `gameInit()` + `_clearMatchState()`.
+- [ ] `home.dart`: register `game.onRequestResumeMatch` in `setupGameCallbacks` → non-dismissible `AlertDialog` (`barrierDismissible:false` + `PopScope` blocking back). Resume = prominent default → `game.resumePendingMatch()`. Discard opens a second non-dismissible "Discard match?" confirm → `game.discardPendingMatch()`.
+- [ ] Write `test/game_recovery_test.dart` covering the spec's Testing section (freeze, normalize-both-states, suppress-notify on late reconnect, restore-by-id, bootstrap-doesn't-wipe, clear-on-fullTime, callback drain, penalty-preserve, half-time continues).
+- [ ] **Commit** `feat(recovery): cold-resume flow + resume/discard dialog`.
+
+### Task 5: Verify + PR + review-anvil
+
+- [ ] Push `mrshu/match-recovery`, open PR vs `dev` (CI runs `flutter analyze` + `flutter test`).
+- [ ] Run `/review-anvil`.
+
+## Self-review notes
+
+- Spec coverage: all Files-touched rows mapped (store=T1, module=T2, game persist=T3, game cold-resume + home + tests=T4). Web-binding row intentionally omitted (deferred per issue #45).
+- The `_markDirty` privacy fix and the dropped anchor/web fields are the only deviations from the 2026-06-20 spec; both documented under Global Constraints.

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -214,8 +214,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   /// Mark dirty and schedule a coalesced flush AFTER the current synchronous
-  /// work (e.g. the START/STOP fan-out) has been launched, via scheduleMicrotask
-  /// — so the snapshot build + jsonEncode never run inline on a command path.
+  /// work has run, via scheduleMicrotask — so the snapshot build + jsonEncode
+  /// never run inline on the caller's frame. This is deliberate: callers like
+  /// [Module.setLabel]/[Module.play] are reached from within larger synchronous
+  /// operations, and the microtask hop keeps the build off that frame even
+  /// though no current caller sits on the START/STOP fan-out itself (those use
+  /// the bare flag [markMatchStateDirty]). Use [_flushMatchStateNow] when an
+  /// immediate synchronous flush is wanted (heartbeat tick / resume commit).
   void _markDirtyFlush() {
     if (_suppressPersist || _stateStore == null) return;
     _dirty = true;
@@ -238,8 +243,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// Public clear for intentional fresh-start paths outside the resume flow
   /// (e.g. Settings "Reset current game"). gameInit() deliberately does not
   /// clear the snapshot, so those paths must clear it explicitly or a killed
-  /// app would re-offer the reset match on next launch.
-  void clearMatchSnapshot() => _clearMatchState();
+  /// app would re-offer the reset match on next launch. Awaitable so a caller
+  /// can confirm the clear landed (the destructive intent should not be lost on
+  /// an immediate kill).
+  Future<void> clearMatchSnapshot() => _clearMatchStateAndWait();
 
   /// Build the snapshot (if dirty) and enqueue the save. A no-op unless dirty,
   /// the store exists, and persistence isn't suppressed.
@@ -591,6 +598,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   void notifyAllModulesTimer() {
+    // Penalties are a match-time concept; robots are off-field during the
+    // half-time break, so never count a penalty down (and never auto-release it
+    // via play()) while in halfTime. Normally modules are in halfTime state here
+    // so the loop is a no-op anyway, but a cold resume can restore a module in
+    // damage (a penalty given during the break) — guard against auto-PLAY there.
+    if (currentStage == MatchStage.halfTime) return;
+
     // Use a flag so that at most one vibration fires per timer tick even if
     // multiple modules hit a threshold simultaneously.
     bool vibrateTriggered = false;
@@ -686,8 +700,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         // The per-tick heartbeat was suppressed during the replay burst, so
         // flush ONCE now — otherwise a crash right after a warm resume would
         // persist the stale pre-background freeze point and over-credit time on
-        // the next cold resume.
-        _flushMatchStateNow();
+        // the next cold resume. But if the replay reached fullTime, the
+        // secondHalf->fullTime tick already CLEARED the snapshot; don't re-save a
+        // terminal match (it would undo the clear-on-fullTime contract).
+        if (currentStage != MatchStage.fullTime) {
+          _flushMatchStateNow();
+        }
       }
     }
   }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -222,6 +222,25 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     scheduleMicrotask(_persistMatchState);
   }
 
+  /// Public entry for off-hot-path collaborators (e.g. [Module.setLabel]) that
+  /// want a change scheduled to disk now, not merely flagged for the next
+  /// heartbeat. Never call from a robot-command path.
+  void markMatchStateDirtyAndFlush() => _markDirtyFlush();
+
+  /// Force an immediate, synchronous flush of the current state. `_dirty` alone
+  /// is not enough — [_persistMatchState] no-ops unless dirty — so the two are
+  /// always paired; this helper makes that contract explicit at every call site.
+  void _flushMatchStateNow() {
+    markMatchStateDirty();
+    _persistMatchState();
+  }
+
+  /// Public clear for intentional fresh-start paths outside the resume flow
+  /// (e.g. Settings "Reset current game"). gameInit() deliberately does not
+  /// clear the snapshot, so those paths must clear it explicitly or a killed
+  /// app would re-offer the reset match on next launch.
+  void clearMatchSnapshot() => _clearMatchState();
+
   /// Build the snapshot (if dirty) and enqueue the save. A no-op unless dirty,
   /// the store exists, and persistence isn't suppressed.
   void _persistMatchState() {
@@ -239,6 +258,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   void _clearMatchState() {
     _dirty = false;
     unawaited(_stateStore?.clear());
+  }
+
+  /// Same as [_clearMatchState] but awaitable, for destructive UI paths that
+  /// want to confirm the clear landed before dismissing.
+  Future<void> _clearMatchStateAndWait() async {
+    _dirty = false;
+    await _stateStore?.clear();
   }
 
   MatchSnapshot _buildSnapshot() {
@@ -315,17 +341,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _pendingResume = null;
     // Commit the restored state ONCE, now that the suppress scope has closed (a
     // flush while suppressed is a no-op).
-    markMatchStateDirty();
-    _persistMatchState();
+    _flushMatchStateNow();
     notifyListeners();
   }
 
   /// Referee chose Discard: fresh match and clear the persisted snapshot.
-  void discardPendingMatch() {
+  /// Awaits the clear so the destructive flow doesn't dismiss while a failed/
+  /// pending tombstone could still re-offer the match on next launch (this is a
+  /// dialog action, not a robot-command path, so the await is safe).
+  Future<void> discardPendingMatch() async {
     _pendingResume = null;
     gameInit();
     setTeamToDefaultOrder();
-    _clearMatchState();
+    await _clearMatchStateAndWait();
     notifyListeners();
   }
 
@@ -402,8 +430,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // warm-resume replay burst. Direct flush (not microtask): the 1 Hz tick is
       // a low-frequency callback, not a command path.
       if (!_replaying && _remainingTime % 5 == 0) {
-        markMatchStateDirty();
-        _persistMatchState();
+        _flushMatchStateNow();
       }
     }
 
@@ -535,9 +562,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       disconnectAll();
     } else if (_numberOfPlaying > 0) {
       stopAll(true);
-      // Master STOP changes module state without touching the match clock;
-      // mark dirty (flag only, off the command path) so the snapshot tracks it.
-      markMatchStateDirty();
+      // Master STOP clears penalties and changes module state without touching
+      // the match clock, so the heartbeat may not be running; schedule a flush
+      // (off the command path) so a crash right after STOP can't restore stale
+      // penalties.
+      _markDirtyFlush();
     } else {
       if (!_isGameRunning &&
           (currentStage == MatchStage.firstHalf ||
@@ -658,8 +687,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         // flush ONCE now — otherwise a crash right after a warm resume would
         // persist the stale pre-background freeze point and over-credit time on
         // the next cold resume.
-        markMatchStateDirty();
-        _persistMatchState();
+        _flushMatchStateNow();
       }
     }
   }
@@ -937,6 +965,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _remainingTime = seconds.clamp(1, periodTime);
     notifyListeners();
     _broadcastStageAndTime();
+    // A manual clock correction changes the exact freeze point cold resume
+    // restores; persist it (off the hot path — the editor is only open while
+    // the clock is stopped) so a crash before the next event can't lose it.
+    _markDirtyFlush();
   }
 
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -11,6 +11,7 @@ import 'package:rcj_scoreboard/services/notification_service.dart';
 import 'package:rcj_scoreboard/services/vibration_service.dart';
 import 'package:rcj_scoreboard/services/wakelock_service.dart';
 import 'package:rcj_scoreboard/services/preset_service.dart';
+import 'package:rcj_scoreboard/services/match_state_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum MatchStage {
@@ -50,6 +51,23 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // and module updates still run during replay.
   bool _replaying = false;
   SharedPreferences? _prefs;
+
+  // ---- Match cold-resume persistence (#45) ----
+  MatchStateStore? _stateStore;
+  // Coalesced persist marker: set on any recoverable change (trivial bool, safe
+  // on the robot-command path); the snapshot build + jsonEncode happen later in
+  // a flush, never inline on the START/STOP fan-out.
+  bool _dirty = false;
+  // Suppresses persistence during bootstrap/reset and during the multi-step
+  // cold-resume restore, so an internal (non-referee) reset can't overwrite the
+  // on-disk snapshot and a restore can't write a dozen partial snapshots.
+  bool _suppressPersist = false;
+  // The snapshot of an in-progress match found at cold launch, awaiting the
+  // referee's Resume/Discard choice. Null when there is nothing to resume.
+  MatchSnapshot? _pendingResume;
+  // One-shot so the resume prompt fires exactly once (guards the
+  // snapshot-stashed vs callback-registered race in _maybeFireResumePrompt).
+  bool _resumePrompted = false;
   //MQTT
   MqttService mqttService = MqttService();
   BleBridgeService bleBridgeService = BleBridgeService();
@@ -60,6 +78,22 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   // Callback to request showing the dialog
   void Function()? onRequestSwitchTeamOrderDialog;
+
+  // Callback to request showing the cold-resume prompt. A DRAINING setter:
+  // main.dart constructs Game() before runApp and _loadPrefs() is async, so the
+  // snapshot may be stashed before OR after Home registers this callback. On
+  // assignment we fire immediately if a resume is already pending, so whichever
+  // happens last triggers the prompt (guarded once by _resumePrompted).
+  void Function()? _onRequestResumeMatch;
+  void Function()? get onRequestResumeMatch => _onRequestResumeMatch;
+  set onRequestResumeMatch(void Function()? callback) {
+    _onRequestResumeMatch = callback;
+    _maybeFireResumePrompt();
+  }
+
+  /// The match awaiting a Resume/Discard decision (null if none). Read by the
+  /// home screen to render the prompt body (teams, score, stage, staleness).
+  MatchSnapshot? get pendingResume => _pendingResume;
 
   Game() {
     WidgetsBinding.instance.addObserver(this);
@@ -91,19 +125,50 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   Future<void> _loadPrefs() async {
     _prefs = await SharedPreferences.getInstance();
+    _stateStore = MatchStateStore(_prefs!);
     _periodTime = _prefs!.getInt(_periodTimeKey) ?? 600;
     _halfTimeDuration = _prefs!.getInt(_halfTimeDurationKey) ?? 300;
     _numberOfPLayers =
         (_prefs!.getInt(_numberOfPlayersKey) ?? 2).clamp(1, _maxPlayer).toInt();
     _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? 60;
 
+    // Load any in-progress-match snapshot BEFORE the bootstrap gameInit() so the
+    // bootstrap can't clobber it. gameInit() no longer clears the snapshot, and
+    // its internal stopTimer() is a persist chokepoint, so wrap the bootstrap in
+    // _suppressPersist — otherwise it would overwrite the snapshot with the
+    // default (inGame=false) state via that indirect path.
+    final snapshot = _stateStore!.load();
     if (!inGame) {
-      gameInit();
+      _suppressPersist = true;
+      try {
+        gameInit();
+      } finally {
+        _suppressPersist = false;
+      }
     }
+
+    // A usable in-progress match (not already finished) → stash and prompt the
+    // referee. Stage fullTime means the match was over, so nothing to resume.
+    if (snapshot != null &&
+        snapshot.inGame &&
+        _stageFromName(snapshot.stage) != MatchStage.fullTime) {
+      _pendingResume = snapshot;
+      _maybeFireResumePrompt();
+    }
+
     // Prompt for notification permission once on first launch (one-shot), now
     // that _prefs is available — keeps the OS dialog off the match-start path.
     _maybeRequestNotificationPermission();
     notifyListeners();
+  }
+
+  void _maybeFireResumePrompt() {
+    if (_resumePrompted) return;
+    if (_pendingResume == null) return;
+    final callback = _onRequestResumeMatch;
+    if (callback == null) return;
+    _resumePrompted = true;
+    callback();
   }
 
   void gameInit() {
@@ -135,6 +200,154 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   void gameRefresh() {
     // refresh all values on every sink (mqtt + bridge)
     _broadcastFullState();
+  }
+
+  // ---- Match cold-resume persistence (#45) ----
+
+  /// Mark the match state dirty. Trivial bool set, intentionally cheap so it is
+  /// safe to call from anywhere — including the robot-command fan-out — without
+  /// touching the START/STOP latency invariant. No snapshot build, no JSON.
+  /// No-op before the store exists (constructor bootstrap) or while suppressed.
+  void markMatchStateDirty() {
+    if (_suppressPersist || _stateStore == null) return;
+    _dirty = true;
+  }
+
+  /// Mark dirty and schedule a coalesced flush AFTER the current synchronous
+  /// work (e.g. the START/STOP fan-out) has been launched, via scheduleMicrotask
+  /// — so the snapshot build + jsonEncode never run inline on a command path.
+  void _markDirtyFlush() {
+    if (_suppressPersist || _stateStore == null) return;
+    _dirty = true;
+    scheduleMicrotask(_persistMatchState);
+  }
+
+  /// Build the snapshot (if dirty) and enqueue the save. A no-op unless dirty,
+  /// the store exists, and persistence isn't suppressed.
+  void _persistMatchState() {
+    if (_suppressPersist) return;
+    if (!_dirty) return;
+    final store = _stateStore;
+    if (store == null) return;
+    _dirty = false;
+    unawaited(store.save(_buildSnapshot()));
+  }
+
+  /// Clear the persisted match (end of match / fresh start / discard). Drops the
+  /// dirty flag so a pending flush can't immediately re-save, and tombstones the
+  /// snapshot in the store.
+  void _clearMatchState() {
+    _dirty = false;
+    unawaited(_stateStore?.clear());
+  }
+
+  MatchSnapshot _buildSnapshot() {
+    return MatchSnapshot(
+      stage: currentStage.name,
+      remainingTime: _remainingTime,
+      isTimeRunning: isTimeRunning,
+      inGame: inGame,
+      timerButtonText: timerButtonText,
+      savedAtMs: DateTime.now().millisecondsSinceEpoch,
+      teams: teams
+          .map((t) => TeamSnapshot(id: t.id, name: t.name, score: t.score))
+          .toList(),
+      modules:
+          teams.expand((t) => t.modules).map((m) => m.toSnapshot()).toList(),
+    );
+  }
+
+  MatchStage _stageFromName(String name) => MatchStage.values.firstWhere(
+        (s) => s.name == name,
+        orElse: () => MatchStage.firstHalf,
+      );
+
+  /// Restore the match the referee chose to resume: full state, clock FROZEN at
+  /// the persisted freeze point (no dead-time subtraction), robots STOPPED.
+  /// Runs under _suppressPersist so it writes no partial snapshots; the single
+  /// committed save happens after the scope closes.
+  void resumePendingMatch() {
+    final snapshot = _pendingResume;
+    if (snapshot == null) return;
+
+    _suppressPersist = true;
+    try {
+      final stage = _stageFromName(snapshot.stage);
+      currentStage = stage;
+      inGame = true;
+
+      _restoreTeamOrderAndInfo(snapshot.teams);
+
+      // Restore full per-module state (matched by stable moduleId). Late async
+      // reconnects mutate only connection status (not a persisted field), so
+      // they don't each trigger a save.
+      final byId = {for (final m in snapshot.modules) m.moduleId: m};
+      for (final team in teams) {
+        for (final module in team.modules) {
+          final moduleSnap = byId[module.moduleId];
+          if (moduleSnap != null) module.restoreFromSnapshot(moduleSnap);
+        }
+      }
+
+      _remainingTime = snapshot.remainingTime;
+
+      if (stage == MatchStage.halfTime) {
+        // Resume the break RUNNING (option i): the half-time break drives no
+        // robot play, so freezing it would strand the remaining break with no
+        // way to continue. SKIP still lets the referee jump to the second half.
+        timerButtonText = 'SKIP';
+        startTimer();
+      } else {
+        // firstHalf / secondHalf: freeze where it died, robots stopped. The
+        // referee resumes play manually via the existing double-tap START.
+        isTimeRunning = false;
+        _isGameRunning = false;
+        _runClockStartedAt = null;
+        _runClockStartRemainingTime = null;
+        timerButtonText = 'START';
+      }
+
+      _broadcastFullState();
+    } finally {
+      _suppressPersist = false;
+    }
+
+    _pendingResume = null;
+    // Commit the restored state ONCE, now that the suppress scope has closed (a
+    // flush while suppressed is a no-op).
+    markMatchStateDirty();
+    _persistMatchState();
+    notifyListeners();
+  }
+
+  /// Referee chose Discard: fresh match and clear the persisted snapshot.
+  void discardPendingMatch() {
+    _pendingResume = null;
+    gameInit();
+    setTeamToDefaultOrder();
+    _clearMatchState();
+    notifyListeners();
+  }
+
+  void _restoreTeamOrderAndInfo(List<TeamSnapshot> teamSnaps) {
+    // Game() always builds teams as [A, B]. A swapped match was reordered by
+    // toggleTeamOrder() reversing the list, and _teamColorHex + the UI color
+    // bars are keyed on team.id, so reverse the live list first when the
+    // snapshot's first team is 'B', THEN assign names/scores by matching id
+    // (never positionally) so they land on the correct physical side.
+    if (teamSnaps.isNotEmpty &&
+        teamSnaps.first.id == 'B' &&
+        teams.length == 2 &&
+        teams.first.id == 'A') {
+      teams = teams.reversed.toList();
+    }
+    for (final snap in teamSnaps) {
+      final matches = teams.where((t) => t.id == snap.id);
+      if (matches.isEmpty) continue;
+      final team = matches.first;
+      team.name = snap.name;
+      team.score = snap.score;
+    }
   }
 
   // Timer
@@ -174,6 +387,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         _tickTimer();
       }
     });
+    _markDirtyFlush();
   }
 
   void _tickTimer() {
@@ -182,6 +396,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _checkGameTimerVibration();
       notifyAllModulesTimer();
       mqttService.publishTime(_remainingTime);
+      // ~5 s heartbeat for the clock freeze point. Placed only in the normal
+      // decrement branch (before any stage-transition reset below), so the % 5
+      // test never samples a freshly-reset boundary value. Skipped during the
+      // warm-resume replay burst. Direct flush (not microtask): the 1 Hz tick is
+      // a low-frequency callback, not a command path.
+      if (!_replaying && _remainingTime % 5 == 0) {
+        markMatchStateDirty();
+        _persistMatchState();
+      }
     }
 
     if (_remainingTime <= 0) {
@@ -196,6 +419,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           startTimer();
           timerButtonText = 'SKIP';
           halfTimeAll();
+          _markDirtyFlush();
           // Trigger the callback to show the dialog
           if (onRequestSwitchTeamOrderDialog != null) {
             onRequestSwitchTeamOrderDialog!();
@@ -206,12 +430,16 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           _remainingTime = periodTime;
           stopAll(true, force: true);
           timerButtonText = 'START';
+          _markDirtyFlush();
           break;
         case MatchStage.secondHalf:
           currentStage = MatchStage.fullTime;
           stopAll(true);
           timerButtonText = 'REPEAT';
           gameOverAll();
+          // Match just ended: clear the snapshot rather than persisting a
+          // fullTime one (item 2 made this transition a persist point).
+          _clearMatchState();
           break;
         default:
           debugPrint('unknown match stage');
@@ -273,12 +501,18 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _broadcastStageAndTime();
 
       notifyListeners();
+      _markDirtyFlush();
     } else {
-      // GAME OVER
+      // GAME OVER — starting a brand-new match, so clear the (fullTime)
+      // snapshot. gameInit() must NOT clear it itself (it also runs on every
+      // cold launch, before the resume path reads the snapshot). Clear LAST so
+      // the scheduled flushes from gameInit()/notifyModulesScore() see a clean
+      // dirty flag and don't re-write a snapshot after the clear.
       gameInit();
       setTeamToDefaultOrder();
       notifyListeners();
       notifyModulesScore();
+      _clearMatchState();
     }
   }
 
@@ -291,6 +525,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // the bridge only reflects the new sides on the next goal.
     _broadcastTeamInfo();
     _broadcastScore();
+
+    _markDirtyFlush();
   }
 
   /// Toggles all modules based on the current game stage.
@@ -299,6 +535,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       disconnectAll();
     } else if (_numberOfPlaying > 0) {
       stopAll(true);
+      // Master STOP changes module state without touching the match clock;
+      // mark dirty (flag only, off the command path) so the snapshot tracks it.
+      markMatchStateDirty();
     } else {
       if (!_isGameRunning &&
           (currentStage == MatchStage.firstHalf ||
@@ -306,7 +545,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         startTimer();
         timerButtonText = 'STOP';
       }
-      playAll(true);
+      // Penalty-preserve fix (#45): penalty-aware start, matching the central
+      // timer START (toggleTimer -> playAll(false)). playAll(true) ->
+      // Module.playAll()/play() would ZERO an active/restored _penaltyTime; the
+      // master STOP still clears penalties (intended post-goal reset).
+      playAll(false);
     }
   }
 
@@ -360,6 +603,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _runClockStartedAt = null;
     _runClockStartRemainingTime = null;
     notifyListeners();
+    _markDirtyFlush();
   }
 
   @override
@@ -410,6 +654,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           _broadcastStageAndTime();
           notifyListeners();
         }
+        // The per-tick heartbeat was suppressed during the replay burst, so
+        // flush ONCE now — otherwise a crash right after a warm resume would
+        // persist the stale pre-background freeze point and over-credit time on
+        // the next cold resume.
+        markMatchStateDirty();
+        _persistMatchState();
       }
     }
   }
@@ -558,6 +808,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       }
     }
     _broadcastScore();
+    _markDirtyFlush();
   }
 
   String _teamColorHex(Team team) => team.id == 'A' ? '77FF00' : 'FF00FF';
@@ -711,11 +962,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (match != null) {
       teams[0].name = match.team1;
       teams[1].name = match.team2;
-      
+
       mqttService.topicField = match.field;
-      
+
       _broadcastTeamInfo();
+      _markDirtyFlush();
     }
+  }
+
+  /// Set a team's name from the UI. Routes through here (instead of a direct
+  /// `team.name =` + `notifyMQTT()`) so the change also persists into the
+  /// cold-resume snapshot.
+  void setTeamName(Team team, String value) {
+    team.name = value;
+    notifyMQTT();
+    _markDirtyFlush();
   }
 
   void notifyMQTT() {

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -370,6 +370,7 @@ class Module with ChangeNotifier {
   }
 
   void playOrDamage() {
+    _clearRestoreSuppress();
     _lastState = _state;
     if (_penaltyTime > 0) {
       _playStatus(false);
@@ -382,9 +383,11 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    _game.markMatchStateDirty();
   }
 
   void play() async {
+    _clearRestoreSuppress();
     _lastState = _state;
     _playStatus(true);
     _penaltyTime = 0;
@@ -392,9 +395,11 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    _game.markMatchStateDirty();
   }
 
   void playOrDamageAll() async {
+    _clearRestoreSuppress();
     _lastState = _state;
     if (_penaltyTime > 0) {
       _playStatus(false);
@@ -412,9 +417,11 @@ class Module with ChangeNotifier {
       // Send it one more time with acknowledgment to ensure all modules are in play state
       bleSendPlay();
     }
+    _game.markMatchStateDirty();
   }
 
   void playAll() async {
+    _clearRestoreSuppress();
     _lastState = _state;
     _playStatus(true);
     _penaltyTime = 0;
@@ -428,6 +435,16 @@ class Module with ChangeNotifier {
     }
     // Send it one more time with acknowledgment to ensure all modules are in play state
     bleSendPlay();
+    _game.markMatchStateDirty();
+  }
+
+  // Cancel a pending cold-resume restore suppression: once the referee starts a
+  // robot (any START path), subsequent reconnect bleNotify()s must reflect the
+  // real state, not a lingering STOP. Without this a late reconnect after START
+  // would STOP an already-playing robot (the play START path does not itself
+  // call bleNotify, so it would not otherwise consume the one-shot).
+  void _clearRestoreSuppress() {
+    _suppressNextRestoreNotify = false;
   }
 
   void stopAll(bool removePenalty, {bool force = false}) async {
@@ -447,6 +464,7 @@ class Module with ChangeNotifier {
           await Future.delayed(const Duration(milliseconds: 100));
         }
     }
+    _game.markMatchStateDirty();
   }
 
   void stop() {
@@ -470,6 +488,7 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    _game.markMatchStateDirty();
   }
 
   void penalty(int seconds) {
@@ -500,6 +519,7 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    _game.markMatchStateDirty();
   }
 
   void halfTimeSyncTime() {
@@ -516,6 +536,7 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    _game.markMatchStateDirty();
   }
 
 
@@ -593,6 +614,8 @@ class Module with ChangeNotifier {
   int get penaltyTime => _penaltyTime;
   ModuleState get state => _state;
   ModuleState get lastState => _lastState;
+  @visibleForTesting
+  bool get suppressNextRestoreNotify => _suppressNextRestoreNotify;
 
   void setLabel(String label) {
     _label = label.trim();
@@ -601,8 +624,11 @@ class Module with ChangeNotifier {
     // bleSendName() self-guards on connection, so this is a no-op otherwise.
     // (Not in the START/STOP critical path — fire-and-forget is fine.)
     unawaited(bleSendName());
-    // A module label is recoverable state; mark dirty so the snapshot tracks it.
-    _game.markMatchStateDirty();
+    // A module label is recoverable state. Schedule a flush (not just a dirty
+    // flag): labels are typically edited pre-match while the clock is stopped,
+    // when the heartbeat isn't running, so a bare flag could be lost on a crash.
+    // Off the START/STOP hot path, so the scheduled flush is fine.
+    _game.markMatchStateDirtyAndFlush();
   }
 
   void applyPresetConfig(String macAddress, String label) {

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -479,6 +479,9 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
+    // Penalty given is a discrete recoverable event; mark the match state dirty
+    // so the snapshot captures it (the flush rides the heartbeat / next event).
+    _game.markMatchStateDirty();
   }
 
   void _askForPenalty() {
@@ -589,6 +592,7 @@ class Module with ChangeNotifier {
   bool get hasCustomLabel => _label != null && _label!.isNotEmpty;
   int get penaltyTime => _penaltyTime;
   ModuleState get state => _state;
+  ModuleState get lastState => _lastState;
 
   void setLabel(String label) {
     _label = label.trim();
@@ -597,6 +601,8 @@ class Module with ChangeNotifier {
     // bleSendName() self-guards on connection, so this is a no-op otherwise.
     // (Not in the START/STOP critical path — fire-and-forget is fine.)
     unawaited(bleSendName());
+    // A module label is recoverable state; mark dirty so the snapshot tracks it.
+    _game.markMatchStateDirty();
   }
 
   void applyPresetConfig(String macAddress, String label) {

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -383,7 +383,10 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
-    _game.markMatchStateDirty();
+    // Single-module action (not the simultaneous START/STOP fan-out), so a
+    // scheduled flush is latency-safe and persists it even when the clock is
+    // stopped (e.g. a robot toggled while the cold-resumed clock is frozen).
+    _game.markMatchStateDirtyAndFlush();
   }
 
   void play() async {
@@ -395,7 +398,7 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
-    _game.markMatchStateDirty();
+    _game.markMatchStateDirtyAndFlush();
   }
 
   void playOrDamageAll() async {
@@ -498,9 +501,9 @@ class Module with ChangeNotifier {
 
     bleNotify();
     notifyListeners();
-    // Penalty given is a discrete recoverable event; mark the match state dirty
-    // so the snapshot captures it (the flush rides the heartbeat / next event).
-    _game.markMatchStateDirty();
+    // Penalty given is a discrete recoverable event; flush it (off the hot path)
+    // so it survives a crash even if the clock isn't running to drive a heartbeat.
+    _game.markMatchStateDirtyAndFlush();
   }
 
   void _askForPenalty() {

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/services/error_messages.dart';
+import 'package:rcj_scoreboard/services/match_state_store.dart';
 
 
 enum ModuleState {
@@ -51,6 +52,14 @@ class Module with ChangeNotifier {
   bool _isConnected = false;
   bool _isPlaying = false;
   int _penaltyTime = 0;
+  // One-shot set by [restoreFromSnapshot] on a cold-resume restore. The FIRST
+  // post-restore [bleNotify] (fired seconds later from the reconnect's
+  // connected-event, so a synchronous game-scoped flag would already be cleared)
+  // consumes it and sends at most a STOP — never play/damage — so a robot can't
+  // auto-PLAY or self-release its penalty while the match clock is frozen. It is
+  // per-module so each module's own late reconnect is covered, and one-shot so
+  // it can't linger and suppress the referee's later START.
+  bool _suppressNextRestoreNotify = false;
   String macAddress = '';
   String bleStatus = 'Disconnected';
   // True while we want to be connected (connect tapped, autoConnect active).
@@ -83,6 +92,18 @@ class Module with ChangeNotifier {
   }
 
   void bleNotify() async {
+    if (_suppressNextRestoreNotify) {
+      // First reconnect after a cold-resume restore: keep the robot stopped
+      // regardless of the restored _state (esp. a restored `damage` module),
+      // so its penalty countdown does not start while the match clock is
+      // frozen. The referee's double-tap START re-arms play/damage with time.
+      try {
+        await bleSendStop();
+      } finally {
+        _suppressNextRestoreNotify = false;
+      }
+      return;
+    }
     switch (_state) {
       case ModuleState.play:
         await bleSendPlay();
@@ -594,6 +615,74 @@ class Module with ChangeNotifier {
     setBleDevice(BluetoothDevice.fromId(newMac));
     if (_isEnabled) {
       bleConnect();
+    }
+  }
+
+  // ---- Cold-resume snapshot / restore (#45) ----
+
+  /// Capture this module's recoverable state for the match snapshot.
+  ModuleSnapshot toSnapshot() => ModuleSnapshot(
+        moduleId: moduleId,
+        isEnabled: _isEnabled,
+        macAddress: macAddress,
+        customLabel: hasCustomLabel ? _label : null,
+        state: _state.name,
+        lastState: _lastState.name,
+        penaltyTime: _penaltyTime,
+      );
+
+  /// Restore this module from a cold-resume snapshot. Ordering matters:
+  ///   1. apply `isEnabled` first — `disable()` disconnects and
+  ///      `applyPresetConfig` only reconnects when enabled, so the flag must be
+  ///      correct before the reconnect step;
+  ///   2. set the normalized state/penalty and arm the restore-notify one-shot;
+  ///   3. re-establish the BLE device (a cold kill built a fresh Module with no
+  ///      device), reusing the preset-load path for the auto-reconnect.
+  void restoreFromSnapshot(ModuleSnapshot s) {
+    if (s.isEnabled) {
+      enable();
+    } else {
+      disable();
+    }
+
+    _penaltyTime = s.penaltyTime;
+    // Normalize play/halfTime/fullTime -> stop for BOTH _state and _lastState:
+    // a restored `play` _state would make the reconnect bleNotify() emit
+    // bleSendPlay() (auto-PLAY), and a `play` _lastState would make the
+    // single-tap Module.stop() (switches on _lastState) a silent no-op. Keep
+    // damage/stop as-is.
+    _state = _normalizeRestoredState(_parseState(s.state));
+    _lastState = _normalizeRestoredState(_parseState(s.lastState));
+    _suppressNextRestoreNotify = true;
+
+    if (s.isEnabled && s.macAddress.isNotEmpty) {
+      // applyPresetConfig() sets the label, builds the device and reconnects.
+      // It takes a non-null label, hence `?? ''` (an empty label resolves to
+      // the default name via the `name` getter).
+      applyPresetConfig(s.macAddress, s.customLabel ?? '');
+    } else {
+      // Not reconnecting: still record the MAC (for a later manual connect) and
+      // apply the label, mirroring applyPresetConfig's always-apply-label rule.
+      macAddress = s.macAddress;
+      setLabel(s.customLabel ?? '');
+    }
+    notifyListeners();
+  }
+
+  ModuleState _parseState(String name) => ModuleState.values.firstWhere(
+        (s) => s.name == name,
+        orElse: () => ModuleState.stop,
+      );
+
+  ModuleState _normalizeRestoredState(ModuleState state) {
+    switch (state) {
+      case ModuleState.damage:
+        return ModuleState.damage;
+      case ModuleState.stop:
+      case ModuleState.play:
+      case ModuleState.halfTime:
+      case ModuleState.fullTime:
+        return ModuleState.stop;
     }
   }
 

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -616,6 +616,7 @@ class Module with ChangeNotifier {
   bool get hasCustomLabel => _label != null && _label!.isNotEmpty;
   int get penaltyTime => _penaltyTime;
   ModuleState get state => _state;
+  @visibleForTesting
   ModuleState get lastState => _lastState;
   @visibleForTesting
   bool get suppressNextRestoreNotify => _suppressNextRestoreNotify;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -13,6 +13,7 @@ import 'package:rcj_scoreboard/screens/settings.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:rcj_scoreboard/services/ble_adapter_monitor.dart';
+import 'package:rcj_scoreboard/services/match_state_store.dart';
 import 'package:rcj_scoreboard/screens/widgets/bluetooth_banner.dart';
 
 class Home extends StatelessWidget {
@@ -522,8 +523,10 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
                   fillColor: Colors.grey[800],
                 ),
                 onSubmitted: (value) {
-                  team.name = value;
-                  game.notifyMQTT();
+                  // Route through Game.setTeamName so the edit also persists
+                  // into the cold-resume snapshot (a direct team.name = bypasses
+                  // every persistence chokepoint).
+                  game.setTeamName(team, value);
                 },
               ),
             ),
@@ -740,6 +743,149 @@ void setupGameCallbacks(Game game, BuildContext context) {
       game.toggleTeamOrder(); // Switch team order
     }
   };
+
+  // Cold-resume prompt (#45). Non-destructive: Resume is the prominent default;
+  // Discard requires a deliberate second confirmation so a stray tap can never
+  // wipe an in-progress match (double-tap safety invariant). The dialog is
+  // non-dismissible (no barrier/back-button escape into neither path).
+  game.onRequestResumeMatch = () {
+    // The draining setter may invoke this synchronously from within build()
+    // (setupGameCallbacks runs in Home.build), so defer to after the frame —
+    // showDialog() during build throws.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final snapshot = game.pendingResume;
+      if (snapshot == null) return;
+      if (!context.mounted) return;
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+      builder: (dialogContext) => PopScope(
+        canPop: false,
+        child: AlertDialog(
+          backgroundColor: Colors.grey[800],
+          title: const Text('Resume match in progress?',
+              style: TextStyle(color: Colors.white)),
+          content: Text(_resumeMatchBody(snapshot),
+              style: const TextStyle(color: Colors.white)),
+          actions: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.grey[600],
+                    ),
+                    onPressed: () async {
+                      final confirmed = await _confirmDiscardMatch(dialogContext);
+                      if (confirmed == true) {
+                        game.discardPendingMatch();
+                        if (dialogContext.mounted) {
+                          Navigator.of(dialogContext).pop();
+                        }
+                      }
+                    },
+                    child: const Text('Discard',
+                        style: TextStyle(color: Colors.white)),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green[600],
+                    ),
+                    onPressed: () {
+                      game.resumePendingMatch();
+                      Navigator.of(dialogContext).pop();
+                    },
+                    child: const Text('Resume',
+                        style: TextStyle(color: Colors.white)),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      );
+    });
+  };
+}
+
+String _resumeMatchBody(MatchSnapshot snapshot) {
+  final teams = snapshot.teams;
+  final leftName = teams.isNotEmpty ? teams[0].name : 'Team A';
+  final rightName = teams.length > 1 ? teams[1].name : 'Team B';
+  final leftScore = teams.isNotEmpty ? teams[0].score : 0;
+  final rightScore = teams.length > 1 ? teams[1].score : 0;
+  final ageMin =
+      ((DateTime.now().millisecondsSinceEpoch - snapshot.savedAtMs) / 60000)
+          .floor();
+  final saved = ageMin <= 0 ? 'saved just now' : 'saved $ageMin min ago';
+  return '$leftName $leftScore – $rightScore $rightName\n'
+      '${_resumeStageLabel(snapshot.stage)}, $saved';
+}
+
+String _resumeStageLabel(String stageName) {
+  switch (stageName) {
+    case 'firstHalf':
+      return '1st half';
+    case 'halfTime':
+      return 'Half-time';
+    case 'secondHalf':
+      return '2nd half';
+    case 'fullTime':
+      return 'Full-time';
+    default:
+      return stageName;
+  }
+}
+
+Future<bool?> _confirmDiscardMatch(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => PopScope(
+      canPop: false,
+      child: AlertDialog(
+        backgroundColor: Colors.grey[800],
+        title: const Text('Discard match?',
+            style: TextStyle(color: Colors.white)),
+        content: const Text(
+            'This permanently deletes the saved match and cannot be undone.',
+            style: TextStyle(color: Colors.white)),
+        actions: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.grey[600],
+                  ),
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('Cancel',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red[600],
+                  ),
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('Discard',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
 }
 
 Future<bool> _showExitDialog(BuildContext context) async {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -779,7 +779,7 @@ void setupGameCallbacks(Game game, BuildContext context) {
                     onPressed: () async {
                       final confirmed = await _confirmDiscardMatch(dialogContext);
                       if (confirmed == true) {
-                        game.discardPendingMatch();
+                        await game.discardPendingMatch();
                         if (dialogContext.mounted) {
                           Navigator.of(dialogContext).pop();
                         }

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -152,16 +152,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             SettingButton(
                               title: 'Reset current game',
                               buttonText: 'Reset',
-                              onPressed: () {
+                              onPressed: () async {
                                 setState(() {
                                   widget.game.setTeamToDefaultOrder();
                                   widget.game.gameInit();
                                   widget.game.resetModuleNames();
-                                  // gameInit() deliberately does not clear the
-                                  // cold-resume snapshot; an intentional reset
-                                  // must, or a kill would re-offer this match.
-                                  widget.game.clearMatchSnapshot();
                                 });
+                                // gameInit() deliberately does not clear the
+                                // cold-resume snapshot; an intentional reset
+                                // must, or a kill would re-offer this match.
+                                // Awaited so the clear lands before a possible
+                                // immediate kill (off the robot-command path).
+                                await widget.game.clearMatchSnapshot();
                               },
                             ),
                             SettingButton(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -157,6 +157,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                   widget.game.setTeamToDefaultOrder();
                                   widget.game.gameInit();
                                   widget.game.resetModuleNames();
+                                  // gameInit() deliberately does not clear the
+                                  // cold-resume snapshot; an intentional reset
+                                  // must, or a kill would re-offer this match.
+                                  widget.game.clearMatchSnapshot();
                                 });
                               },
                             ),

--- a/lib/services/match_state_store.dart
+++ b/lib/services/match_state_store.dart
@@ -97,6 +97,11 @@ class MatchSnapshot {
   final int version;
   final String stage; // MatchStage.name
   final int remainingTime; // the freeze point (heartbeat-maintained)
+  // Captured at save time for diagnostics/forward-compat only. The restore path
+  // (Game.resumePendingMatch) deliberately does NOT consult these: a cold resume
+  // always freezes the clock (or resumes the half-time break) and derives the
+  // button label from the stage, so honoring a persisted isTimeRunning=true
+  // would auto-run a half and violate the never-auto-PLAY invariant.
   final bool isTimeRunning; // whether the clock was running at save time
   final bool inGame;
   final String timerButtonText;
@@ -190,18 +195,25 @@ class MatchStateStore {
   }
 
   /// Enqueue a clear in the SAME stream (not a side API): bump the generation,
-  /// persist the tombstone immediately so a crash can't lose it, and drop any
-  /// pending save.
+  /// record the clear intent in the pending slot, persist the tombstone (so a
+  /// crash can't lose it), and drop any pending save.
+  ///
+  /// The intent is recorded **before** the `await`: otherwise a `save()` racing
+  /// in during the tombstone write (the app calls both unawaited) would stamp
+  /// the already-bumped generation, drain a snapshot, and then be wiped when the
+  /// resumed clear set its pending slot — losing a newer match. Recording first
+  /// makes the genuinely-last caller win (latest-intent semantics).
   Future<void> clear() async {
     _generation++;
+    _pendingIsClear = true;
+    _pendingSnapshot = null;
+    _pendingGeneration = _generation;
+    _hasPending = true;
     try {
       await _prefs.setInt(_tombstoneKey, _generation);
     } catch (e) {
       debugPrint('MatchStateStore.clear tombstone write failed: $e');
     }
-    _pendingIsClear = true;
-    _pendingSnapshot = null;
-    _hasPending = true;
     return _drain();
   }
 

--- a/lib/services/match_state_store.dart
+++ b/lib/services/match_state_store.dart
@@ -210,7 +210,8 @@ class MatchStateStore {
     _pendingGeneration = _generation;
     _hasPending = true;
     try {
-      await _prefs.setInt(_tombstoneKey, _generation);
+      final ok = await _prefs.setInt(_tombstoneKey, _generation);
+      if (!ok) debugPrint('MatchStateStore: tombstone write returned false');
     } catch (e) {
       debugPrint('MatchStateStore.clear tombstone write failed: $e');
     }
@@ -236,10 +237,12 @@ class MatchStateStore {
 
         try {
           if (isClear) {
-            await _prefs.remove(_snapshotKey);
+            final ok = await _prefs.remove(_snapshotKey);
+            if (!ok) debugPrint('MatchStateStore: snapshot remove returned false');
           } else if (snapshot != null) {
             final map = snapshot.toJson()..['generation'] = generation;
-            await _prefs.setString(_snapshotKey, jsonEncode(map));
+            final ok = await _prefs.setString(_snapshotKey, jsonEncode(map));
+            if (!ok) debugPrint('MatchStateStore: snapshot save returned false');
           }
         } catch (e) {
           // Best-effort: log and keep draining any newer pending op.

--- a/lib/services/match_state_store.dart
+++ b/lib/services/match_state_store.dart
@@ -1,0 +1,263 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Schema version of the persisted match snapshot. A snapshot with any other
+/// version is ignored on load (treated as "no match"), so an old/incompatible
+/// snapshot can never crash startup or restore garbage. Bump this whenever the
+/// serialized shape changes incompatibly (e.g. when PR #15's web-match binding
+/// fields are added).
+const int kMatchSnapshotVersion = 1;
+
+/// Per-team recoverable state. Order is preserved by [MatchSnapshot.teams] so a
+/// swapped team order can be restored onto the correct physical side.
+@immutable
+class TeamSnapshot {
+  final String id;
+  final String name;
+  final int score;
+
+  const TeamSnapshot({
+    required this.id,
+    required this.name,
+    required this.score,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'score': score,
+      };
+
+  factory TeamSnapshot.fromJson(Map<String, dynamic> json) => TeamSnapshot(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        score: (json['score'] as num).toInt(),
+      );
+}
+
+/// Per-module recoverable state. Kept self-contained (flat fields) rather than
+/// embedding `ModuleConfig` so the recovery schema isn't coupled to the preset
+/// schema (see design doc). `macAddress` is REQUIRED for auto-reconnect after a
+/// cold kill, which constructs fresh `Module`s with no device.
+@immutable
+class ModuleSnapshot {
+  final int moduleId;
+  final bool isEnabled;
+  final String macAddress;
+  final String? customLabel;
+
+  /// `ModuleState.name` of `_state` at save time.
+  final String state;
+
+  /// `ModuleState.name` of `_lastState` at save time (drives `Module.stop()`).
+  final String lastState;
+
+  /// Remaining penalty/damage seconds.
+  final int penaltyTime;
+
+  const ModuleSnapshot({
+    required this.moduleId,
+    required this.isEnabled,
+    required this.macAddress,
+    required this.customLabel,
+    required this.state,
+    required this.lastState,
+    required this.penaltyTime,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'moduleId': moduleId,
+        'isEnabled': isEnabled,
+        'macAddress': macAddress,
+        'customLabel': customLabel,
+        'state': state,
+        'lastState': lastState,
+        'penaltyTime': penaltyTime,
+      };
+
+  factory ModuleSnapshot.fromJson(Map<String, dynamic> json) => ModuleSnapshot(
+        moduleId: (json['moduleId'] as num).toInt(),
+        isEnabled: json['isEnabled'] as bool,
+        macAddress: json['macAddress'] as String,
+        customLabel: json['customLabel'] as String?,
+        state: json['state'] as String,
+        lastState: json['lastState'] as String,
+        penaltyTime: (json['penaltyTime'] as num).toInt(),
+      );
+}
+
+/// One versioned snapshot of the whole match. Written as a single JSON value
+/// under one key (see design doc: splitting static vs dynamic saves nothing on
+/// Android because a prefs commit rewrites the whole file).
+@immutable
+class MatchSnapshot {
+  final int version;
+  final String stage; // MatchStage.name
+  final int remainingTime; // the freeze point (heartbeat-maintained)
+  final bool isTimeRunning; // whether the clock was running at save time
+  final bool inGame;
+  final String timerButtonText;
+  final List<TeamSnapshot> teams; // order preserved (captures team swap)
+  final List<ModuleSnapshot> modules;
+  final int savedAtMs; // epoch ms, for staleness display
+
+  const MatchSnapshot({
+    this.version = kMatchSnapshotVersion,
+    required this.stage,
+    required this.remainingTime,
+    required this.isTimeRunning,
+    required this.inGame,
+    required this.timerButtonText,
+    required this.teams,
+    required this.modules,
+    required this.savedAtMs,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'version': version,
+        'stage': stage,
+        'remainingTime': remainingTime,
+        'isTimeRunning': isTimeRunning,
+        'inGame': inGame,
+        'timerButtonText': timerButtonText,
+        'teams': teams.map((t) => t.toJson()).toList(),
+        'modules': modules.map((m) => m.toJson()).toList(),
+        'savedAtMs': savedAtMs,
+      };
+
+  factory MatchSnapshot.fromJson(Map<String, dynamic> json) => MatchSnapshot(
+        version: (json['version'] as num).toInt(),
+        stage: json['stage'] as String,
+        remainingTime: (json['remainingTime'] as num).toInt(),
+        isTimeRunning: json['isTimeRunning'] as bool,
+        inGame: json['inGame'] as bool,
+        timerButtonText: json['timerButtonText'] as String,
+        teams: (json['teams'] as List)
+            .map((e) => TeamSnapshot.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        modules: (json['modules'] as List)
+            .map((e) => ModuleSnapshot.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        savedAtMs: (json['savedAtMs'] as num).toInt(),
+      );
+}
+
+/// Thin wrapper over [SharedPreferences] that persists exactly one
+/// [MatchSnapshot] under [_snapshotKey], with **serialized + coalesced** writes
+/// so a slow older write can never overwrite a newer one (or resurrect a
+/// discarded match).
+///
+/// Ordering model:
+/// - A single in-flight write + a "latest pending" slot (coalescing): rapid
+///   `save`/`clear` calls collapse to the most recent intent.
+/// - A monotonic [_generation], persisted as a tombstone under [_tombstoneKey].
+///   `clear()` bumps the generation and persists the tombstone; each `save`
+///   stamps the snapshot with the current generation. `load()` rejects any
+///   snapshot whose stamped generation predates the tombstone — so even a late
+///   stale `save` that physically beat a `clear` to disk is ignored on the next
+///   launch. (Honest scope: the in-memory coalescing only guarantees ordering
+///   while the process is alive; the tombstone is what makes it crash-safe.)
+class MatchStateStore {
+  static const String _snapshotKey = 'match_state_snapshot';
+  static const String _tombstoneKey = 'match_state_tombstone_generation';
+
+  final SharedPreferences _prefs;
+
+  int _generation;
+
+  // Coalescing state: at most one op is in flight; the latest requested
+  // terminal state lives in the pending slot.
+  bool _hasPending = false;
+  bool _pendingIsClear = false;
+  MatchSnapshot? _pendingSnapshot;
+  int _pendingGeneration = 0;
+  bool _draining = false;
+  Future<void>? _drainFuture;
+
+  MatchStateStore(this._prefs) : _generation = _prefs.getInt(_tombstoneKey) ?? 0;
+
+  /// Enqueue a snapshot write (coalesced). Best-effort and never throws into
+  /// the caller. Safe to call off the hot path; the actual `setString` is async.
+  Future<void> save(MatchSnapshot snapshot) {
+    _pendingIsClear = false;
+    _pendingSnapshot = snapshot;
+    _pendingGeneration = _generation;
+    _hasPending = true;
+    return _drain();
+  }
+
+  /// Enqueue a clear in the SAME stream (not a side API): bump the generation,
+  /// persist the tombstone immediately so a crash can't lose it, and drop any
+  /// pending save.
+  Future<void> clear() async {
+    _generation++;
+    try {
+      await _prefs.setInt(_tombstoneKey, _generation);
+    } catch (e) {
+      debugPrint('MatchStateStore.clear tombstone write failed: $e');
+    }
+    _pendingIsClear = true;
+    _pendingSnapshot = null;
+    _hasPending = true;
+    return _drain();
+  }
+
+  Future<void> _drain() {
+    if (_draining) return _drainFuture ?? Future<void>.value();
+    _draining = true;
+    _drainFuture = _runDrain();
+    return _drainFuture!;
+  }
+
+  Future<void> _runDrain() async {
+    try {
+      while (_hasPending) {
+        final isClear = _pendingIsClear;
+        final snapshot = _pendingSnapshot;
+        final generation = _pendingGeneration;
+        _hasPending = false;
+        _pendingIsClear = false;
+        _pendingSnapshot = null;
+
+        try {
+          if (isClear) {
+            await _prefs.remove(_snapshotKey);
+          } else if (snapshot != null) {
+            final map = snapshot.toJson()..['generation'] = generation;
+            await _prefs.setString(_snapshotKey, jsonEncode(map));
+          }
+        } catch (e) {
+          // Best-effort: log and keep draining any newer pending op.
+          debugPrint('MatchStateStore write failed: $e');
+        }
+      }
+    } finally {
+      _draining = false;
+      _drainFuture = null;
+    }
+  }
+
+  /// Returns the persisted snapshot, or `null` on a missing, unparseable, or
+  /// version-mismatched value, or one whose generation predates the tombstone.
+  MatchSnapshot? load() {
+    final raw = _prefs.getString(_snapshotKey);
+    if (raw == null) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return null;
+      if ((decoded['version'] as num?)?.toInt() != kMatchSnapshotVersion) {
+        return null;
+      }
+      final generation = (decoded['generation'] as num?)?.toInt() ?? 0;
+      final tombstone = _prefs.getInt(_tombstoneKey) ?? 0;
+      if (generation < tombstone) return null;
+      return MatchSnapshot.fromJson(decoded);
+    } catch (e) {
+      debugPrint('MatchStateStore.load parse failed: $e');
+      return null;
+    }
+  }
+}

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -15,8 +15,6 @@ import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
 
-const String _kSnapshotKey = 'match_state_snapshot';
-
 ModuleSnapshot _moduleSnap({
   required int id,
   String state = 'stop',
@@ -65,14 +63,15 @@ MatchSnapshot _snap({
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late SharedPreferences prefs;
+
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
+    prefs = await SharedPreferences.getInstance();
     await prefs.clear();
   });
 
   Future<void> persist(MatchSnapshot snapshot) async {
-    final prefs = await SharedPreferences.getInstance();
     await MatchStateStore(prefs).save(snapshot);
   }
 
@@ -108,7 +107,6 @@ void main() {
       final game = Game();
       await settleLoad(tester);
 
-      final prefs = await SharedPreferences.getInstance();
       final reloaded = MatchStateStore(prefs).load();
       expect(reloaded, isNotNull,
           reason: 'the suppressed bootstrap must not overwrite the snapshot');
@@ -230,6 +228,36 @@ void main() {
       game.dispose();
     });
 
+    testWidgets('half-time resume does not count down a restored penalty',
+        (tester) async {
+      // A penalty given during the break is unusual but possible; on resume the
+      // break clock runs, so the penalty must NOT count down (and must never
+      // auto-release the robot via play()) while off-field at half-time.
+      await persist(_snap(
+        stage: 'halfTime',
+        remainingTime: 60,
+        modules: [
+          _moduleSnap(id: 0, state: 'damage', lastState: 'damage', penalty: 5),
+        ],
+      ));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+      final m0 = game.teams[0].modules[0];
+      expect(m0.state, ModuleState.damage);
+      expect(m0.penaltyTime, 5);
+
+      await tester.pump(const Duration(seconds: 1)); // one break tick
+      expect(m0.penaltyTime, 5,
+          reason: 'penalties must not count down during the half-time break');
+      expect(m0.state, ModuleState.damage);
+
+      game.stopTimer();
+      game.dispose();
+    });
+
     testWidgets('restores a swapped team order by id, not by index',
         (tester) async {
       // Saved with B on the physical left (teams[0].id == 'B').
@@ -269,7 +297,6 @@ void main() {
       expect(game.getScore('A'), 0);
       expect(game.inGame, isFalse);
 
-      final prefs = await SharedPreferences.getInstance();
       expect(MatchStateStore(prefs).load(), isNull);
       game.dispose();
     });
@@ -285,7 +312,6 @@ void main() {
       await tester.pump(); // run the scheduled microtask flush
       await tester.pump(); // let the async save() setString land
 
-      final prefs = await SharedPreferences.getInstance();
       final snapshot = MatchStateStore(prefs).load();
       expect(snapshot, isNotNull);
       expect(snapshot!.teams.firstWhere((t) => t.id == 'A').score, 1);
@@ -313,8 +339,7 @@ void main() {
       final game = Game();
       await settleLoad(tester);
 
-      game.clearMatchSnapshot();
-      await tester.pump();
+      await game.clearMatchSnapshot();
       await tester.pump();
 
       expect(MatchStateStore(prefs).load(), isNull);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1,0 +1,304 @@
+// Tests for match cold-resume (#45): persistence wiring + restore flow.
+//
+// Like game_remaining_time_test, these use testWidgets because the Game
+// constructor stands up wakelock/notification/MQTT/bridge services whose
+// platform-channel calls reject asynchronously in the headless test VM; the
+// widget binding tolerates those pending replies. We avoid leaving real Timers
+// pending (Timer.periodic from startTimer, and the 100 ms staggered fan-out
+// delays) by either not starting the clock or cancelling/draining it before the
+// test returns.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/models/module.dart';
+import 'package:rcj_scoreboard/services/match_state_store.dart';
+
+const String _kSnapshotKey = 'match_state_snapshot';
+
+ModuleSnapshot _moduleSnap({
+  required int id,
+  String state = 'stop',
+  String lastState = 'stop',
+  int penalty = 0,
+  bool enabled = true,
+  String mac = '',
+  String? label,
+}) {
+  return ModuleSnapshot(
+    moduleId: id,
+    isEnabled: enabled,
+    macAddress: mac,
+    customLabel: label,
+    state: state,
+    lastState: lastState,
+    penaltyTime: penalty,
+  );
+}
+
+MatchSnapshot _snap({
+  String stage = 'firstHalf',
+  bool inGame = true,
+  int remainingTime = 200,
+  int scoreA = 0,
+  int scoreB = 0,
+  String nameA = 'Team A',
+  String nameB = 'Team B',
+  List<ModuleSnapshot> modules = const [],
+  String firstTeamId = 'A',
+}) {
+  final teamA = TeamSnapshot(id: 'A', name: nameA, score: scoreA);
+  final teamB = TeamSnapshot(id: 'B', name: nameB, score: scoreB);
+  return MatchSnapshot(
+    stage: stage,
+    remainingTime: remainingTime,
+    isTimeRunning: false,
+    inGame: inGame,
+    timerButtonText: 'START',
+    savedAtMs: 1000,
+    teams: firstTeamId == 'A' ? [teamA, teamB] : [teamB, teamA],
+    modules: modules,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  });
+
+  Future<void> persist(MatchSnapshot snapshot) async {
+    final prefs = await SharedPreferences.getInstance();
+    await MatchStateStore(prefs).save(snapshot);
+  }
+
+  // Two pumps let the async _loadPrefs() (one getInstance await) finish.
+  Future<void> settleLoad(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump();
+  }
+
+  group('cold-launch detection', () {
+    testWidgets('an in-progress snapshot is offered for resume',
+        (tester) async {
+      await persist(_snap(remainingTime: 200));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.pendingResume, isNotNull);
+      expect(game.pendingResume!.remainingTime, 200);
+      game.dispose();
+    });
+
+    testWidgets('a fullTime snapshot is NOT offered for resume',
+        (tester) async {
+      await persist(_snap(stage: 'fullTime'));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.pendingResume, isNull);
+      game.dispose();
+    });
+
+    testWidgets('bootstrap gameInit does NOT wipe the on-disk snapshot',
+        (tester) async {
+      await persist(_snap(remainingTime: 200, scoreA: 3));
+      final game = Game();
+      await settleLoad(tester);
+
+      final prefs = await SharedPreferences.getInstance();
+      final reloaded = MatchStateStore(prefs).load();
+      expect(reloaded, isNotNull,
+          reason: 'the suppressed bootstrap must not overwrite the snapshot');
+      expect(reloaded!.remainingTime, 200);
+      expect(reloaded.teams.firstWhere((t) => t.id == 'A').score, 3);
+      game.dispose();
+    });
+
+    testWidgets('resume callback drains the pending prompt exactly once',
+        (tester) async {
+      await persist(_snap());
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.pendingResume, isNotNull);
+
+      var fired = 0;
+      game.onRequestResumeMatch = () => fired++;
+      expect(fired, 1, reason: 'registering after stash should fire once');
+
+      game.onRequestResumeMatch = () => fired++;
+      expect(fired, 1, reason: 'a second registration must not re-fire');
+      game.dispose();
+    });
+  });
+
+  group('resumePendingMatch', () {
+    testWidgets('freezes the clock at the persisted freeze point (firstHalf)',
+        (tester) async {
+      await persist(_snap(
+          stage: 'firstHalf', remainingTime: 137, scoreA: 2, scoreB: 1));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+
+      expect(game.remainingTime, 137,
+          reason: 'no dead-time subtraction on cold resume');
+      expect(game.isTimerRunning, isFalse);
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.getScore('A'), 2);
+      expect(game.getScore('B'), 1);
+      expect(game.pendingResume, isNull);
+      game.dispose();
+    });
+
+    testWidgets(
+        'normalizes play -> stop for BOTH state and lastState; keeps damage',
+        (tester) async {
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 300,
+        modules: [
+          _moduleSnap(id: 0, state: 'play', lastState: 'play'),
+          _moduleSnap(
+              id: 1, state: 'damage', lastState: 'play', penalty: 20),
+        ],
+      ));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+
+      final m0 = game.teams[0].modules[0];
+      final m1 = game.teams[0].modules[1];
+      expect(m0.state, ModuleState.stop);
+      expect(m0.lastState, ModuleState.stop);
+      // damage state preserved, but a `play` lastState is still normalized so
+      // single-tap Module.stop() (switches on lastState) isn't a silent no-op.
+      expect(m1.state, ModuleState.damage);
+      expect(m1.lastState, ModuleState.stop);
+      expect(m1.penaltyTime, 20);
+      game.dispose();
+    });
+
+    testWidgets('half-time resume keeps the break clock running (not skipped)',
+        (tester) async {
+      await persist(_snap(stage: 'halfTime', remainingTime: 90));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+
+      expect(game.currentStage, MatchStage.halfTime);
+      expect(game.isTimerRunning, isTrue,
+          reason: 'break resumes running, not frozen/auto-skipped');
+      expect(game.timerButtonText, 'SKIP');
+      expect(game.remainingTime, 90);
+
+      game.stopTimer(); // cancel the periodic timer started by the resume
+      game.dispose();
+    });
+
+    testWidgets('restores a swapped team order by id, not by index',
+        (tester) async {
+      // Saved with B on the physical left (teams[0].id == 'B').
+      await persist(_snap(
+        firstTeamId: 'B',
+        scoreA: 1, // Team A (logical) scored 1
+        scoreB: 4, // Team B (logical) scored 4
+        nameA: 'Alpha',
+        nameB: 'Bravo',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+
+      // Physical left is now B; scores/names land by id regardless of side.
+      expect(game.teams[0].id, 'B');
+      expect(game.teams[0].name, 'Bravo');
+      expect(game.teams[0].score, 4);
+      expect(game.getScore('A'), 1);
+      expect(game.getScore('B'), 4);
+      game.dispose();
+    });
+
+    testWidgets('discardPendingMatch resets and clears the snapshot',
+        (tester) async {
+      await persist(_snap(remainingTime: 200, scoreA: 5));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.pendingResume, isNotNull);
+
+      game.discardPendingMatch();
+      await tester.pump();
+      await tester.pump(); // let the async clear() (tombstone + remove) land
+
+      expect(game.pendingResume, isNull);
+      expect(game.getScore('A'), 0);
+      expect(game.inGame, isFalse);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(MatchStateStore(prefs).load(), isNull);
+      game.dispose();
+    });
+  });
+
+  group('persistence wiring', () {
+    testWidgets('a score change persists into the snapshot', (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      game.teams[0].addScore(1);
+      game.notifyModulesScore();
+      await tester.pump(); // run the scheduled microtask flush
+      await tester.pump(); // let the async save() setString land
+
+      final prefs = await SharedPreferences.getInstance();
+      final snapshot = MatchStateStore(prefs).load();
+      expect(snapshot, isNotNull);
+      expect(snapshot!.teams.firstWhere((t) => t.id == 'A').score, 1);
+      game.dispose();
+    });
+  });
+
+  group('penalty-preserve fix', () {
+    testWidgets('penalty-aware start preserves an active penalty',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      final module = game.teams[0].modules[0];
+
+      module.penalty(30);
+      expect(module.state, ModuleState.damage);
+      expect(module.penaltyTime, 30);
+
+      // The path the master "START ALL ROBOTS" now uses (playAll(false) ->
+      // playOrDamageAll). The penalty branch does not zero the penalty.
+      module.playOrDamageAll();
+      expect(module.state, ModuleState.damage);
+      expect(module.penaltyTime, 30);
+      game.dispose();
+    });
+
+    testWidgets('master STOP still clears an active penalty', (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      final module = game.teams[0].modules[0];
+
+      module.penalty(30);
+      module.stopAll(true); // removePenalty: true
+      expect(module.penaltyTime, 0);
+
+      // Drain the 3x100ms staggered STOP fan-out delays so no Timer is pending.
+      await tester.pump(const Duration(milliseconds: 400));
+      game.dispose();
+    });
+  });
+}

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -185,6 +185,32 @@ void main() {
       game.dispose();
     });
 
+    testWidgets('referee START clears the per-module restore-notify one-shot',
+        (tester) async {
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 300,
+        modules: [_moduleSnap(id: 0, state: 'play', lastState: 'play')],
+      ));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.resumePendingMatch();
+      await tester.pump();
+      final m0 = game.teams[0].modules[0];
+      expect(m0.suppressNextRestoreNotify, isTrue,
+          reason: 'armed by restore so a frozen-window reconnect stays stopped');
+
+      // A referee START path must cancel the suppression synchronously, so a
+      // LATE reconnect after START reflects the real (playing) state instead of
+      // sending a stale STOP.
+      m0.playOrDamageAll();
+      expect(m0.suppressNextRestoreNotify, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 400)); // drain fan-out
+      game.dispose();
+    });
+
     testWidgets('half-time resume keeps the break clock running (not skipped)',
         (tester) async {
       await persist(_snap(stage: 'halfTime', remainingTime: 90));
@@ -236,9 +262,8 @@ void main() {
       await settleLoad(tester);
       expect(game.pendingResume, isNotNull);
 
-      game.discardPendingMatch();
+      await game.discardPendingMatch(); // awaits the clear (tombstone + remove)
       await tester.pump();
-      await tester.pump(); // let the async clear() (tombstone + remove) land
 
       expect(game.pendingResume, isNull);
       expect(game.getScore('A'), 0);
@@ -264,6 +289,35 @@ void main() {
       final snapshot = MatchStateStore(prefs).load();
       expect(snapshot, isNotNull);
       expect(snapshot!.teams.firstWhere((t) => t.id == 'A').score, 1);
+      game.dispose();
+    });
+
+    testWidgets('a manual remaining-time edit persists', (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      game.currentStage = MatchStage.firstHalf;
+      game.setRemainingTime(123);
+      await tester.pump();
+      await tester.pump();
+
+      final loaded = MatchStateStore(prefs).load();
+      expect(loaded, isNotNull);
+      expect(loaded!.remainingTime, 123);
+      game.dispose();
+    });
+
+    testWidgets('clearMatchSnapshot removes the snapshot (e.g. Settings reset)',
+        (tester) async {
+      await persist(_snap(remainingTime: 200));
+      final game = Game();
+      await settleLoad(tester);
+
+      game.clearMatchSnapshot();
+      await tester.pump();
+      await tester.pump();
+
+      expect(MatchStateStore(prefs).load(), isNull);
       game.dispose();
     });
   });

--- a/test/match_state_store_test.dart
+++ b/test/match_state_store_test.dart
@@ -1,0 +1,172 @@
+// Tests for MatchStateStore (match cold-resume persistence, #45).
+//
+// SharedPreferences.setMockInitialValues needs the platform channel binding, so
+// we ensure the test binding is initialized. getInstance() caches a static
+// instance across tests, so we clear() it in setUp for a clean slate (and plant
+// any preloaded values via setString rather than initial values). The store
+// itself does no Flutter widget work, so plain test() is fine.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/services/match_state_store.dart';
+
+const String _kSnapshotKey = 'match_state_snapshot';
+
+MatchSnapshot _sampleSnapshot({
+  int remainingTime = 312,
+  bool inGame = true,
+  String stage = 'firstHalf',
+}) {
+  return MatchSnapshot(
+    stage: stage,
+    remainingTime: remainingTime,
+    isTimeRunning: false,
+    inGame: inGame,
+    timerButtonText: 'START',
+    savedAtMs: 1000,
+    teams: const [
+      TeamSnapshot(id: 'A', name: 'Reds', score: 2),
+      TeamSnapshot(id: 'B', name: 'Blues', score: 1),
+    ],
+    modules: const [
+      ModuleSnapshot(
+        moduleId: 0,
+        isEnabled: true,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        customLabel: 'R1',
+        state: 'damage',
+        lastState: 'play',
+        penaltyTime: 45,
+      ),
+      ModuleSnapshot(
+        moduleId: 5,
+        isEnabled: false,
+        macAddress: '',
+        customLabel: null,
+        state: 'stop',
+        lastState: 'stop',
+        penaltyTime: 0,
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await prefs.clear(); // clean slate regardless of getInstance() caching
+  });
+
+  group('MatchSnapshot JSON', () {
+    test('round-trips all fields incl. per-module recovery data', () {
+      final back = MatchSnapshot.fromJson(_sampleSnapshot().toJson());
+      expect(back.version, kMatchSnapshotVersion);
+      expect(back.stage, 'firstHalf');
+      expect(back.remainingTime, 312);
+      expect(back.inGame, isTrue);
+      expect(back.teams[0].id, 'A');
+      expect(back.teams[1].name, 'Blues');
+      expect(back.teams[1].score, 1);
+
+      final m0 = back.modules[0];
+      expect(m0.moduleId, 0);
+      expect(m0.macAddress, 'AA:BB:CC:DD:EE:FF');
+      expect(m0.customLabel, 'R1');
+      expect(m0.state, 'damage');
+      expect(m0.lastState, 'play');
+      expect(m0.penaltyTime, 45);
+
+      final m1 = back.modules[1];
+      expect(m1.isEnabled, isFalse);
+      expect(m1.customLabel, isNull);
+      expect(m1.macAddress, '');
+    });
+  });
+
+  group('MatchStateStore save/load', () {
+    test('saves and loads a snapshot', () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      final loaded = store.load();
+      expect(loaded, isNotNull);
+      expect(loaded!.remainingTime, 312);
+      expect(loaded.modules.first.penaltyTime, 45);
+    });
+
+    test('load() is null when no snapshot has been written', () {
+      expect(MatchStateStore(prefs).load(), isNull);
+    });
+
+    test('load() is null on corrupt JSON', () async {
+      await prefs.setString(_kSnapshotKey, 'not valid json {{{');
+      expect(MatchStateStore(prefs).load(), isNull);
+    });
+
+    test('load() is null on version mismatch', () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      final raw = prefs.getString(_kSnapshotKey)!;
+      final bumped = raw.replaceFirst(
+          '"version":$kMatchSnapshotVersion', '"version":99999');
+      await prefs.setString(_kSnapshotKey, bumped);
+      expect(store.load(), isNull);
+    });
+
+    test('clear() removes the snapshot', () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      expect(store.load(), isNotNull);
+      await store.clear();
+      expect(store.load(), isNull);
+    });
+
+    test('a save after clear() is loadable again', () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      await store.clear();
+      await store.save(_sampleSnapshot(remainingTime: 100));
+      final loaded = store.load();
+      expect(loaded, isNotNull);
+      expect(loaded!.remainingTime, 100);
+    });
+
+    test(
+        'a stale older save completing after a clear does NOT resurrect the match',
+        () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      // Fire a save and a clear without awaiting the save first: the clear bumps
+      // the generation/tombstone, so even if the older save lands last it must
+      // be rejected on load.
+      final staleSave = store.save(_sampleSnapshot(remainingTime: 999));
+      final clear = store.clear();
+      await Future.wait([staleSave, clear]);
+      expect(store.load(), isNull,
+          reason: 'cleared match must stay cleared even if a stale save lands');
+    });
+
+    test('tombstone rejects a stale snapshot that beat the clear to disk',
+        () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      await store.clear();
+
+      // Simulate a late write that physically beat the clear to disk: plant a
+      // snapshot stamped with an old generation (0). A fresh store over the same
+      // prefs must reject it via the persisted tombstone.
+      await prefs.setString(
+        _kSnapshotKey,
+        '{"version":$kMatchSnapshotVersion,"generation":0,"stage":"firstHalf",'
+            '"remainingTime":312,"isTimeRunning":false,"inGame":true,'
+            '"timerButtonText":"START","teams":[],"modules":[],"savedAtMs":1}',
+      );
+      expect(MatchStateStore(prefs).load(), isNull);
+    });
+  });
+}

--- a/test/match_state_store_test.dart
+++ b/test/match_state_store_test.dart
@@ -151,6 +151,21 @@ void main() {
           reason: 'cleared match must stay cleared even if a stale save lands');
     });
 
+    test('a new save after an unawaited clear wins (latest intent)', () async {
+      final store = MatchStateStore(prefs);
+      await store.save(_sampleSnapshot());
+      // Discard then immediately start a NEW match, both unawaited (as the app
+      // does via _clearMatchState/_persistMatchState). The later save is the
+      // genuine latest intent and must survive — the clear must not wipe it.
+      final clear = store.clear();
+      final save = store.save(_sampleSnapshot(remainingTime: 77));
+      await Future.wait([clear, save]);
+      final loaded = store.load();
+      expect(loaded, isNotNull,
+          reason: 'the newer save must win over the prior clear');
+      expect(loaded!.remainingTime, 77);
+    });
+
     test('tombstone rejects a stale snapshot that beat the clear to disk',
         () async {
       final store = MatchStateStore(prefs);


### PR DESCRIPTION
Implements the cold-resume / match crash-recovery feature tracked in #45, per the finalized design in `docs/superpowers/specs/2026-06-20-match-state-recovery-design.md` (merged in #18).

## What this does
If the referee phone background-kills the app or crashes mid-match, relaunching now detects the in-progress match and offers **Resume** or **Discard**:

- **Resume** restores the whole match state — score, stage, team order/names, and full per-module state (enabled, label, `state`/`lastState`, remaining `penaltyTime`) — **freezes the clock at the persisted freeze point** (no dead-time subtraction), keeps robots **STOPPED**, and auto-reconnects modules. The referee resumes play manually with the existing double-tap START. Never auto-PLAYs.
- **Discard** starts fresh (`gameInit()`) and clears the snapshot, behind a deliberate confirm so a stray tap can't wipe an in-progress match.

Warm resume (app backgrounded, process alive) is unchanged — it still advances the clock via the lifecycle observer.

## How
- **`lib/services/match_state_store.dart`** (new): one versioned `MatchSnapshot` under a single `SharedPreferences` key, with **serialized + coalesced** writes and a **tombstone-generation guard** so a slow/late `save` can never overwrite a newer write or resurrect a discarded match. `load()` returns null on missing/corrupt/version-mismatch.
- **`game.dart`**: persistence is **off the START/STOP hot path** — callers set a dirty flag; the snapshot build + `jsonEncode` run in a coalesced flush scheduled after the robot-command fan-out. ~5 s heartbeat for the freeze point + discrete-event writes. Cold-resume flow loads the snapshot **before** the suppress-wrapped bootstrap `gameInit()` and fires a draining `onRequestResumeMatch` callback. Restore is by team **id** (handles swap); half-time resumes the break **running**.
- **`module.dart`**: `toSnapshot()`/`restoreFromSnapshot()` — normalizes `play`/`halfTime`/`fullTime` → `stop` for **both** `_state` and `_lastState` (so reconnect can't auto-PLAY and single-tap stop isn't a no-op), plus a per-module `_suppressNextRestoreNotify` one-shot so a restored `damage` robot doesn't start its penalty countdown while the clock is frozen.
- **Penalty-preserve fix** (bundled, required for resume to be usable): master "START ALL ROBOTS" → `playAll(false)` (penalty-aware); STOP still clears penalties.

## Invariants preserved
- **START/STOP latency** (#1): no awaits/blocking added to `bleSendPlayAll/StopAll` or the fan-out; saves are flag-then-flush off the hot path.
- **Double-tap safety** (#2): resume prompt is a non-dismissible, non-destructive dialog; Resume is the prominent default; Discard needs a second confirm.
- **Provider tree / portrait-only / no new packages**: `MatchStateStore` is a plain `Game` dependency.

## Scope notes vs. the spec
- **Web-match binding fields deferred.** PR #15 hasn't landed, so `loadedFromWeb`/`scoreboardMatchId` are intentionally **not** in v1; #45 is standalone and ships without #15 (per the issue). They'll be added as a small follow-up on the #15 side, bumping the snapshot version then. The clock-anchor fields are also dropped from v1 (design decision #7: pure freeze-and-give-back).
- `Game.markMatchStateDirty()` is **public** because Dart privacy is per-file and `Module` lives in a separate file (the spec wrote `_markDirty`).

## Tests
- `test/match_state_store_test.dart`: round-trip; null on missing/corrupt/version-mismatch; clear; stale-save-after-clear no-resurrect; tombstone crash-window guard.
- `test/game_recovery_test.dart`: cold-launch detection (offer in-progress, skip fullTime, bootstrap doesn't wipe, callback drains once); resume (clock frozen, `play`→`stop` both fields, half-time runs, restore-by-id, discard clears); score persists; penalty-preserve (start keeps penalty, STOP clears).

> Note: built without a local Flutter toolchain — relying on the CI Quality Gate (`flutter analyze` + `flutter test`) to validate.

Plan: `docs/superpowers/plans/2026-06-22-match-cold-resume.md`.
