### PR TITLE
feat(recovery): persist scoreboard match binding across cold resume (#53)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -903,6 +903,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (_lastAppliedScoreboardSignature == signature) {
       return;
     }
+    var reArmedFromSuppression = false;
     if (inGame && _suppressScoreboardFinalResult) {
       // A resumed match's final result is suppressed until its bound fixture's
       // config arrives. Re-arm ONLY for that same fixture (the unawaited config
@@ -914,6 +915,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           config.matchCode != resumedCode) {
         return;
       }
+      reArmedFromSuppression = true;
     }
     _lastAppliedScoreboardSignature = signature;
     _suppressScoreboardFinalResult = false;
@@ -932,6 +934,17 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (!inGame) {
       periodTime = config.durationSeconds;
       gameInit();
+    } else if (reArmedFromSuppression &&
+        currentStage == MatchStage.fullTime) {
+      // The bound fixture's config only surfaced AFTER this resumed match had
+      // already run to full-time while suppressed. The sole
+      // _queueFinalResultSubmission() call site (the secondHalf -> fullTime
+      // tick) returned early because the result was suppressed and the config
+      // was absent, so nothing was ever queued and the snapshot was already
+      // cleared - the result would be lost forever (#53). Now that the bound
+      // fixture's config is here, submit it. enqueueFinalResult is idempotent
+      // per match_code, so this is safe even if an item somehow already exists.
+      _queueFinalResultSubmission();
     }
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -932,8 +932,17 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _scoreboardHomeTeamId = homeIsLeft ? 'A' : 'B';
     _scoreboardAwayTeamId = homeIsLeft ? 'B' : 'A';
 
-    teams[0].name = homeIsLeft ? config.homeTeamName : config.awayTeamName;
-    teams[1].name = homeIsLeft ? config.awayTeamName : config.homeTeamName;
+    // Assign names by stable team ID, not by list position. If this re-runs
+    // while the order is swapped (e.g. the version bump after a successful
+    // submit re-applies the config at full-time), a positional assignment would
+    // scramble the names onto the wrong teams. The score mapping already keys on
+    // the team ID (_scoreboardHomeTeamId), so naming by ID keeps names and
+    // scores consistent regardless of side.
+    for (final team in teams) {
+      team.name = team.id == _scoreboardHomeTeamId
+          ? config.homeTeamName
+          : config.awayTeamName;
+    }
 
     // Apply remote timing presets only before a match starts (between matches,
     // after a reset). Never call gameInit() at full-time: a version-only update

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -900,7 +900,17 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // the displayed names; the `if (!inGame)` guard below still gates timing.
     final signature =
         '${config.matchCode}:${config.version}:${config.durationSeconds}:${homeIsLeft ? 'L' : 'R'}:${config.homeTeamName}:${config.awayTeamName}';
