### PR TITLE
Add no-show penalty goal mode

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -185,7 +185,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (_remainingTime > 0) {
       _remainingTime--;
       _checkGameTimerVibration();
-      notifyAllModulesTimer();
+      if (!_noShowPenaltyGoalsActive) {
+        notifyAllModulesTimer();
+      }
       mqttService.publishTime(_remainingTime);
       _maybeAwardNoShowPenaltyGoal();
     }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -751,7 +751,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   bool get noShowPenaltyGoalsActive => _noShowPenaltyGoalsActive;
   String get noShowPenaltyGoalIntervalLabel {
     if (_noShowPenaltyGoalIntervalSeconds % 60 == 0) {
-      final minutes = _noShowPenaltyGoalIntervalSeconds ~/ 60;
+      const minutes = _noShowPenaltyGoalIntervalSeconds ~/ 60;
       return minutes == 1 ? '1 goal/min' : '1 goal/$minutes min';
     }
     return '1 goal/$_noShowPenaltyGoalIntervalSeconds sec';

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -108,27 +108,27 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     notifyListeners();
   }
 
-  void gameInit() {
+  void gameInit({bool resetModules = true}) {
     currentStage = MatchStage.firstHalf;
     _remainingTime = periodTime;
     isTimeRunning = false;
     _isGameRunning = false;
     timerButtonText = 'START';
     inGame = false;
-    _noShowPenaltyGoalsActive = false;
-    _noShowPenaltyScoringTeamId = null;
-    _lastNoShowPenaltyGoalElapsed = 0;
+    _resetNoShowPenaltyGoals();
 
     stopTimer();
 
     // enable or disable players based on player number;
     for (var team in teams) {
       team.score = 0;
-      for (var i = 0; i < _maxPlayer; i++) {
-        i < numberOfPLayers
-            ? team.modules[i].enable()
-            : team.modules[i].disable();
-        team.modules[i].init();
+      if (resetModules) {
+        for (var i = 0; i < _maxPlayer; i++) {
+          i < numberOfPLayers
+              ? team.modules[i].enable()
+              : team.modules[i].disable();
+          team.modules[i].init();
+        }
       }
     }
     notifyListeners();
@@ -221,7 +221,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           break;
         case MatchStage.secondHalf:
           currentStage = MatchStage.fullTime;
-          _noShowPenaltyGoalsActive = false;
+          _resetNoShowPenaltyGoals();
           if (!noShowModeActive) {
             stopAll(true);
             gameOverAll();
@@ -371,22 +371,24 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   void startNoShowPenaltyGoals(Team scoringTeam) {
-    gameInit();
+    gameInit(resetModules: false);
     _noShowPenaltyGoalsActive = true;
     _noShowPenaltyScoringTeamId = scoringTeam.id;
     _lastNoShowPenaltyGoalElapsed = 0;
     timerButtonText = 'STOP';
     startTimer();
-    notifyListeners();
   }
 
   void stopNoShowPenaltyGoals() {
+    _resetNoShowPenaltyGoals();
+    timerButtonText = 'START';
+    stopTimer();
+  }
+
+  void _resetNoShowPenaltyGoals() {
     _noShowPenaltyGoalsActive = false;
     _noShowPenaltyScoringTeamId = null;
     _lastNoShowPenaltyGoalElapsed = 0;
-    timerButtonText = 'START';
-    stopTimer();
-    notifyListeners();
   }
 
   Team? get _noShowPenaltyScoringTeam {
@@ -747,7 +749,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   int get remainingTime => _remainingTime;
   bool get noShowPenaltyGoalsActive => _noShowPenaltyGoalsActive;
-  String get noShowPenaltyGoalIntervalLabel => '1 goal/min';
+  String get noShowPenaltyGoalIntervalLabel {
+    if (_noShowPenaltyGoalIntervalSeconds % 60 == 0) {
+      final minutes = _noShowPenaltyGoalIntervalSeconds ~/ 60;
+      return minutes == 1 ? '1 goal/min' : '1 goal/$minutes min';
+    }
+    return '1 goal/$_noShowPenaltyGoalIntervalSeconds sec';
+  }
   String get noShowPenaltyScoringTeamName =>
       _noShowPenaltyScoringTeam?.name ?? '';
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -26,6 +26,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   static const String _penaltyTimeKey = 'game_penalty_time';
   static const String _notifPermissionRequestedKey =
       'notif_permission_requested';
+  static const int _noShowPenaltyGoalIntervalSeconds = 60;
 
   String timerButtonText = 'START';
   final int _maxPlayer = 5;
@@ -39,6 +40,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   bool inGame = false;
   bool isTimeRunning = false;
   int _numberOfPlaying = 0;
+  bool _noShowPenaltyGoalsActive = false;
+  String? _noShowPenaltyScoringTeamId;
+  int _lastNoShowPenaltyGoalElapsed = 0;
   MatchStage currentStage = MatchStage.firstHalf;
   Timer? _timer;
   DateTime? _runClockStartedAt;
@@ -111,6 +115,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _isGameRunning = false;
     timerButtonText = 'START';
     inGame = false;
+    _noShowPenaltyGoalsActive = false;
+    _noShowPenaltyScoringTeamId = null;
+    _lastNoShowPenaltyGoalElapsed = 0;
 
     stopTimer();
 
@@ -180,6 +187,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _checkGameTimerVibration();
       notifyAllModulesTimer();
       mqttService.publishTime(_remainingTime);
+      _maybeAwardNoShowPenaltyGoal();
     }
 
     if (_remainingTime <= 0) {
@@ -187,29 +195,38 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       isTimeRunning = false;
       _timer?.cancel();
 
+      final noShowModeActive = _noShowPenaltyGoalsActive;
       switch (currentStage) {
         case MatchStage.firstHalf:
           currentStage = MatchStage.halfTime;
           _remainingTime = halfTimeDuration;
           startTimer();
           timerButtonText = 'SKIP';
-          halfTimeAll();
-          // Trigger the callback to show the dialog
-          if (onRequestSwitchTeamOrderDialog != null) {
-            onRequestSwitchTeamOrderDialog!();
+          if (!noShowModeActive) {
+            halfTimeAll();
+            // Trigger the callback to show the dialog
+            if (onRequestSwitchTeamOrderDialog != null) {
+              onRequestSwitchTeamOrderDialog!();
+            }
           }
           break;
         case MatchStage.halfTime:
           currentStage = MatchStage.secondHalf;
           _remainingTime = periodTime;
-          stopAll(true, force: true);
+          _lastNoShowPenaltyGoalElapsed = 0;
+          if (!noShowModeActive) {
+            stopAll(true, force: true);
+          }
           timerButtonText = 'START';
           break;
         case MatchStage.secondHalf:
           currentStage = MatchStage.fullTime;
-          stopAll(true);
+          _noShowPenaltyGoalsActive = false;
+          if (!noShowModeActive) {
+            stopAll(true);
+            gameOverAll();
+          }
           timerButtonText = 'REPEAT';
-          gameOverAll();
           break;
         default:
           debugPrint('unknown match stage');
@@ -218,7 +235,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _broadcastStageAndTime();
     }
 
-    if (currentStage == MatchStage.halfTime && _remainingTime % 30 == 0) {
+    if (!_noShowPenaltyGoalsActive &&
+        currentStage == MatchStage.halfTime &&
+        _remainingTime % 30 == 0) {
       halfTimeSyncTimeAll();
     }
 
@@ -250,11 +269,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       if (_isGameRunning) {
         stopTimer();
         timerButtonText = 'START';
-        stopAll(false);
+        if (!_noShowPenaltyGoalsActive) {
+          stopAll(false);
+        }
       } else {
         timerButtonText = 'STOP';
         startTimer();
-        playAll(false);
+        if (!_noShowPenaltyGoalsActive) {
+          playAll(false);
+        }
       }
     } else if (currentStage == MatchStage.halfTime) {
       // SKIP
@@ -265,7 +288,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _runClockStartRemainingTime = null;
       currentStage = MatchStage.secondHalf;
       _remainingTime = periodTime;
-      stopAll(true, force: true);
+      _lastNoShowPenaltyGoalElapsed = 0;
+      if (!_noShowPenaltyGoalsActive) {
+        stopAll(true, force: true);
+      }
       timerButtonText = 'START';
 
       _broadcastStageAndTime();
@@ -293,6 +319,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   /// Toggles all modules based on the current game stage.
   void toggleAllModules() {
+    if (_noShowPenaltyGoalsActive) {
+      return;
+    }
     if (currentStage == MatchStage.fullTime) {
       disconnectAll();
     } else if (_numberOfPlaying > 0) {
@@ -314,6 +343,59 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         module.setLabel(module.defaultName);
       }
     }
+  }
+
+  void _maybeAwardNoShowPenaltyGoal() {
+    if (!_noShowPenaltyGoalsActive || !_isGameRunning) return;
+    if (currentStage != MatchStage.firstHalf &&
+        currentStage != MatchStage.secondHalf) {
+      return;
+    }
+
+    final scoringTeamId = _noShowPenaltyScoringTeamId;
+    if (scoringTeamId == null) return;
+
+    final elapsed = periodTime - _remainingTime;
+    if (elapsed <= 0 ||
+        elapsed == _lastNoShowPenaltyGoalElapsed ||
+        elapsed % _noShowPenaltyGoalIntervalSeconds != 0) {
+      return;
+    }
+
+    final scoringTeam = _noShowPenaltyScoringTeam;
+    if (scoringTeam == null) return;
+
+    scoringTeam.addScore(1);
+    _lastNoShowPenaltyGoalElapsed = elapsed;
+    notifyModulesScore();
+  }
+
+  void startNoShowPenaltyGoals(Team scoringTeam) {
+    gameInit();
+    _noShowPenaltyGoalsActive = true;
+    _noShowPenaltyScoringTeamId = scoringTeam.id;
+    _lastNoShowPenaltyGoalElapsed = 0;
+    timerButtonText = 'STOP';
+    startTimer();
+    notifyListeners();
+  }
+
+  void stopNoShowPenaltyGoals() {
+    _noShowPenaltyGoalsActive = false;
+    _noShowPenaltyScoringTeamId = null;
+    _lastNoShowPenaltyGoalElapsed = 0;
+    timerButtonText = 'START';
+    stopTimer();
+    notifyListeners();
+  }
+
+  Team? get _noShowPenaltyScoringTeam {
+    final scoringTeamId = _noShowPenaltyScoringTeamId;
+    if (scoringTeamId == null) return null;
+    for (final team in teams) {
+      if (team.id == scoringTeamId) return team;
+    }
+    return null;
   }
 
   void notifyAllModulesTimer() {
@@ -664,6 +746,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   int get remainingTime => _remainingTime;
+  bool get noShowPenaltyGoalsActive => _noShowPenaltyGoalsActive;
+  String get noShowPenaltyGoalIntervalLabel => '1 goal/min';
+  String get noShowPenaltyScoringTeamName =>
+      _noShowPenaltyScoringTeam?.name ?? '';
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;
   bool get isTimerRunning => isTimeRunning;
   bool get isGameRunning => _isGameRunning;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -26,16 +26,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   static const String _penaltyTimeKey = 'game_penalty_time';
   static const String _notifPermissionRequestedKey =
       'notif_permission_requested';
-  static const int _noShowPenaltyGoalIntervalSeconds = 60;
+  static const int _defaultPeriodTimeSeconds = 600;
+  static const int _defaultHalfTimeDurationSeconds = 300;
+  static const int _defaultPenaltyTimeSeconds = 60;
+  static const int _defaultPlayersPerTeam = 2;
+  static const int _noShowPenaltyGoalIntervalSeconds = 30;
+  static const int _maxNoShowPenaltyGoalDifference = 10;
 
   String timerButtonText = 'START';
   final int _maxPlayer = 5;
   List<Team> teams = [];
-  int _numberOfPLayers = 2;
+  int _numberOfPLayers = _defaultPlayersPerTeam;
   int _remainingTime = 0;
-  int _penaltyTime = 60;
-  int _periodTime = 600;
-  int _halfTimeDuration = 300;
+  int _penaltyTime = _defaultPenaltyTimeSeconds;
+  int _periodTime = _defaultPeriodTimeSeconds;
+  int _halfTimeDuration = _defaultHalfTimeDurationSeconds;
   bool _isGameRunning = false;
   bool inGame = false;
   bool isTimeRunning = false;
@@ -93,11 +98,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   Future<void> _loadPrefs() async {
     _prefs = await SharedPreferences.getInstance();
-    _periodTime = _prefs!.getInt(_periodTimeKey) ?? 600;
-    _halfTimeDuration = _prefs!.getInt(_halfTimeDurationKey) ?? 300;
-    _numberOfPLayers =
-        (_prefs!.getInt(_numberOfPlayersKey) ?? 2).clamp(1, _maxPlayer).toInt();
-    _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? 60;
+    _periodTime = _prefs!.getInt(_periodTimeKey) ?? _defaultPeriodTimeSeconds;
+    _halfTimeDuration =
+        _prefs!.getInt(_halfTimeDurationKey) ?? _defaultHalfTimeDurationSeconds;
+    _numberOfPLayers = (_prefs!.getInt(_numberOfPlayersKey) ??
+            _defaultPlayersPerTeam)
+        .clamp(1, _maxPlayer)
+        .toInt();
+    _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
 
     if (!inGame) {
       gameInit();
@@ -365,7 +373,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
 
     final scoringTeam = _noShowPenaltyScoringTeam;
-    if (scoringTeam == null) return;
+    if (scoringTeam == null || !_canAwardNoShowPenaltyGoal(scoringTeam)) {
+      return;
+    }
 
     scoringTeam.addScore(1);
     _lastNoShowPenaltyGoalElapsed = elapsed;
@@ -400,6 +410,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       if (team.id == scoringTeamId) return team;
     }
     return null;
+  }
+
+  bool _canAwardNoShowPenaltyGoal(Team scoringTeam) {
+    Team? opposingTeam;
+    for (final team in teams) {
+      if (team.id != scoringTeam.id) {
+        opposingTeam = team;
+        break;
+      }
+    }
+    if (opposingTeam == null) return true;
+    return scoringTeam.score - opposingTeam.score <
+        _maxNoShowPenaltyGoalDifference;
   }
 
   void notifyAllModulesTimer() {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -263,10 +263,9 @@ Widget buildTeamContainer(Team team, Game game) {
       builder: (context, team, child) {
         return GestureDetector(
           onDoubleTap: () {
+            if (game.noShowPenaltyGoalsActive) return;
             team.addScore(1);
-            if (!game.noShowPenaltyGoalsActive) {
-              game.stopAll(true);
-            }
+            game.stopAll(true);
             game.notifyModulesScore();
           },
           onLongPress: () {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -194,6 +194,7 @@ Widget buildModuleButton(Module module, Game game) {
         return Expanded(
           child: GestureDetector(
             onDoubleTap: () {
+              if (game.noShowPenaltyGoalsActive) return;
               if (module.isPlaying) {
                 if (game.isGameRunning) {
                   module.penalty(game.penaltyTime);
@@ -263,7 +264,9 @@ Widget buildTeamContainer(Team team, Game game) {
         return GestureDetector(
           onDoubleTap: () {
             team.addScore(1);
-            game.stopAll(true);
+            if (!game.noShowPenaltyGoalsActive) {
+              game.stopAll(true);
+            }
             game.notifyModulesScore();
           },
           onLongPress: () {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -69,6 +69,35 @@ class _SettingsScreenState extends State<SettingsScreen> {
     super.dispose();
   }
 
+  Future<void> _confirmStartNoShowPenaltyGoals(int scoringTeamIndex) async {
+    final scoringTeam = widget.game.teams[scoringTeamIndex];
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Start no-show penalty goals?'),
+        content: Text(
+          '${scoringTeam.name} will receive one goal every minute while the '
+          'game timer runs. The current game will be reset.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Start'),
+          ),
+        ],
+      ),
+    );
+
+    if (!mounted || confirmed != true) return;
+    setState(() {
+      widget.game.startNoShowPenaltyGoals(scoringTeam);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return PopScope(
@@ -136,38 +165,77 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                 ],
                               );
                             }),
-                        SettingsSection(
-                          title: 'Current Game',
-                          locked: false,
-                          settings: [
-                            SettingButton(
-                              title: 'Switch team order',
-                              buttonText: 'Switch',
-                              onPressed: () {
-                                setState(() {
-                                  widget.game.toggleTeamOrder();
-                                });
-                              },
-                            ),
-                            SettingButton(
-                              title: 'Reset current game',
-                              buttonText: 'Reset',
-                              onPressed: () {
-                                setState(() {
-                                  widget.game.setTeamToDefaultOrder();
-                                  widget.game.gameInit();
-                                  widget.game.resetModuleNames();
-                                });
-                              },
-                            ),
-                            SettingButton(
-                              title: 'Disconnect all robots',
-                              buttonText: 'Disconnect',
-                              onPressed: () {
-                                widget.game.disconnectAll();
-                              },
-                            ),
-                          ],
+                        AnimatedBuilder(
+                          animation: widget.game,
+                          builder: (context, child) {
+                            final noShowActive =
+                                widget.game.noShowPenaltyGoalsActive;
+                            return SettingsSection(
+                              title: 'Current Game',
+                              locked: false,
+                              settings: [
+                                SettingButton(
+                                  title: 'Switch team order',
+                                  buttonText: 'Switch',
+                                  onPressed: () {
+                                    setState(() {
+                                      widget.game.toggleTeamOrder();
+                                    });
+                                  },
+                                ),
+                                SettingButton(
+                                  title: 'Reset current game',
+                                  buttonText: 'Reset',
+                                  onPressed: () {
+                                    setState(() {
+                                      widget.game.setTeamToDefaultOrder();
+                                      widget.game.gameInit();
+                                      widget.game.resetModuleNames();
+                                    });
+                                  },
+                                ),
+                                SettingStatus(
+                                  title: 'No-show penalty goals',
+                                  status: noShowActive
+                                      ? '${widget.game.noShowPenaltyScoringTeamName}: ${widget.game.noShowPenaltyGoalIntervalLabel}'
+                                      : 'Off',
+                                ),
+                                if (!noShowActive) ...[
+                                  SettingButton(
+                                    title:
+                                        '${widget.game.teams[0].name} scores no-show goals',
+                                    buttonText: 'Start',
+                                    onPressed: () =>
+                                        _confirmStartNoShowPenaltyGoals(0),
+                                  ),
+                                  SettingButton(
+                                    title:
+                                        '${widget.game.teams[1].name} scores no-show goals',
+                                    buttonText: 'Start',
+                                    onPressed: () =>
+                                        _confirmStartNoShowPenaltyGoals(1),
+                                  ),
+                                ],
+                                if (noShowActive)
+                                  SettingButton(
+                                    title: 'Stop no-show penalty goals',
+                                    buttonText: 'Stop',
+                                    onPressed: () {
+                                      setState(() {
+                                        widget.game.stopNoShowPenaltyGoals();
+                                      });
+                                    },
+                                  ),
+                                SettingButton(
+                                  title: 'Disconnect all robots',
+                                  buttonText: 'Disconnect',
+                                  onPressed: () {
+                                    widget.game.disconnectAll();
+                                  },
+                                ),
+                              ],
+                            );
+                          },
                         ),
                         ValueListenableBuilder<BridgeConnectionState>(
                             valueListenable: widget

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -76,8 +76,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       builder: (context) => AlertDialog(
         title: const Text('Start no-show penalty goals?'),
         content: Text(
-          '${scoringTeam.name} will receive one goal every minute while the '
-          'game timer runs. The current game will be reset.',
+          '${scoringTeam.name} will receive ${widget.game.noShowPenaltyGoalIntervalLabel} '
+          'while the game timer runs. The current game will be reset.',
         ),
         actions: [
           TextButton(
@@ -183,17 +183,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                     });
                                   },
                                 ),
-                                SettingButton(
-                                  title: 'Reset current game',
-                                  buttonText: 'Reset',
-                                  onPressed: () {
-                                    setState(() {
-                                      widget.game.setTeamToDefaultOrder();
-                                      widget.game.gameInit();
-                                      widget.game.resetModuleNames();
-                                    });
-                                  },
-                                ),
+                                if (!noShowActive)
+                                  SettingButton(
+                                    title: 'Reset current game',
+                                    buttonText: 'Reset',
+                                    onPressed: () {
+                                      setState(() {
+                                        widget.game.setTeamToDefaultOrder();
+                                        widget.game.gameInit();
+                                        widget.game.resetModuleNames();
+                                      });
+                                    },
+                                  ),
                                 SettingStatus(
                                   title: 'No-show penalty goals',
                                   status: noShowActive

--- a/test/no_show_penalty_goals_test.dart
+++ b/test/no_show_penalty_goals_test.dart
@@ -22,12 +22,12 @@ void main() {
   }
 
   group('No-show penalty goals', () {
-    testWidgets('awards one goal per elapsed minute to the selected team',
+    testWidgets('awards one goal per elapsed 30 seconds to the selected team',
         (tester) async {
       final game = await createGame(tester);
       game.startNoShowPenaltyGoals(game.teams[0]);
 
-      await tester.pump(const Duration(seconds: 59));
+      await tester.pump(const Duration(seconds: 29));
       expect(scoreFor(game, 'A'), 0);
       expect(scoreFor(game, 'B'), 0);
 
@@ -35,7 +35,7 @@ void main() {
       expect(scoreFor(game, 'A'), 1);
       expect(scoreFor(game, 'B'), 0);
 
-      await tester.pump(const Duration(seconds: 60));
+      await tester.pump(const Duration(seconds: 30));
       expect(scoreFor(game, 'A'), 2);
       expect(scoreFor(game, 'B'), 0);
 
@@ -48,7 +48,7 @@ void main() {
       game.startNoShowPenaltyGoals(game.teams[0]);
       game.toggleTeamOrder();
 
-      await tester.pump(const Duration(seconds: 60));
+      await tester.pump(const Duration(seconds: 30));
 
       expect(game.teams.first.id, 'B');
       expect(scoreFor(game, 'A'), 1);
@@ -62,7 +62,7 @@ void main() {
       final game = await createGame(tester);
       game.startNoShowPenaltyGoals(game.teams[0]);
 
-      await tester.pump(const Duration(seconds: 60));
+      await tester.pump(const Duration(seconds: 30));
       expect(scoreFor(game, 'A'), 1);
 
       game.stopNoShowPenaltyGoals();
@@ -73,18 +73,31 @@ void main() {
       expect(scoreFor(game, 'A'), 1);
     });
 
+    testWidgets('caps automatic goals at a 10-goal difference', (tester) async {
+      final game = await createGame(tester);
+      game.periodTime = 600;
+      game.startNoShowPenaltyGoals(game.teams[0]);
+
+      await tester.pump(const Duration(seconds: 330));
+
+      expect(scoreFor(game, 'A'), 10);
+      expect(scoreFor(game, 'B'), 0);
+
+      game.stopNoShowPenaltyGoals();
+    });
+
     testWidgets('deactivates automatically at full time', (tester) async {
       final game = await createGame(tester);
-      game.periodTime = 60;
+      game.periodTime = 30;
       game.halfTimeDuration = 1;
       game.startNoShowPenaltyGoals(game.teams[0]);
 
-      await tester.pump(const Duration(seconds: 61));
+      await tester.pump(const Duration(seconds: 31));
       expect(game.currentStage, MatchStage.secondHalf);
       expect(game.noShowPenaltyGoalsActive, isTrue);
 
       game.toggleTimer();
-      await tester.pump(const Duration(seconds: 60));
+      await tester.pump(const Duration(seconds: 30));
 
       expect(game.currentStage, MatchStage.fullTime);
       expect(game.noShowPenaltyGoalsActive, isFalse);

--- a/test/no_show_penalty_goals_test.dart
+++ b/test/no_show_penalty_goals_test.dart
@@ -38,6 +38,8 @@ void main() {
       await tester.pump(const Duration(seconds: 60));
       expect(scoreFor(game, 'A'), 2);
       expect(scoreFor(game, 'B'), 0);
+
+      game.stopNoShowPenaltyGoals();
     });
 
     testWidgets('keeps scoring by team id after team order switches',
@@ -51,6 +53,8 @@ void main() {
       expect(game.teams.first.id, 'B');
       expect(scoreFor(game, 'A'), 1);
       expect(scoreFor(game, 'B'), 0);
+
+      game.stopNoShowPenaltyGoals();
     });
 
     testWidgets('stopping no-show mode stops future automatic goals',

--- a/test/no_show_penalty_goals_test.dart
+++ b/test/no_show_penalty_goals_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<Game> createGame(WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({
+      'notif_permission_requested': true,
+    });
+    final game = Game();
+    addTearDown(game.dispose);
+    await tester.pump();
+    game.periodTime = 180;
+    game.halfTimeDuration = 60;
+    return game;
+  }
+
+  int scoreFor(Game game, String teamId) {
+    return game.teams.firstWhere((team) => team.id == teamId).score;
+  }
+
+  group('No-show penalty goals', () {
+    testWidgets('awards one goal per elapsed minute to the selected team',
+        (tester) async {
+      final game = await createGame(tester);
+      game.startNoShowPenaltyGoals(game.teams[0]);
+
+      await tester.pump(const Duration(seconds: 59));
+      expect(scoreFor(game, 'A'), 0);
+      expect(scoreFor(game, 'B'), 0);
+
+      await tester.pump(const Duration(seconds: 1));
+      expect(scoreFor(game, 'A'), 1);
+      expect(scoreFor(game, 'B'), 0);
+
+      await tester.pump(const Duration(seconds: 60));
+      expect(scoreFor(game, 'A'), 2);
+      expect(scoreFor(game, 'B'), 0);
+    });
+
+    testWidgets('keeps scoring by team id after team order switches',
+        (tester) async {
+      final game = await createGame(tester);
+      game.startNoShowPenaltyGoals(game.teams[0]);
+      game.toggleTeamOrder();
+
+      await tester.pump(const Duration(seconds: 60));
+
+      expect(game.teams.first.id, 'B');
+      expect(scoreFor(game, 'A'), 1);
+      expect(scoreFor(game, 'B'), 0);
+    });
+
+    testWidgets('stopping no-show mode stops future automatic goals',
+        (tester) async {
+      final game = await createGame(tester);
+      game.startNoShowPenaltyGoals(game.teams[0]);
+
+      await tester.pump(const Duration(seconds: 60));
+      expect(scoreFor(game, 'A'), 1);
+
+      game.stopNoShowPenaltyGoals();
+      expect(game.noShowPenaltyGoalsActive, isFalse);
+      expect(game.isTimerRunning, isFalse);
+
+      await tester.pump(const Duration(seconds: 120));
+      expect(scoreFor(game, 'A'), 1);
+    });
+
+    testWidgets('deactivates automatically at full time', (tester) async {
+      final game = await createGame(tester);
+      game.periodTime = 60;
+      game.halfTimeDuration = 1;
+      game.startNoShowPenaltyGoals(game.teams[0]);
+
+      await tester.pump(const Duration(seconds: 61));
+      expect(game.currentStage, MatchStage.secondHalf);
+      expect(game.noShowPenaltyGoalsActive, isTrue);
+
+      game.toggleTimer();
+      await tester.pump(const Duration(seconds: 60));
+
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.noShowPenaltyGoalsActive, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #8.

Adds a no-show penalty-goal mode for matches where one team does not show up:

- Settings → Current Game now lets the referee start no-show scoring for either team.
- Starting no-show mode resets the game, starts the match timer, and awards the selected team one goal per minute while the game clock runs.
- No-show mode is timer/score-only: robot START/STOP/stage commands are suppressed during this mode, including all-modules, individual module controls, score taps, and automatic stage transitions.
- Scores still fan out through the normal score path, so MQTT, BLE bridge, and connected module score displays stay in sync.
- Settings status updates live and exposes an explicit Stop control while no-show scoring is active.

## Review-anvil results

Ran a 3-round multi-agent review/fix loop:

1. **Round 1** found robot-command isolation gaps at stage transitions/all-modules control, score fan-out inconsistency, and active-mode UI/reset issues. Fixed in `feat(game): add no-show penalty goals` follow-up edits before commit.
2. **Round 2** found remaining robot-command paths: no-show startup went through full `gameInit()`/module init, individual module controls were still active, and manual score taps could stop robots. Fixed in `fix(game): isolate no-show mode from robot commands`.
3. **Round 3** converged with no material findings. Remaining comments were only low/nit cleanup suggestions.

## Verification

- `git diff --check` passed.
- `flutter analyze` could not be run in this shell because `flutter` is not available (`command not found`).

## Reviewers

Requesting review from @mato157 and @f-wllr.