### PR TITLE
chore: bump version to 0.10.3+13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.10.2+12
+version: 0.10.3+13
 
 
 environment:


### PR DESCRIPTION
## Why

The **Release** workflow has been failing on every push to `main` since the `0.10.2` release was cut.

It derives its tag from the semver part of `version:` in `pubspec.yaml` (`release.yml:28-31`), then guards against re-tagging (`release.yml:37-46`). Tag `v0.10.2` was created on 2026-06-17 with PR #7, but PRs #55 and #54 then merged to `main` **without a version bump**, so each Release run bails in ~10s at:

```
ERROR: Tag v0.10.2 already exists.
Bump the version in pubspec.yaml before merging to main.
```

The guard worked as designed — the fix is to bump the version.

## What

- Bump `version` `0.10.2+12` → `0.10.3+13` in `pubspec.yaml`

Both merged PRs (#54, #55) were bug fixes, so a patch bump is appropriate. `versionName`/`versionCode` flow straight from `pubspec.yaml` into the signed Android build, so no other files change. Once this lands on `main`, the Release workflow derives a fresh `v0.10.3`, passes the guard, and cuts the release.