### PR TITLE
fix(scoreboard): apply referee-match venue to the MQTT field number

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -972,7 +972,20 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // this guard to "match" the catigoal path — the guard is the fix.
     final venueField = fieldNumberFromVenue(config.venueShortName);
     if (venueField.isNotEmpty) {
+      final previousTopic = mqttService.topic;
       mqttService.topicField = venueField;
+      // If the field changes while a match is already underway — a mid-game
+      // venue correction, or the late-config re-arm of a suppressed resume — the
+      // `if (!inGame)` gameInit() broadcast below is skipped, so nothing would
+      // repopulate the NEW retained MQTT topic. Since publishes are retained,
+      // subscribers on the corrected field_N would otherwise see a previous
+      // match's retained data (or nothing) until the next score/stage event.
+      // Rebroadcast current state once, only when the topic actually changed, so
+      // an idempotent re-apply of the same field doesn't spam the bus.
+      // _broadcastFullState is off the robot START/STOP hot path (invariant #1).
+      if (inGame && mqttService.topic != previousTopic) {
+        _broadcastFullState();
+      }
     }
 
     // Apply remote timing presets only before a match starts (between matches,

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -422,6 +422,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
               '${config.homeTeamName}:${config.awayTeamName}:'
               '${config.venueShortName}';
           _suppressScoreboardFinalResult = false;
