### PR TITLE
ci: gate PRs on integration_test via an Android emulator job

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -42,6 +42,9 @@ jobs:
     name: Integration Test (Android emulator)
     runs-on: ubuntu-latest
     needs: quality-gate
+    # Fail fast if the emulator wedges or `flutter test` hangs, rather than
+    # holding a runner for GitHub's 6h default job timeout on a stuck gate.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -32,3 +32,69 @@ jobs:
 
       - name: Build check
         run: flutter build bundle
+
+  # On-device smoke test (integration_test/) on a headless Android emulator.
+  # Gates the double-tap/single-tap safety invariant (CLAUDE.md #2) that the
+  # headless `flutter test` above cannot exercise (real gesture arena + the
+  # Settings → toggle → Home wiring). Gated behind quality-gate so a failed
+  # analyze/test/build never pays the (slower) emulator boot.
+  integration-test:
+    name: Integration Test (Android emulator)
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.0'
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # KVM hardware acceleration — without it the x86_64 emulator boots far
+      # slower (or falls back to ARM emulation). ubuntu-latest runners expose
+      # /dev/kvm; this just opens its permissions to the runner user.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Cache the cold-booted AVD so most runs skip the multi-minute first boot.
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-v1
+
+      # First run on a cache miss: create the AVD and save a boot snapshot.
+      - name: Create AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          # API 34 matches the device the harness was verified on in PR #46.
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run integration tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          # The booted emulator is the only attached device, so `flutter test`
+          # auto-selects it. Runs everything under integration_test/.
+          script: flutter test integration_test

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -45,6 +45,17 @@ jobs:
     # Fail fast if the emulator wedges or `flutter test` hangs, rather than
     # holding a runner for GitHub's 6h default job timeout on a stuck gate.
     timeout-minutes: 30
+    # One source of truth for the AVD definition. The snapshot-create and
+    # test-run steps below must describe the SAME device, or the cached
+    # snapshot won't match the AVD the tests boot on — and the cache key is
+    # derived from these so a bump auto-invalidates the old snapshot.
+    # Pixel 6 / API 34 match the device PR #46 was verified on; the default
+    # AVD is a short 320x640 screen on which Home's portrait Column overflows
+    # (Flutter raises an overflow as a thrown error → test failure).
+    env:
+      EMULATOR_API_LEVEL: 34
+      EMULATOR_ARCH: x86_64
+      EMULATOR_PROFILE: pixel_6
     steps:
       - uses: actions/checkout@v4
 
@@ -75,21 +86,19 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api34-pixel6-v1
+          # Key tracks the AVD config (bump -vN to force a fresh snapshot).
+          key: avd-${{ env.EMULATOR_API_LEVEL }}-${{ env.EMULATOR_PROFILE }}-v1
 
-      # First run on a cache miss: create the AVD and save a boot snapshot.
+      # On a cache miss, create the AVD; android-emulator-runner saves its
+      # state on exit, which actions/cache then stores via the `path` above so
+      # later runs restore it instead of cold-booting.
       - name: Create AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # API 34 + Pixel 6 profile match the device the harness was verified
-          # on in PR #46. The profile matters: the default AVD is a short
-          # 320x640 screen on which Home's portrait Column overflows (Flutter
-          # treats an overflow as a thrown error → test failure). A real phone
-          # profile gives the vertical space the layout expects.
-          api-level: 34
-          arch: x86_64
-          profile: pixel_6
+          api-level: ${{ env.EMULATOR_API_LEVEL }}
+          arch: ${{ env.EMULATOR_ARCH }}
+          profile: ${{ env.EMULATOR_PROFILE }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -98,9 +107,9 @@ jobs:
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
-          arch: x86_64
-          profile: pixel_6
+          api-level: ${{ env.EMULATOR_API_LEVEL }}
+          arch: ${{ env.EMULATOR_ARCH }}
+          profile: ${{ env.EMULATOR_PROFILE }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -101,6 +101,8 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # The booted emulator is the only attached device, so `flutter test`
-          # auto-selects it. Runs everything under integration_test/.
-          script: flutter test integration_test
+          # Pin to the emulator explicitly — android-emulator-runner always
+          # boots it on port 5554 as `emulator-5554`. `flutter test` can prompt
+          # for a target when more than one is selectable (the repo has a web/
+          # target), which would hang this non-interactive step.
+          script: flutter test integration_test -d emulator-5554

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -87,7 +87,7 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           # Key tracks the AVD config (bump -vN to force a fresh snapshot).
-          key: avd-${{ env.EMULATOR_API_LEVEL }}-${{ env.EMULATOR_PROFILE }}-v1
+          key: avd-${{ env.EMULATOR_API_LEVEL }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-v1
 
       # On a cache miss, create the AVD; android-emulator-runner saves its
       # state on exit, which actions/cache then stores via the `path` above so

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -72,16 +72,21 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api34-v1
+          key: avd-api34-pixel6-v1
 
       # First run on a cache miss: create the AVD and save a boot snapshot.
       - name: Create AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # API 34 matches the device the harness was verified on in PR #46.
+          # API 34 + Pixel 6 profile match the device the harness was verified
+          # on in PR #46. The profile matters: the default AVD is a short
+          # 320x640 screen on which Home's portrait Column overflows (Flutter
+          # treats an overflow as a thrown error → test failure). A real phone
+          # profile gives the vertical space the layout expects.
           api-level: 34
           arch: x86_64
+          profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -92,6 +97,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
+          profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true


### PR DESCRIPTION
## What

Wires the `integration_test` harness from #46 into CI. Adds an `integration-test` job to the **PR Quality Gate** workflow that boots a headless Android emulator and runs `flutter test integration_test` against it on every PR to `dev`/`main`.

## Why

Per the discussion on #46: the harness was merged local-only, and we agreed to gate it in CI since runner minutes are free on this public repo (cc @f-wllr). This puts the double-tap / single-tap safety invariant (CLAUDE.md invariant #2) — the real gesture arena and the Settings → toggle → Home wiring that headless `flutter test` can't exercise — under automatic regression protection.

## How

- New `integration-test` job, `needs: quality-gate` so a failed analyze/test/build short-circuits before paying the (slower) emulator boot.
- Boots a headless **API 34 / x86_64** emulator via [`reactivecircus/android-emulator-runner`](https://github.com/ReactiveCircus/android-emulator-runner) — API 34 matches the Pixel 6 / API 34 device #46 was verified on.
- Enables `/dev/kvm` for hardware acceleration, and caches the cold-booted AVD snapshot (`actions/cache`) so most runs skip the multi-minute first boot.

## Notes / non-goals

- As called out in #46: BLE and MQTT hardware paths are **not** asserted (an emulator has no Bluetooth radio), and this does not cover iOS. It guards the gesture/flow layer only.
- Expect the **first** run on a fresh cache to be slow (cold AVD boot + snapshot save); subsequent runs reuse the cached snapshot.

cc @mato157 @f-wllr