-    if (_lastAppliedScoreboardSignature == signature) {
+    // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
+    // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
+    // cleared when the service drops `_matchConfig` to null (a token-changing
+    // deep link or clearLinkedMatchData), so a suppressed resume can carry a
+    // stale signature for its own fixture. If that same fixture's config then
+    // re-arrives, an early dedupe return here would skip the re-arm below and
+    // leave the final result suppressed forever (#53). While suppressed, fall
+    // through to the re-arm guard, which re-arms the bound fixture or rejects a
+    // different one.
+    if (!(inGame && _suppressScoreboardFinalResult) &&
+        _lastAppliedScoreboardSignature == signature) {
       return;
     }
     var reArmedFromSuppression = false;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -89,6 +89,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   String? _lastAppliedScoreboardSignature;
   String? _scoreboardHomeTeamId;
   String? _scoreboardAwayTeamId;
+  bool _suppressScoreboardFinalResult = false;
+  // Identity of the fixture a RESUMED referee match is bound to (#53). Set on
+  // resume (even when the binding is suppressed because the config has not
+  // surfaced yet) so (a) a later-arriving config for the SAME fixture can re-arm
+  // the final-result POST instead of being blocked forever by the suppress
+  // latch, and (b) _buildSnapshot keeps re-persisting the binding through the
+  // suppressed window, so a second kill before the config loads doesn't lose it.
+  String? _resumedFixtureMatchCode;
+  int? _resumedFixtureVersion;
 
   // Callback to request showing the dialog
   void Function()? onRequestSwitchTeamOrderDialog;
@@ -203,6 +212,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _isGameRunning = false;
     timerButtonText = 'START';
     inGame = false;
+    _suppressScoreboardFinalResult = false;
+    _resumedFixtureMatchCode = null;
+    _resumedFixtureVersion = null;
 
     stopTimer();
 
@@ -300,6 +312,28 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   }
 
   MatchSnapshot _buildSnapshot() {
+    final config = scoreboardResultService.matchConfig;
+    final resumedCode = _resumedFixtureMatchCode;
+    final boundToResumed = resumedCode != null && resumedCode.isNotEmpty;
+    // For a RESUMED match the bound fixture is authoritative: the live config may
+    // be a DIFFERENT fixture opened mid-match (rejected by the suppress guard in
+    // _applyScoreboardMatchConfig but still held by the service), so it must NOT
+    // define the persisted binding — otherwise a second kill would resume bound
+    // to the wrong fixture and POST this match's scores against it.
+    // A referee binding also needs a non-empty match code: it is the stable
+    // fixture identity the drift guard and final-result POST key on. An empty
+    // code (server omitted match_code) is not a submittable fixture.
+    final configUsable = config != null &&
+        config.matchCode.isNotEmpty &&
+        (!boundToResumed || config.matchCode == resumedCode);
+    final liveReferee = configUsable && _scoreboardHomeTeamId != null;
+    // A resumed match whose fixture config hasn't surfaced yet is still a
+    // referee match: persist its binding so a second kill in that load window
+    // doesn't downgrade it to a plain match (which would silently drop the POST).
+    final pendingReferee = boundToResumed && _scoreboardHomeTeamId != null;
+    final isReferee = liveReferee || pendingReferee;
+    final boundCode = liveReferee ? config.matchCode : resumedCode;
+    final boundVersion = liveReferee ? config.version : _resumedFixtureVersion;
     return MatchSnapshot(
       stage: currentStage.name,
       remainingTime: _remainingTime,
@@ -307,6 +341,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       inGame: inGame,
       timerButtonText: timerButtonText,
       savedAtMs: DateTime.now().millisecondsSinceEpoch,
+      isRefereeMatch: isReferee,
+      scoreboardMatchCode: isReferee ? boundCode : null,
+      scoreboardVersion: isReferee ? boundVersion : null,
+      scoreboardHomeTeamId: isReferee ? _scoreboardHomeTeamId : null,
+      scoreboardAwayTeamId: isReferee ? _scoreboardAwayTeamId : null,
       teams: teams
           .map((t) => TeamSnapshot(id: t.id, name: t.name, score: t.score))
           .toList(),
@@ -345,6 +384,53 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           final moduleSnap = byId[module.moduleId];
           if (moduleSnap != null) module.restoreFromSnapshot(moduleSnap);
         }
+      }
+
+      // Restore the scoreboard binding (#53) so a resumed referee match still
+      // fires the correct final-result POST at full-time. Drift guard: only
+      // re-arm if the separately-persisted match config still matches the
+      // fixture this match was bound to. If a newer deep link replaced the
+      // config (or none is loaded), do NOT treat the resumed match as a referee
+      // match - avoids POSTing against the wrong fixture.
+      // Drift guard keys on match_code ONLY (the stable fixture identity), not
+      // version: an organizer edit during the kill window bumps the version of
+      // the SAME fixture, and enqueueFinalResult submits the live config version
+      // anyway, so a version-only difference must NOT be treated as drift.
+      final resumedCode = snapshot.scoreboardMatchCode;
+      final config = scoreboardResultService.matchConfig;
+      if (snapshot.isRefereeMatch &&
+          resumedCode != null &&
+          resumedCode.isNotEmpty &&
+          !(config != null && config.matchCode != resumedCode)) {
+        // Same fixture, or its config hasn't surfaced yet (loaded by a separate
+        // unawaited initialize() that may lose the race with the Resume tap).
+        // Restore the binding from the snapshot so it stays persisted (survives
+        // another kill in the load window). Remember the fixture identity so
+        // _buildSnapshot keeps re-persisting it and _applyScoreboardMatchConfig
+        // re-arms when this fixture's config arrives.
+        _scoreboardHomeTeamId = snapshot.scoreboardHomeTeamId;
+        _scoreboardAwayTeamId = snapshot.scoreboardAwayTeamId;
+        _resumedFixtureMatchCode = resumedCode;
+        _resumedFixtureVersion = snapshot.scoreboardVersion;
+        if (config != null) {
+          // Matching config is present → arm the POST now.
+          _lastAppliedScoreboardSignature =
+              '${config.matchCode}:${config.version}:${config.durationSeconds}:'
+              '${config.homeIsLeft ? 'L' : 'R'}:'
+              '${config.homeTeamName}:${config.awayTeamName}';
+          _suppressScoreboardFinalResult = false;
+        } else {
+          // Config not loaded yet → keep the POST suppressed until it arrives.
+          _suppressScoreboardFinalResult = true;
+        }
+      } else {
+        // Non-referee match, or true drift (a DIFFERENT fixture is loaded):
+        // drop the binding entirely so we never POST against the wrong fixture.
+        _scoreboardHomeTeamId = null;
+        _scoreboardAwayTeamId = null;
+        _resumedFixtureMatchCode = null;
+        _resumedFixtureVersion = null;
+        _suppressScoreboardFinalResult = snapshot.isRefereeMatch;
       }
 
       _remainingTime = snapshot.remainingTime;
@@ -817,7 +903,20 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (_lastAppliedScoreboardSignature == signature) {
       return;
     }
+    if (inGame && _suppressScoreboardFinalResult) {
+      // A resumed match's final result is suppressed until its bound fixture's
+      // config arrives. Re-arm ONLY for that same fixture (the unawaited config
+      // load that lost the race with the Resume tap); any OTHER config must not
+      // silently retarget a live match's final result.
+      final resumedCode = _resumedFixtureMatchCode;
+      if (resumedCode == null ||
+          resumedCode.isEmpty ||
+          config.matchCode != resumedCode) {
+        return;
+      }
+    }
     _lastAppliedScoreboardSignature = signature;
+    _suppressScoreboardFinalResult = false;
     _scoreboardHomeTeamId = homeIsLeft ? 'A' : 'B';
     _scoreboardAwayTeamId = homeIsLeft ? 'B' : 'A';
 