+          // Apply the venue field here too. Seeding the signature above means a
+          // later scoreboard-service notification dedupe-returns in
+          // _applyScoreboardMatchConfig BEFORE its field assignment runs, so on
+          // the race where Resume is tapped inside the unawaited initialize()
+          // window (config already set, listeners not yet notified) the resumed
+          // referee match would otherwise keep publishing on a stale/manual MQTT
+          // field (#50). Mirrors _applyScoreboardMatchConfig's field logic and is
+          // idempotent if that path already ran. Same race the binding above is
+          // restored for.
+          final venueField = fieldNumberFromVenue(config.venueShortName);
+          if (venueField.isNotEmpty) {
+            mqttService.topicField = venueField;
+          }
         } else {
           // Config not loaded yet → keep the POST suppressed until it arrives.
           _suppressScoreboardFinalResult = true;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -413,14 +413,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         _resumedFixtureMatchCode = resumedCode;
         _resumedFixtureVersion = snapshot.scoreboardVersion;
         if (config != null) {
-          // Matching config is present → arm the POST now. Keep this string
-          // identical to the signature built in _applyScoreboardMatchConfig
-          // (incl. the trailing venue) or a resumed match re-applies spuriously.
+          // Matching config is present → arm the POST now. Use the shared
+          // signature builder so this stays in lock-step with
+          // _applyScoreboardMatchConfig; a drift here re-applies spuriously.
           _lastAppliedScoreboardSignature =
-              '${config.matchCode}:${config.version}:${config.durationSeconds}:'
-              '${config.homeIsLeft ? 'L' : 'R'}:'
-              '${config.homeTeamName}:${config.awayTeamName}:'
-              '${config.venueShortName}';
+              _scoreboardConfigSignature(config);
           _suppressScoreboardFinalResult = false;
           // Apply the venue field here too. Seeding the signature above means a
           // later scoreboard-service notification dedupe-returns in
@@ -909,16 +906,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     notifyListeners();
   }
 
+  /// Dedupe key for an applied scoreboard config. Includes team names and venue
+  /// so a corrected schedule payload that changes only a name or the venue
+  /// (without bumping version/duration/side) is still applied (names + MQTT
+  /// field). Single source of truth for both `_applyScoreboardMatchConfig` and
+  /// the cold-resume re-arm in `resumePendingMatch`, which must agree exactly or
+  /// the dedupe desyncs.
+  String _scoreboardConfigSignature(ScoreboardMatchConfig config) =>
+      '${config.matchCode}:${config.version}:${config.durationSeconds}:'
+      '${config.homeIsLeft ? 'L' : 'R'}:'
+      '${config.homeTeamName}:${config.awayTeamName}:'
+      '${config.venueShortName}';
+
   void _applyScoreboardMatchConfig(ScoreboardMatchConfig config) {
     final homeIsLeft = config.homeIsLeft;
-    // Team names and venue are part of the signature so a corrected schedule
-    // payload that changes only a name or the venue (without bumping
-    // version/duration/side) still updates the displayed names and the MQTT
-    // field below; the `if (!inGame)` guard below still gates timing. Keep this
-    // string identical to the one written on the resume path (see
-    // resumePendingMatch) or the dedupe desyncs.
-    final signature =
-        '${config.matchCode}:${config.version}:${config.durationSeconds}:${homeIsLeft ? 'L' : 'R'}:${config.homeTeamName}:${config.awayTeamName}:${config.venueShortName}';
+    final signature = _scoreboardConfigSignature(config);
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -944,6 +944,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           : config.awayTeamName;
     }
 
+    // Apply the match's field number to the MQTT topic, mirroring the catigoal
+    // path (Match.fromJson + loadMatchData): take the first run of digits from
+    // the venue short name and strip leading zeros. Leave the existing field
+    // untouched when the venue carries no number (e.g. "Center Court") so a
+    // manually-set field is preserved — the mqtt setter would otherwise publish
+    // to a bare "field_" (#50).
+    final venueField = RegExp(r'\d+')
+            .firstMatch(config.venueShortName)
+            ?.group(0)
+            ?.replaceFirst(RegExp(r'^0+'), '') ??
+        '';
+    if (venueField.isNotEmpty) {
+      mqttService.topicField = venueField;
+    }
+
     // Apply remote timing presets only before a match starts (between matches,
     // after a reset). Never call gameInit() at full-time: a version-only update
     // from a successful result submission would otherwise zero the just-played

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -413,11 +413,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         _resumedFixtureMatchCode = resumedCode;
         _resumedFixtureVersion = snapshot.scoreboardVersion;
         if (config != null) {
-          // Matching config is present → arm the POST now.
+          // Matching config is present → arm the POST now. Keep this string
+          // identical to the signature built in _applyScoreboardMatchConfig
+          // (incl. the trailing venue) or a resumed match re-applies spuriously.
           _lastAppliedScoreboardSignature =
               '${config.matchCode}:${config.version}:${config.durationSeconds}:'
               '${config.homeIsLeft ? 'L' : 'R'}:'
-              '${config.homeTeamName}:${config.awayTeamName}';
+              '${config.homeTeamName}:${config.awayTeamName}:'
+              '${config.venueShortName}';
           _suppressScoreboardFinalResult = false;
         } else {
           // Config not loaded yet → keep the POST suppressed until it arrives.
@@ -895,11 +898,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   void _applyScoreboardMatchConfig(ScoreboardMatchConfig config) {
     final homeIsLeft = config.homeIsLeft;
-    // Team names are part of the signature so a corrected schedule payload that
-    // changes only a name (without bumping version/duration/side) still updates
-    // the displayed names; the `if (!inGame)` guard below still gates timing.
+    // Team names and venue are part of the signature so a corrected schedule
+    // payload that changes only a name or the venue (without bumping
+    // version/duration/side) still updates the displayed names and the MQTT
+    // field below; the `if (!inGame)` guard below still gates timing. Keep this
+    // string identical to the one written on the resume path (see
+    // resumePendingMatch) or the dedupe desyncs.
     final signature =
-        '${config.matchCode}:${config.version}:${config.durationSeconds}:${homeIsLeft ? 'L' : 'R'}:${config.homeTeamName}:${config.awayTeamName}';
+        '${config.matchCode}:${config.version}:${config.durationSeconds}:${homeIsLeft ? 'L' : 'R'}:${config.homeTeamName}:${config.awayTeamName}:${config.venueShortName}';
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -944,17 +944,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           : config.awayTeamName;
     }
 
-    // Apply the match's field number to the MQTT topic, mirroring the catigoal
-    // path (Match.fromJson + loadMatchData): take the first run of digits from
-    // the venue short name and strip leading zeros. Leave the existing field
-    // untouched when the venue carries no number (e.g. "Center Court") so a
-    // manually-set field is preserved — the mqtt setter would otherwise publish
-    // to a bare "field_" (#50).
-    final venueField = RegExp(r'\d+')
-            .firstMatch(config.venueShortName)
-            ?.group(0)
-            ?.replaceFirst(RegExp(r'^0+'), '') ??
-        '';
+    // Apply the match's field number to the MQTT topic. This reuses the catigoal
+    // field-extraction rule (`fieldNumberFromVenue`, shared with
+    // `Match.fromJson`) but deliberately does NOT mirror `loadMatchData`'s
+    // unconditional assignment: when the venue carries no number (e.g. "Center
+    // Court") we leave the existing field untouched so a manually-set field is
+    // preserved, instead of publishing to a bare "field_" (#50). Do not remove
+    // this guard to "match" the catigoal path — the guard is the fix.
+    final venueField = fieldNumberFromVenue(config.venueShortName);
     if (venueField.isNotEmpty) {
       mqttService.topicField = venueField;
     }

--- a/lib/services/match_data.dart
+++ b/lib/services/match_data.dart
@@ -5,6 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:rcj_scoreboard/services/error_messages.dart';
 
 
+/// Extract the field number from a raw venue/pitch string: the first run of
+/// digits, with leading zeros stripped (e.g. "Field 03" -> "3", "Pitch 12" ->
+/// "12"). Returns '' when there is no digit. Note a venue whose only digit is
+/// zero ("Field 0") also yields '' — acceptable since RCJ field numbers start
+/// at 1. Shared by the catigoal path (`Match.fromJson`) and the scoreboard
+/// referee-link path (`Game._applyScoreboardMatchConfig`) so the two stay
+/// aligned (#50).
+String fieldNumberFromVenue(String raw) =>
+    RegExp(r'\d+').firstMatch(raw)?.group(0)?.replaceFirst(RegExp(r'^0+'), '') ??
+    '';
+
 class Match {
   final String id;
   final String fieldRaw;
@@ -26,11 +37,8 @@ class Match {
       fieldRaw: json['pitch'] as String? ?? '', // Safely extract pitch
       team1: json['team1']?['name'] as String? ?? 'Unknown Team 1', // Safely extract team1 name
       team2: json['team2']?['name'] as String? ?? 'Unknown Team 2', // Safely extract team2 name
-      field: RegExp(r'\d+')
-              .firstMatch(json['pitch'] as String? ?? '')
-              ?.group(0)
-              ?.replaceFirst(RegExp(r'^0+'), '') ??
-          '', // Safely extract field number
+      field: fieldNumberFromVenue(
+          json['pitch'] as String? ?? ''), // Safely extract field number
     );
   }
 }

--- a/test/field_number_from_venue_test.dart
+++ b/test/field_number_from_venue_test.dart
@@ -1,0 +1,28 @@
+// Unit tests for the shared venue->field-number rule (#50). Both the catigoal
+// path (Match.fromJson) and the scoreboard referee-link path
+// (Game._applyScoreboardMatchConfig) depend on this single helper, so it gets
+// its own test home.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/services/match_data.dart';
+
+void main() {
+  test('extracts the first digit run', () {
+    expect(fieldNumberFromVenue('Field 3'), '3');
+    expect(fieldNumberFromVenue('Pitch 12'), '12');
+  });
+
+  test('strips leading zeros', () {
+    expect(fieldNumberFromVenue('Field 03'), '3');
+    expect(fieldNumberFromVenue('007'), '7');
+  });
+
+  test('returns empty when there is no digit', () {
+    expect(fieldNumberFromVenue('Center Court'), '');
+    expect(fieldNumberFromVenue(''), '');
+  });
+
+  test('a zero-only venue yields empty (RCJ fields start at 1)', () {
+    expect(fieldNumberFromVenue('Field 0'), '');
+  });
+}

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -430,6 +430,41 @@ void main() {
       game.dispose();
     });
 
