### PR TITLE
Fix no-module penalty tracking

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -665,6 +665,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   int get remainingTime => _remainingTime;
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;
+  // True iff at least one enabled module is connected across either team.
+  // Gates the no-module penalty path (issue #22): when the app is used purely
+  // for time/score/penalty tracking with no robots, a module double-tap records
+  // a penalty directly instead of "starting" a robot that does not exist. The
+  // isEnabled filter mirrors the other connection/fan-out scans in this file.
   bool get anyModuleConnected => teams.any((team) =>
       team.modules.any((module) => module.isEnabled && module.isConnected));
   bool get noModuleConnected => !anyModuleConnected;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -665,8 +665,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   int get remainingTime => _remainingTime;
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;
-  bool get anyModuleConnected =>
-      teams.any((team) => team.modules.any((module) => module.isConnected));
+  bool get anyModuleConnected => teams.any((team) =>
+      team.modules.any((module) => module.isEnabled && module.isConnected));
   bool get noModuleConnected => !anyModuleConnected;
   bool get isTimerRunning => isTimeRunning;
   bool get isGameRunning => _isGameRunning;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -665,6 +665,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   int get remainingTime => _remainingTime;
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;
+  bool get anyModuleConnected =>
+      teams.any((team) => team.modules.any((module) => module.isConnected));
+  bool get noModuleConnected => !anyModuleConnected;
   bool get isTimerRunning => isTimeRunning;
   bool get isGameRunning => _isGameRunning;
   String get gameStageString {

--- a/lib/models/module.dart
+++ b/lib/models/module.dart
@@ -50,6 +50,11 @@ class Module with ChangeNotifier {
   bool _isConnected = false;
   bool _isPlaying = false;
   int _penaltyTime = 0;
+  // Whether the module should resume playing when its penalty is cleared or
+  // expires. Captured at penalty() entry: a module penalised from the play
+  // state (the only way a connected module is penalised) resumes play, while a
+  // no-module penalty recorded on a stopped module returns to stop.
+  bool _resumeAfterPenalty = false;
   String macAddress = '';
   String bleStatus = 'Disconnected';
   // True while we want to be connected (connect tapped, autoConnect active).
@@ -69,6 +74,7 @@ class Module with ChangeNotifier {
     _penaltyTime = 0;
     _state = ModuleState.stop;
     _lastState = ModuleState.stop;
+    _resumeAfterPenalty = false;
   }
 
   void enable() {
@@ -363,6 +369,16 @@ class Module with ChangeNotifier {
   }
 
   void play() async {
+    // Clearing or expiring a penalty for a module that was not playing before
+    // the penalty (e.g. a no-module penalty recorded on a stopped module) must
+    // return it to stop, not promote it to playing.
+    if (_state == ModuleState.damage && !_resumeAfterPenalty) {
+      _penaltyTime = 0;
+      _stop();
+      return;
+    }
+    _resumeAfterPenalty = false;
+
     _lastState = _state;
     _playStatus(true);
     _penaltyTime = 0;
@@ -451,6 +467,7 @@ class Module with ChangeNotifier {
   }
 
   void penalty(int seconds) {
+    _resumeAfterPenalty = _isPlaying || _state == ModuleState.play;
     _playStatus(false);
     _penaltyTime = seconds;
     _state = ModuleState.damage;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -194,6 +194,14 @@ Widget buildModuleButton(Module module, Game game) {
         return Expanded(
           child: GestureDetector(
             onDoubleTap: () {
+              // No-module mode (issue #22): with no robots connected the module
+              // is never "playing", so the old handler fell through to play().
+              // Record a penalty directly while the match is running. A second
+              // double-tap finds the module in `damage`, skips this branch, and
+              // lands on play() below — which clears the penalty back to stop
+              // (see Module.play / _resumeAfterPenalty). So tap = penalise,
+              // tap-again = clear. As soon as one module connects this whole
+              // branch is skipped and the connected-robot flow below applies.
               if (game.noModuleConnected && game.isGameRunning &&
                   module.state != ModuleState.damage) {
                 module.penalty(game.penaltyTime);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -194,7 +194,9 @@ Widget buildModuleButton(Module module, Game game) {
         return Expanded(
           child: GestureDetector(
             onDoubleTap: () {
-              if (module.isPlaying) {
+              if (game.noModuleConnected && game.isGameRunning) {
+                module.penalty(game.penaltyTime);
+              } else if (module.isPlaying) {
                 if (game.isGameRunning) {
                   module.penalty(game.penaltyTime);
                 } else {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -194,7 +194,8 @@ Widget buildModuleButton(Module module, Game game) {
         return Expanded(
           child: GestureDetector(
             onDoubleTap: () {
-              if (game.noModuleConnected && game.isGameRunning) {
+              if (game.noModuleConnected && game.isGameRunning &&
+                  module.state != ModuleState.damage) {
                 module.penalty(game.penaltyTime);
               } else if (module.isPlaying) {
                 if (game.isGameRunning) {


### PR DESCRIPTION
## Summary
- add a game-level helper to detect whether any robot module is connected
- when zero modules are connected and the match is running, module double-tap records a penalty directly
- keep existing behavior unchanged as soon as at least one module is connected

Fixes #22

## Verification
- git diff --check
- flutter analyze *(not run: flutter is not available on this PATH in the agent environment)*
- flutter test *(not run: flutter is not available on this PATH in the agent environment)*