@@ -838,7 +937,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   void _queueFinalResultSubmission() {
     final config = scoreboardResultService.matchConfig;
-    if (config == null) return;
+    // Final gate before the POST: need a submittable fixture (non-empty code)
+    // and a non-suppressed binding.
+    if (config == null || config.matchCode.isEmpty) return;
+    if (_suppressScoreboardFinalResult) return;
+    // A resumed match is bound to its fixture: never POST if the live config has
+    // drifted to a different fixture (e.g. a deep link opened mid-match). Belt-
+    // and-suspenders with the suppress guard above.
+    final resumedCode = _resumedFixtureMatchCode;
+    if (resumedCode != null &&
+        resumedCode.isNotEmpty &&
+        config.matchCode != resumedCode) {
+      return;
+    }
 
     final defaultHomeTeamId = config.homeIsLeft ? 'A' : 'B';
     final defaultAwayTeamId = config.homeIsLeft ? 'B' : 'A';

--- a/lib/services/match_state_store.dart
+++ b/lib/services/match_state_store.dart
@@ -7,9 +7,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Schema version of the persisted match snapshot. A snapshot with any other
 /// version is ignored on load (treated as "no match"), so an old/incompatible
 /// snapshot can never crash startup or restore garbage. Bump this whenever the
-/// serialized shape changes incompatibly (e.g. when PR #15's web-match binding
-/// fields are added).
-const int kMatchSnapshotVersion = 1;
+/// serialized shape changes incompatibly. v2 adds scoreboard binding fields.
+const int kMatchSnapshotVersion = 2;
 
 /// Per-team recoverable state. Order is preserved by [MatchSnapshot.teams] so a
 /// swapped team order can be restored onto the correct physical side.
@@ -108,6 +107,15 @@ class MatchSnapshot {
   final List<TeamSnapshot> teams; // order preserved (captures team swap)
   final List<ModuleSnapshot> modules;
   final int savedAtMs; // epoch ms, for staleness display
+  /// Scoreboard binding (#53). Non-null only for a referee/deep-link match.
+  /// Lets a resumed match re-arm the correct final-result POST and lets the
+  /// resume path cross-check against the separately-persisted match config
+  /// (drift guard) before treating the match as a live referee match.
+  final bool isRefereeMatch;
+  final String? scoreboardMatchCode;
+  final int? scoreboardVersion;
+  final String? scoreboardHomeTeamId; // 'A' or 'B'
+  final String? scoreboardAwayTeamId; // 'A' or 'B'
 
   const MatchSnapshot({
     this.version = kMatchSnapshotVersion,
@@ -119,6 +127,11 @@ class MatchSnapshot {
     required this.teams,
     required this.modules,
     required this.savedAtMs,
+    this.isRefereeMatch = false,
+    this.scoreboardMatchCode,
+    this.scoreboardVersion,
+    this.scoreboardHomeTeamId,
+    this.scoreboardAwayTeamId,
   });
 
   Map<String, dynamic> toJson() => {
@@ -131,6 +144,11 @@ class MatchSnapshot {
         'teams': teams.map((t) => t.toJson()).toList(),
         'modules': modules.map((m) => m.toJson()).toList(),
         'savedAtMs': savedAtMs,
+        'isRefereeMatch': isRefereeMatch,
+        'scoreboardMatchCode': scoreboardMatchCode,
+        'scoreboardVersion': scoreboardVersion,
+        'scoreboardHomeTeamId': scoreboardHomeTeamId,
+        'scoreboardAwayTeamId': scoreboardAwayTeamId,
       };
 
   factory MatchSnapshot.fromJson(Map<String, dynamic> json) => MatchSnapshot(
@@ -147,6 +165,11 @@ class MatchSnapshot {
             .map((e) => ModuleSnapshot.fromJson(e as Map<String, dynamic>))
             .toList(),
         savedAtMs: (json['savedAtMs'] as num).toInt(),
+        isRefereeMatch: json['isRefereeMatch'] as bool? ?? false,
+        scoreboardMatchCode: json['scoreboardMatchCode'] as String?,
+        scoreboardVersion: (json['scoreboardVersion'] as num?)?.toInt(),
+        scoreboardHomeTeamId: json['scoreboardHomeTeamId'] as String?,
+        scoreboardAwayTeamId: json['scoreboardAwayTeamId'] as String?,
       );
 }
 

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -40,6 +40,23 @@ class ScoreboardResultService with ChangeNotifier {
 
   ScoreboardMatchConfig? get matchConfig => _matchConfig;
   String get statusMessage => _statusMessage;
+
+  /// Test-only seam: simulate a match config (and its credentials) surfacing
+  /// — as a deep link / persisted load would — and notify listeners, WITHOUT
+  /// the real [initialize] path. Unit tests can't run that path: it awaits the
+  /// app_links method channel (`getInitialLink`), which has no handler under
+  /// `flutter test` and never returns, and it performs real network I/O.
+  @visibleForTesting
+  void debugApplyMatchConfig(
+    ScoreboardMatchConfig config, {
+    String? token,
+    Uri? baseUri,
+  }) {
+    _matchConfig = config;
+    if (token != null) _token = token;
+    if (baseUri != null) _baseUri = baseUri;
+    notifyListeners();
+  }
   bool get hasToken => _token != null && _token!.isNotEmpty;
   bool get hasConflict => conflictCount > 0;
   int get pendingCount =>

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -662,6 +662,13 @@ void main() {
       expect(result.homeGoals, 4, reason: 'home is team A');
       expect(result.awayGoals, 2, reason: 'away is team B');
       expect(result.version, 3);
+      expect(
+        game.scoreboardResultService.outbox
+            .where((i) => i.matchCode == 'M-LFT')
+            .length,
+        1,
+        reason: 'exactly one submission - the re-arm must not double-queue',
+      );
 
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -16,6 +16,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/models/team.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
 
 ModuleSnapshot _moduleSnap({
@@ -901,6 +902,99 @@ void main() {
       expect(game.inGame, isFalse);
 
       expect(MatchStateStore(prefs).load(), isNull);
+      game.dispose();
+    });
+  });
+
+  group('scoreboard team naming (#53)', () {
+    Team teamById(Game game, String id) =>
+        game.teams.firstWhere((t) => t.id == id);
+
+    testWidgets('config re-apply after a swap keeps names matched by team id',
+        (tester) async {
+      // Repro of the swap+full-time display bug: the post-submit version bump
+      // re-applies the config while the order is swapped. Names must follow the
+      // team identity (home name -> home team), not the list position.
+      final game = Game();
+      await settleLoad(tester);
+
+      // Initial config (homeIsLeft true => home is team A).
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-NAME',
+          version: 1,
+          homeTeamName: 'Red Robots',
+          awayTeamName: 'Blue Bots',
+        )),
+      );
+      await tester.pump();
+      expect(teamById(game, 'A').name, 'Red Robots');
+      expect(teamById(game, 'B').name, 'Blue Bots');
+
+      // Swap the order (2nd-half switch), then re-apply the SAME fixture with a
+      // bumped version (mimics _updateMatchVersionFromResponse after a 200).
+      game.toggleTeamOrder();
+      await tester.pump();
+      expect(game.teams[0].id, 'B', reason: 'order is now swapped');
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-NAME',
+          version: 2, // bumped => signature differs => re-applies
+          homeTeamName: 'Red Robots',
+          awayTeamName: 'Blue Bots',
+        )),
+      );
+      await tester.pump();
+
+      // Names must still be on the correct teams by id, NOT scrambled onto the
+      // physical positions.
+      expect(teamById(game, 'A').name, 'Red Robots',
+          reason: 'home name stays on home team (id A) after swap');
+      expect(teamById(game, 'B').name, 'Blue Bots',
+          reason: 'away name stays on away team (id B) after swap');
+      game.dispose();
+    });
+
+    testWidgets('home_is_left false + swap keeps home name on team B',
+        (tester) async {
+      // The home_is_left:false counterpart of the swap test above (home is team
+      // B). Swapping then re-applying must keep the home name on team B; the old
+      // positional code would put it on teams[0] (team A after swap) and fail.
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-RIGHT',
+          version: 1,
+          homeIsLeft: false, // home is team B
+          homeTeamName: 'Red Robots',
+          awayTeamName: 'Blue Bots',
+        )),
+      );
+      await tester.pump();
+      expect(teamById(game, 'B').name, 'Red Robots',
+          reason: 'home (id B when !homeIsLeft) gets the home name');
+      expect(teamById(game, 'A').name, 'Blue Bots');
+
+      game.toggleTeamOrder();
+      await tester.pump();
+      expect(game.teams[0].id, 'B');
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-RIGHT',
+          version: 2, // bumped => re-applies while swapped
+          homeIsLeft: false,
+          homeTeamName: 'Red Robots',
+          awayTeamName: 'Blue Bots',
+        )),
+      );
+      await tester.pump();
+      expect(teamById(game, 'B').name, 'Red Robots',
+          reason: 'home name stays on team B after swap+reapply');
+      expect(teamById(game, 'A').name, 'Blue Bots');
       game.dispose();
     });
   });

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -8,11 +8,14 @@
 // delays) by either not starting the clock or cancelling/draining it before the
 // test returns.
 
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/module.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
 
 ModuleSnapshot _moduleSnap({
@@ -35,6 +38,42 @@ ModuleSnapshot _moduleSnap({
   );
 }
 
+Map<String, dynamic> _scoreboardConfig({
+  required String matchCode,
+  required int version,
+  bool homeIsLeft = true,
+  int durationSeconds = 600,
+  String homeTeamName = 'Home',
+  String awayTeamName = 'Away',
+}) =>
+    {
+      'match_code': matchCode,
+      'home_team': homeTeamName,
+      'away_team': awayTeamName,
+      'home_is_left': homeIsLeft,
+      'venue': 'Field 1',
+      'scheduled_start': null,
+      'duration_seconds': durationSeconds,
+      'timezone': 'Europe/Prague',
+      'version': version,
+      'status': 'SCHEDULED',
+    };
+
+Future<void> _seedScoreboardPrefs(
+  SharedPreferences prefs,
+  Map<String, dynamic> config, {
+  String? token,
+  Uri? baseUri,
+}) async {
+  await prefs.setString('scoreboard_match_config', jsonEncode(config));
+  if (token != null) {
+    await prefs.setString('scoreboard_token', token);
+  }
+  if (baseUri != null) {
+    await prefs.setString('scoreboard_base_url', baseUri.toString());
+  }
+}
+
 MatchSnapshot _snap({
   String stage = 'firstHalf',
   bool inGame = true,
@@ -45,6 +84,11 @@ MatchSnapshot _snap({
   String nameB = 'Team B',
   List<ModuleSnapshot> modules = const [],
   String firstTeamId = 'A',
+  bool isRefereeMatch = false,
+  String? scoreboardMatchCode,
+  int? scoreboardVersion,
+  String? scoreboardHomeTeamId,
+  String? scoreboardAwayTeamId,
 }) {
   final teamA = TeamSnapshot(id: 'A', name: nameA, score: scoreA);
   final teamB = TeamSnapshot(id: 'B', name: nameB, score: scoreB);
@@ -55,6 +99,11 @@ MatchSnapshot _snap({
     inGame: inGame,
     timerButtonText: 'START',
     savedAtMs: 1000,
+    isRefereeMatch: isRefereeMatch,
+    scoreboardMatchCode: scoreboardMatchCode,
+    scoreboardVersion: scoreboardVersion,
+    scoreboardHomeTeamId: scoreboardHomeTeamId,
+    scoreboardAwayTeamId: scoreboardAwayTeamId,
     teams: firstTeamId == 'A' ? [teamA, teamB] : [teamB, teamA],
     modules: modules,
   );
@@ -79,6 +128,53 @@ void main() {
   Future<void> settleLoad(WidgetTester tester) async {
     await tester.pump();
     await tester.pump();
+  }
+
+  Future<void> settleScoreboardConfig(WidgetTester tester, Game game) async {
+    for (var i = 0; i < 20; i++) {
+      if (game.scoreboardResultService.matchConfig != null) return;
+      await tester.pump(const Duration(milliseconds: 1));
+    }
+    fail('scoreboard match config did not load');
+  }
+
+  Future<MatchSnapshot> waitForSavedSnapshot(
+    WidgetTester tester,
+    bool Function(MatchSnapshot snapshot) matches,
+  ) async {
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      final snapshot = MatchStateStore(prefs).load();
+      if (snapshot != null && matches(snapshot)) return snapshot;
+    }
+    fail('expected saved snapshot was not written');
+  }
+
+  Future<ResultOutboxItem> waitForOutboxItem(
+    WidgetTester tester,
+    Game game,
+    String matchCode,
+  ) async {
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      final matches = game.scoreboardResultService.outbox
+          .where((item) => item.matchCode == matchCode);
+      if (matches.isNotEmpty) return matches.first;
+    }
+    fail('expected final result outbox item was not queued');
+  }
+
+  Future<void> expectNoOutboxItem(
+    WidgetTester tester,
+    Game game,
+    String matchCode,
+  ) async {
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      final hasMatch = game.scoreboardResultService.outbox
+          .any((item) => item.matchCode == matchCode);
+      expect(hasMatch, isFalse);
+    }
   }
 
   group('cold-launch detection', () {
@@ -135,8 +231,8 @@ void main() {
   group('resumePendingMatch', () {
     testWidgets('freezes the clock at the persisted freeze point (firstHalf)',
         (tester) async {
-      await persist(_snap(
-          stage: 'firstHalf', remainingTime: 137, scoreA: 2, scoreB: 1));
+      await persist(
+          _snap(stage: 'firstHalf', remainingTime: 137, scoreA: 2, scoreB: 1));
       final game = Game();
       await settleLoad(tester);
 
@@ -161,8 +257,7 @@ void main() {
         remainingTime: 300,
         modules: [
           _moduleSnap(id: 0, state: 'play', lastState: 'play'),
-          _moduleSnap(
-              id: 1, state: 'damage', lastState: 'play', penalty: 20),
+          _moduleSnap(id: 1, state: 'damage', lastState: 'play', penalty: 20),
         ],
       ));
       final game = Game();
@@ -197,7 +292,8 @@ void main() {
       await tester.pump();
       final m0 = game.teams[0].modules[0];
       expect(m0.suppressNextRestoreNotify, isTrue,
-          reason: 'armed by restore so a frozen-window reconnect stays stopped');
+          reason:
+              'armed by restore so a frozen-window reconnect stays stopped');
 
       // A referee START path must cancel the suppression synchronously, so a
       // LATE reconnect after START reflects the real (playing) state instead of
@@ -280,6 +376,453 @@ void main() {
       expect(game.teams[0].score, 4);
       expect(game.getScore('A'), 1);
       expect(game.getScore('B'), 4);
+      game.dispose();
+    });
+
+    testWidgets('resume re-arms scoreboard binding for final result mapping',
+        (tester) async {
+      final config = _scoreboardConfig(matchCode: 'M-53', version: 4);
+      await _seedScoreboardPrefs(
+        prefs,
+        config,
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 2,
+        scoreB: 5,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-53',
+        scoreboardVersion: 4,
+        scoreboardHomeTeamId: 'B',
+        scoreboardAwayTeamId: 'A',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+
+      game.resumePendingMatch();
+      // savedAtMs > 1000 proves this is the snapshot RE-SAVED by resume, not the
+      // seeded one (savedAtMs == 1000) that already had the binding.
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) => snapshot.isRefereeMatch && snapshot.savedAtMs > 1000,
+      );
+      expect(saved.scoreboardMatchCode, 'M-53');
+      expect(saved.scoreboardVersion, 4);
+      expect(saved.scoreboardHomeTeamId, 'B');
+      expect(saved.scoreboardAwayTeamId, 'A');
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      final result = await waitForOutboxItem(tester, game, 'M-53');
+
+      expect(result.homeGoals, 5,
+          reason: 'home score comes from restored team id B');
+      expect(result.awayGoals, 2,
+          reason: 'away score comes from restored team id A');
+      expect(result.version, 4);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('swapped resume keeps scoreboard mapping by stable team id',
+        (tester) async {
+      final config = _scoreboardConfig(
+        matchCode: 'M-SWAP',
+        version: 2,
+        homeIsLeft: false,
+      );
+      await _seedScoreboardPrefs(
+        prefs,
+        config,
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        firstTeamId: 'B',
+        scoreA: 3,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-SWAP',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+
+      game.resumePendingMatch();
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) =>
+            snapshot.isRefereeMatch &&
+            snapshot.savedAtMs > 1000 &&
+            snapshot.teams.first.id == 'B',
+      );
+      expect(saved.scoreboardHomeTeamId, 'A');
+      expect(saved.scoreboardAwayTeamId, 'B');
+      expect(game.teams[0].id, 'B');
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      final result = await waitForOutboxItem(tester, game, 'M-SWAP');
+
+      expect(result.homeGoals, 3,
+          reason: 'home score follows team A even after side swap');
+      expect(result.awayGoals, 1,
+          reason: 'away score follows team B even after side swap');
+      expect(result.version, 2);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('drift guard drops stale scoreboard binding on resume',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'Y', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'X',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+
+      game.resumePendingMatch();
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) => !snapshot.isRefereeMatch,
+      );
+
+      expect(saved.scoreboardMatchCode, isNull);
+      expect(saved.scoreboardVersion, isNull);
+      expect(saved.scoreboardHomeTeamId, isNull);
+      expect(saved.scoreboardAwayTeamId, isNull);
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      await expectNoOutboxItem(tester, game, 'Y');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('resume re-arms on a same-fixture version bump (#53)',
+        (tester) async {
+      // Organizer edited the fixture during the kill window: same match_code,
+      // newer version. The drift guard keys on match_code only, so this must
+      // re-arm and submit the LIVE config version, not drift-suppress.
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-VER', version: 9),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 1,
+        scoreB: 4,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-VER',
+        scoreboardVersion: 4,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+
+      game.resumePendingMatch();
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      final result = await waitForOutboxItem(tester, game, 'M-VER');
+
+      expect(result.homeGoals, 1);
+      expect(result.awayGoals, 4);
+      expect(result.version, 9,
+          reason: 'submits the live config version, not the snapshot version');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('late-arriving fixture config re-arms a suppressed resume (#53)',
+        (tester) async {
+      // The scoreboard config loads via a separate unawaited initialize() and
+      // may not have surfaced before the referee taps Resume. Resume then
+      // suppresses; when the SAME fixture's config arrives it must re-arm (the
+      // suppress latch is not one-way), and the final POST must fire.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 6,
+        scoreB: 0,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-LATE',
+        scoreboardVersion: 3,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      // No scoreboard config seeded yet → matchConfig is null at resume time.
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch(); // suppressed: bound fixture remembered as M-LATE
+
+      // Now the fixture's config arrives and notifies listeners. A dead local
+      // base URL makes the resulting submit network call fail instantly
+      // (connection refused) instead of hitting the real host.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-LATE', version: 3),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      final result = await waitForOutboxItem(tester, game, 'M-LATE');
+
+      expect(result.homeGoals, 6,
+          reason: 're-armed mapping: home is team A');
+      expect(result.awayGoals, 0,
+          reason: 're-armed mapping: away is team B');
+      expect(result.version, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('suppressed resume re-persists the binding for a 2nd kill (#53)',
+        (tester) async {
+      // Config not loaded at resume → binding is suppressed. The snapshot it
+      // RE-SAVES must still be a referee match with the binding intact, so a
+      // second kill before the config surfaces recovers it (not a plain match).
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 2,
+        scoreB: 2,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-PEND',
+        scoreboardVersion: 5,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch(); // suppressed (no config yet)
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) => snapshot.isRefereeMatch && snapshot.savedAtMs > 1000,
+      );
+      expect(saved.scoreboardMatchCode, 'M-PEND',
+          reason: 'binding survives the suppressed window for a second kill');
+      expect(saved.scoreboardVersion, 5);
+      expect(saved.scoreboardHomeTeamId, 'A');
+      expect(saved.scoreboardAwayTeamId, 'B');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('late config re-arms a swapped resumed match correctly (#53)',
+        (tester) async {
+      // Swapped team order (firstTeamId B → teams[0] is B) but home is team A
+      // (homeIsLeft true). home != teams[0], so a positional (teams[0]) mapping
+      // bug would give the wrong score and fail this test. The late-config
+      // re-arm must map home/away by STABLE team id, not position.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        firstTeamId: 'B',
+        scoreA: 1,
+        scoreB: 7,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-LSWAP',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch(); // suppressed
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-LSWAP', version: 2, homeIsLeft: true),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(game.teams[0].id, 'B', reason: 'team order stayed swapped');
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      final result = await waitForOutboxItem(tester, game, 'M-LSWAP');
+
+      expect(result.homeGoals, 1,
+          reason: 'home is team A (id), not teams[0] which is B');
+      expect(result.awayGoals, 7, reason: 'away is team B');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('a different fixture mid-suppressed-resume cannot hijack it (#53)',
+        (tester) async {
+      // Resume bound to M-HX with no config yet (suppressed). Then a DIFFERENT
+      // fixture M-HY opens mid-match. It must be rejected: the re-saved snapshot
+      // must still be M-HX (a 2nd kill must NOT resume bound to M-HY), and no
+      // result may be POSTed against M-HY.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 3,
+        scoreB: 2,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-HX',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      game.resumePendingMatch(); // suppressed, bound to M-HX
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-HY', version: 9),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      // Force a fresh snapshot save now that the foreign config is loaded.
+      game.notifyModulesScore();
+      await tester.pump();
+      await tester.pump();
+      final saved = MatchStateStore(prefs).load();
+      expect(saved, isNotNull);
+      expect(saved!.isRefereeMatch, isTrue);
+      expect(saved.scoreboardMatchCode, 'M-HX',
+          reason: 'foreign fixture must not overwrite the bound one');
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      await expectNoOutboxItem(tester, game, 'M-HY');
+      await expectNoOutboxItem(tester, game, 'M-HX');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('a live referee match persists its binding on first kill (#53)',
+        (tester) async {
+      // First-kill path (no prior snapshot): a deep-link config is applied to a
+      // fresh match, the match starts, and the persisted snapshot must carry the
+      // referee binding so it can be resumed + submitted.
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-FIRST', version: 4),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      game.startTimer(); // inGame = true
+      game.notifyModulesScore();
+      await tester.pump();
+      await tester.pump();
+
+      final saved = MatchStateStore(prefs).load();
+      expect(saved, isNotNull);
+      expect(saved!.inGame, isTrue);
+      expect(saved.isRefereeMatch, isTrue);
+      expect(saved.scoreboardMatchCode, 'M-FIRST');
+      expect(saved.scoreboardVersion, 4);
+      expect(saved.scoreboardHomeTeamId, 'A');
+      expect(saved.scoreboardAwayTeamId, 'B');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'non-referee swapped match resumes and never submits a result (#53)',
+        (tester) async {
+      // Regression guard: #53 touches the shared _buildSnapshot/resume paths.
+      // A plain (non-deep-link) match with a SWAPPED team order must still
+      // resume with its order+score intact AND must never enter the scoreboard
+      // result path (no binding, no POST). No scoreboard prefs are seeded.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        firstTeamId: 'B', // swapped: teams[0] is B
+        scoreA: 3,
+        scoreB: 1,
+        // isRefereeMatch defaults to false (plain match).
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch();
+
+      // Team order + scores restored by stable id (not position).
+      expect(game.teams[0].id, 'B', reason: 'swapped order restored');
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 3);
+      expect(game.teams.firstWhere((t) => t.id == 'B').score, 1);
+
+      // The re-saved snapshot is a plain match: no referee binding leaks in.
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) => snapshot.savedAtMs > 1000,
+      );
+      expect(saved.isRefereeMatch, isFalse);
+      expect(saved.scoreboardMatchCode, isNull);
+      expect(saved.scoreboardHomeTeamId, isNull);
+      expect(saved.scoreboardAwayTeamId, isNull);
+
+      // Drive to full-time: a non-referee match must POST nothing.
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      expect(game.scoreboardResultService.outbox, isEmpty,
+          reason: 'a plain match must never queue a scoreboard result');
+
+      await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();
     });
 

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -614,6 +614,59 @@ void main() {
       game.dispose();
     });
 
+    testWidgets(
+        'late config after full-time still submits a suppressed resume (#53)',
+        (tester) async {
+      // Regression: a resumed referee match can reach full-time WHILE STILL
+      // suppressed (its fixture config has not surfaced yet). The sole
+      // _queueFinalResultSubmission() call site is the secondHalf->fullTime
+      // tick, which returns early under suppression, and the same tick clears
+      // the snapshot - so without re-submitting on late config arrival the
+      // result is lost forever. The late config must drive the POST.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 4,
+        scoreB: 2,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-LFT',
+        scoreboardVersion: 3,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      // No scoreboard config seeded yet -> matchConfig is null at resume time.
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch(); // suppressed: bound fixture remembered as M-LFT
+
+      // Drive to full-time BEFORE the config surfaces. The suppressed full-time
+      // tick must NOT queue anything yet.
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      await expectNoOutboxItem(tester, game, 'M-LFT');
+
+      // Now the bound fixture's config finally arrives, after full-time.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-LFT', version: 3),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      final result = await waitForOutboxItem(tester, game, 'M-LFT');
+      expect(result.homeGoals, 4, reason: 'home is team A');
+      expect(result.awayGoals, 2, reason: 'away is team B');
+      expect(result.version, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
     testWidgets('suppressed resume re-persists the binding for a 2nd kill (#53)',
         (tester) async {
       // Config not loaded at resume → binding is suppressed. The snapshot it

--- a/test/match_state_store_test.dart
+++ b/test/match_state_store_test.dart
@@ -17,6 +17,11 @@ MatchSnapshot _sampleSnapshot({
   int remainingTime = 312,
   bool inGame = true,
   String stage = 'firstHalf',
+  bool isRefereeMatch = false,
+  String? scoreboardMatchCode,
+  int? scoreboardVersion,
+  String? scoreboardHomeTeamId,
+  String? scoreboardAwayTeamId,
 }) {
   return MatchSnapshot(
     stage: stage,
@@ -25,6 +30,11 @@ MatchSnapshot _sampleSnapshot({
     inGame: inGame,
     timerButtonText: 'START',
     savedAtMs: 1000,
+    isRefereeMatch: isRefereeMatch,
+    scoreboardMatchCode: scoreboardMatchCode,
+    scoreboardVersion: scoreboardVersion,
+    scoreboardHomeTeamId: scoreboardHomeTeamId,
+    scoreboardAwayTeamId: scoreboardAwayTeamId,
     teams: const [
       TeamSnapshot(id: 'A', name: 'Reds', score: 2),
       TeamSnapshot(id: 'B', name: 'Blues', score: 1),
@@ -86,6 +96,49 @@ void main() {
       expect(m1.isEnabled, isFalse);
       expect(m1.customLabel, isNull);
       expect(m1.macAddress, '');
+    });
+
+    test('round-trips scoreboard referee binding fields', () {
+      final back = MatchSnapshot.fromJson(_sampleSnapshot(
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-53',
+        scoreboardVersion: 7,
+        scoreboardHomeTeamId: 'B',
+        scoreboardAwayTeamId: 'A',
+      ).toJson());
+
+      expect(back.isRefereeMatch, isTrue);
+      expect(back.scoreboardMatchCode, 'M-53');
+      expect(back.scoreboardVersion, 7);
+      expect(back.scoreboardHomeTeamId, 'B');
+      expect(back.scoreboardAwayTeamId, 'A');
+    });
+
+    test('round-trips non-referee binding defaults', () {
+      final back = MatchSnapshot.fromJson(_sampleSnapshot().toJson());
+
+      expect(back.isRefereeMatch, isFalse);
+      expect(back.scoreboardMatchCode, isNull);
+      expect(back.scoreboardVersion, isNull);
+      expect(back.scoreboardHomeTeamId, isNull);
+      expect(back.scoreboardAwayTeamId, isNull);
+    });
+
+    test('defaults missing scoreboard binding keys defensively', () {
+      final json = _sampleSnapshot().toJson()
+        ..remove('isRefereeMatch')
+        ..remove('scoreboardMatchCode')
+        ..remove('scoreboardVersion')
+        ..remove('scoreboardHomeTeamId')
+        ..remove('scoreboardAwayTeamId');
+
+      final back = MatchSnapshot.fromJson(json);
+
+      expect(back.isRefereeMatch, isFalse);
+      expect(back.scoreboardMatchCode, isNull);
+      expect(back.scoreboardVersion, isNull);
+      expect(back.scoreboardHomeTeamId, isNull);
+      expect(back.scoreboardAwayTeamId, isNull);
     });
   });
 
@@ -178,8 +231,8 @@ void main() {
       await prefs.setString(
         _kSnapshotKey,
         '{"version":$kMatchSnapshotVersion,"generation":0,"stage":"firstHalf",'
-            '"remainingTime":312,"isTimeRunning":false,"inGame":true,'
-            '"timerButtonText":"START","teams":[],"modules":[],"savedAtMs":1}',
+        '"remainingTime":312,"isTimeRunning":false,"inGame":true,'
+        '"timerButtonText":"START","teams":[],"modules":[],"savedAtMs":1}',
       );
       expect(MatchStateStore(prefs).load(), isNull);
     });


### PR DESCRIPTION
## What

Persists the **scoreboard fixture binding** into the cold-resume `MatchSnapshot` so a referee/deep-link match that is **killed mid-match and resumed** still submits the **correct final result to the correct fixture** at full-time.

Closes #53. Follow-up to #45 (cold-resume) now that #15 (scoreboard final-result flow) is merged — #45's own issue body called this out as "a small follow-up on the #15 side."

## Why

Cold-resume (#45/#47) restored live match state (score, stage, clock freeze-point, team order, per-module penalties) but **not** the scoreboard binding. `Game._scoreboardHomeTeamId/_awayTeamId`, the bound `match_code`/`version`, and the "is referee match" fact lived only in memory. After a cold kill the resume path re-derived them implicitly from the separately-persisted `scoreboardResultService.matchConfig` — which works only if nothing overwrote that config in the meantime. A newer deep link arriving in the kill window could make a resumed match **POST against the wrong fixture**, or the result could be silently dropped.

## How

- **Schema v1 → v2** (`match_state_store.dart`): `MatchSnapshot` gains `isRefereeMatch`, `scoreboardMatchCode`, `scoreboardVersion`, `scoreboardHomeTeamId`, `scoreboardAwayTeamId`. Old v1 snapshots are dropped by the existing `version != kMatchSnapshotVersion` check (accepted: losing an in-progress match across an app update is rare and already the documented behaviour). `fromJson` defaults are backward-compatible.
- **Capture / restore** (`game.dart`): `_buildSnapshot` records the binding; `resumePendingMatch` restores it.
- **Drift guard on `match_code` only** (not version): the match code is the stable fixture identity; an organizer edit during the kill window bumps the version of the *same* fixture, and the POST submits the live config version anyway. A genuinely different fixture loaded at resume drops the binding (no POST).
- **Suppressed-window handling:** the fixture config loads via a separate `unawaited` `initialize()` and may not have surfaced when the referee taps Resume. In that window the binding is **held + re-persisted** (so a *second* kill can't lose it) and **re-armed** only when that *same* fixture's config finally arrives — never by a different fixture. The bound resumed fixture is authoritative in `_buildSnapshot`, so a foreign config opened mid-match cannot hijack the persisted binding.
- **Final-gate fencing** (`_queueFinalResultSubmission`): never POST with an empty `match_code`, and never against a fixture other than the one the match is bound to.

### Invariants preserved (CLAUDE.md)
Persistence stays off the robot START/STOP hot path (saves are `unawaited`, the POST is `unawaited`); no gesture / provider-tree / orientation changes; no new packages. The `ScoreboardResultService.debugApplyMatchConfig` seam is `@visibleForTesting` (the real `initialize()` awaits the app_links method channel — no handler under `flutter test` — and does network I/O).

## Testing

**Static:** `flutter analyze --fatal-infos` clean; **113/113** `flutter test` green.

**New unit/widget coverage** (`test/game_recovery_test.dart`): happy-path mapping · swapped-order mapping · drift drops binding · same-fixture version bump · late-arriving config re-arms a suppressed resume · suppressed resume re-persists for a 2nd kill · late config re-arms a swapped resumed match · foreign fixture cannot hijack a suppressed resume · live referee match persists on first kill · **non-referee swapped match resumes + never submits** (regression guard for the shared paths). Binding round-trip + legacy-default coverage in `test/match_state_store_test.dart`.

**Multi-agent review (review-anvil, codex + claude, 4 rounds):** converged. Two HIGH issues were found and fixed during review — a one-way suppress latch that could permanently drop the POST, and a foreign-config snapshot hijack that an interim fix had itself introduced (caught by the final round).

**Device-verified** on a Pixel-class phone against a local stdlib mock + `adb reverse`:
1. Deep link → match loaded (Red Robots vs Blue Bots, `RR-vs-BB-01`).
2. Score set 2–1, match started, ran into Half-Time.
3. `am force-stop` mid-match → process confirmed dead.
4. Cold relaunch → **Resume dialog: "Red Robots 2 – 1 Blue Bots · Half-time, saved just now"**.
5. Resume → score/stage/teams intact → played 2nd half to full-time.
6. `POST /api/v1/soccer/match/result/ {home_goals:2, away_goals:1}` → **RECORDED 2-1, 200**, against the bound fixture. Full-time score preserved (no 0–0 reset).

The non-referee resume path (e.g. team-order switch) cannot be exercised by a real force-stop on an emulator (force-stop kills the test runner too), so it is covered by the deterministic widget test above, which simulates the kill via persist → fresh `Game()`.

## Reviewer notes

- Not included in this PR (kept focused): the device-testing runbook + mock server live uncommitted in the working tree and can land separately.
- Deferred / out of scope (pre-existing, not introduced here): mid-match relink of a *fresh* (non-resumed) match (#15/#51 territory); an extreme edge where an organizer flips home/away **side** during the kill window on an armed resume.

cc @mrshu @f-wllr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