+    testWidgets(
+        'late config on a suppressed in-game resume applies the venue field (#50)',
+        (tester) async {
+      // Resume a referee match WHILE its fixture config has not surfaced yet, so
+      // the match runs suppressed on the manual/persisted field. When the bound
+      // config later arrives, _applyScoreboardMatchConfig re-arms (bypassing the
+      // dedupe) and must apply the venue field even though we are inGame — the
+      // `if (!inGame) gameInit()` broadcast is skipped on this path.
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 200,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-FLD',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.scoreboardResultService.matchConfig, isNull);
+
+      game.resumePendingMatch(); // suppressed: no config yet
+      // _scoreboardConfig uses venue 'Field 1'.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-FLD', version: 1),
+        ),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      expect(game.mqttService.topic, 'field_1');
+      game.dispose();
+    });
+
     testWidgets('swapped resume keeps scoreboard mapping by stable team id',
         (tester) async {
       final config = _scoreboardConfig(

--- a/test/scoreboard_field_test.dart
+++ b/test/scoreboard_field_test.dart
@@ -1,0 +1,93 @@
+// Tests for #50: a referee-link match must apply its venue's field number to
+// the MQTT topic, mirroring the catigoal path (Match.fromJson + loadMatchData).
+//
+// Uses testWidgets for the same reason as game_recovery_test: the Game
+// constructor stands up wakelock/notification/MQTT/bridge services whose
+// platform-channel calls reject asynchronously in the headless test VM, which
+// the widget binding tolerates. No clock is started, so no Timers leak.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+
+Map<String, dynamic> _config({
+  required String matchCode,
+  required String venue,
+}) =>
+    {
+      'match_code': matchCode,
+      'home_team': 'Home',
+      'away_team': 'Away',
+      'home_is_left': true,
+      'venue': venue,
+      'scheduled_start': null,
+      'duration_seconds': 600,
+      'timezone': 'Europe/Prague',
+      'version': 1,
+      'status': 'SCHEDULED',
+    };
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  });
+
+  // Two pumps let the async _loadPrefs() (one getInstance await) finish.
+  Future<void> settleLoad(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump();
+  }
+
+  void apply(Game game, {required String matchCode, required String venue}) {
+    game.scoreboardResultService.debugApplyMatchConfig(
+      ScoreboardMatchConfig.fromJson(_config(matchCode: matchCode, venue: venue)),
+    );
+  }
+
+  testWidgets('numeric venue sets the MQTT field topic', (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, matchCode: 'M-1', venue: 'Field 3');
+    await tester.pump();
+
+    expect(game.mqttService.topic, 'field_3');
+    game.dispose();
+  });
+
+  testWidgets('venue field number strips leading zeros', (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, matchCode: 'M-1', venue: 'Field 03');
+    await tester.pump();
+
+    expect(game.mqttService.topic, 'field_3');
+    game.dispose();
+  });
+
+  testWidgets('venue without digits leaves the field topic unchanged',
+      (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    // First a numeric venue establishes a known field.
+    apply(game, matchCode: 'M-1', venue: 'Field 5');
+    await tester.pump();
+    expect(game.mqttService.topic, 'field_5');
+
+    // A different fixture (new match_code dodges the signature dedupe) whose
+    // venue carries no number must not clobber the existing field.
+    apply(game, matchCode: 'M-2', venue: 'Center Court');
+    await tester.pump();
+
+    expect(game.mqttService.topic, 'field_5');
+    game.dispose();
+  });
+}

--- a/test/scoreboard_field_test.dart
+++ b/test/scoreboard_field_test.dart
@@ -72,6 +72,25 @@ void main() {
     game.dispose();
   });
 
+  testWidgets('a venue-only correction (same match/version) updates the field',
+      (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, matchCode: 'M-1', venue: 'Field 5');
+    await tester.pump();
+    expect(game.mqttService.topic, 'field_5');
+
+    // Same fixture (match_code + version unchanged) but a corrected venue. The
+    // venue is part of the dedupe signature, so this must not be skipped (#50,
+    // RAVF001).
+    apply(game, matchCode: 'M-1', venue: 'Field 7');
+    await tester.pump();
+
+    expect(game.mqttService.topic, 'field_7');
+    game.dispose();
+  });
+
   testWidgets('venue without digits leaves the field topic unchanged',
       (tester) async {
     final game = Game();


### PR DESCRIPTION
## What
A referee-link match applied team names, timing, and the home/away binding in `_applyScoreboardMatchConfig` (`lib/models/game.dart`) but never touched the MQTT topic. MQTT kept publishing to whatever **Field Number** was set manually, ignoring the fixture's actual field.

## Fix
After the team-name assignment, parse the first digit-run out of `config.venueShortName`, strip leading zeros, and assign `mqttService.topicField` — the **exact** regex the catigoal path already uses (`Match.fromJson` + `loadMatchData`). Guard on a non-empty result so a venue without a number (e.g. `"Center Court"`) leaves the existing field untouched instead of publishing to a bare `field_`.

## Tests
`test/scoreboard_field_test.dart` (written test-first):
- numeric venue `"Field 3"` → `field_3`
- leading zeros stripped (`"Field 03"` → `field_3`)
- no-digit venue (`"Center Court"`) leaves the field unchanged

## Invariants
- Config-only; nothing added to the START/STOP fan-out (invariant #1).
- No UI gesture changes, provider tree unchanged.
- No change to catigoal behavior.

Closes #50