### PR TITLE
feat(scoreboard): referee match lifecycle — confirm-on-load, review/submit, persistent confirmation (#51)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -557,6 +557,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _isGameRunning = false;
       _restoreTeamOrderAndInfo(snapshot.teams);
 
+      // Snapshot-sourced mapping: this is the fallback for the config-NOT-loaded
+      // branch below (it keeps the binding persisted across another kill until
+      // the fixture surfaces). When the config IS already loaded, the branch
+      // below re-derives the mapping from the live config (a side swap during
+      // the kill window makes the snapshot mapping stale), so do not "simplify"
+      // by removing these.
       _scoreboardHomeTeamId = snapshot.scoreboardHomeTeamId;
       _scoreboardAwayTeamId = snapshot.scoreboardAwayTeamId;
       _resumedFixtureMatchCode = snapshot.scoreboardMatchCode;
@@ -565,7 +571,29 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       final config = scoreboardResultService.matchConfig;
       if (config != null && config.matchCode == snapshot.scoreboardMatchCode) {
         // The bound fixture's config is already loaded → arm now and offer the
-        // review immediately.
+        // review immediately. Re-derive the home/away->team-id mapping from the
+        // CURRENT config rather than trusting the snapshot's persisted mapping:
+        // the snapshot keeps match_code/version/team-ids but NOT the captured
+        // signature, so an organizer side-swap (homeIsLeft flip) or home-
+        // redefining rename during the kill window would otherwise read the
+        // final scores under the stale _scoreboardHomeTeamId mapping and POST the
+        // wrong team's goals as "home". The config is the live authority and the
+        // physical scores are keyed on the (fixed) team ids, so deriving the
+        // mapping fresh here keeps home/away correct on a swap. Mirrors
+        // _applyScoreboardMatchConfig; the config-not-loaded branch below already
+        // re-derives via that path when the fixture surfaces.
+        _deriveScoreboardSideMapping(config);
+        // Re-label the teams from the CURRENT config too (by stable id, exactly
+        // like _applyScoreboardMatchConfig): _restoreTeamOrderAndInfo above
+        // restored the snapshot's PRE-swap names, so without this a side swap
+        // would show the old team's name next to the value submitted as the new
+        // "home" and mislabel the confirm checkboxes. Goals already follow the
+        // re-derived mapping; the displayed names must follow it as well.
+        for (final team in teams) {
+          team.name = team.id == _scoreboardHomeTeamId
+              ? config.homeTeamName
+              : config.awayTeamName;
+        }
         _lastAppliedScoreboardSignature = config.signature;
         _suppressScoreboardFinalResult = false;
         _enterFullTimeResultReview();
@@ -1121,8 +1149,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     _lastAppliedScoreboardSignature = signature;
     _suppressScoreboardFinalResult = false;
-    _scoreboardHomeTeamId = config.homeIsLeft ? 'A' : 'B';
-    _scoreboardAwayTeamId = config.homeIsLeft ? 'B' : 'A';
+    _deriveScoreboardSideMapping(config);
 
     // Assign names by stable team ID, not by list position. If this re-runs
     // while the order is swapped (e.g. the version bump after a successful
@@ -1226,6 +1253,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// Capture the just-ended fixture as the result-review subject, then raise the
   /// review affordance. Called at the secondHalf->fullTime tick and, for a
   /// suppressed resume, when the bound fixture's config surfaces post-full-time.
+  /// Map the scoreboard home/away roles onto the fixed physical team ids.
+  /// Team 'A' is always the left side and 'B' the right; `homeIsLeft` decides
+  /// which physical team is "home". The single source of this rule — a stale or
+  /// out-of-sync mapping is exactly what POSTs the wrong team's goals as "home".
+  void _deriveScoreboardSideMapping(ScoreboardMatchConfig config) {
+    _scoreboardHomeTeamId = config.homeIsLeft ? 'A' : 'B';
+    _scoreboardAwayTeamId = config.homeIsLeft ? 'B' : 'A';
+  }
+
   void _enterFullTimeResultReview() {
     final config = scoreboardResultService.matchConfig;
     if (config != null &&

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -87,6 +87,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   WakelockService wakelockService = WakelockService();
   ScoreboardResultService scoreboardResultService = ScoreboardResultService();
   String? _lastAppliedScoreboardSignature;
+  String? _lastPromptedPendingSignature;
   String? _scoreboardHomeTeamId;
   String? _scoreboardAwayTeamId;
   bool _suppressScoreboardFinalResult = false;
@@ -98,9 +99,34 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // suppressed window, so a second kill before the config loads doesn't lose it.
   String? _resumedFixtureMatchCode;
   int? _resumedFixtureVersion;
+  // Signature of the fixture whose result is eligible for review at full time.
+  // Captured the moment the match ends (or the bound fixture's config surfaces
+  // post-full-time for a suppressed resume). The result-review affordance is
+  // gated on the committed config STILL matching this, so loading a different
+  // link at full time can't bind the just-ended match's scores to the new
+  // fixture. Cleared on a fresh match (gameInit).
+  String? _fullTimeResultSignature;
 
   // Callback to request showing the dialog
   void Function()? onRequestSwitchTeamOrderDialog;
+  void Function()? onRequestReviewScoreboardResult;
+
+  // Callback to request the confirm-on-load ("Load match?") dialog. A DRAINING
+  // setter, mirroring [onRequestResumeMatch]: scoreboardResultService.initialize()
+  // is kicked off in the Game constructor and can surface a staged deep link
+  // (pendingMatchConfig) BEFORE Home registers this callback in
+  // didChangeDependencies. A plain field would let _onScoreboardServiceUpdate
+  // mark the prompt consumed against a null callback, stranding the staged match
+  // with no dialog and no re-fire. Firing on assignment lets whichever happens
+  // last (config arrival vs callback registration) raise the prompt.
+  void Function(ScoreboardMatchConfig config)? _onRequestConfirmScoreboardMatch;
+  void Function(ScoreboardMatchConfig config)?
+      get onRequestConfirmScoreboardMatch => _onRequestConfirmScoreboardMatch;
+  set onRequestConfirmScoreboardMatch(
+      void Function(ScoreboardMatchConfig config)? callback) {
+    _onRequestConfirmScoreboardMatch = callback;
+    _maybeFirePendingMatchPrompt();
+  }
 
   // Callback to request showing the cold-resume prompt. A DRAINING setter:
   // main.dart constructs Game() before runApp and _loadPrefs() is async, so the
@@ -130,7 +156,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     Module moduleA3 = Module(this, teamID, 'A3', 2);
     Module moduleA4 = Module(this, teamID, 'A4', 3);
     Module moduleA5 = Module(this, teamID, 'A5', 4);
-    teams.add(Team('Team A', [moduleA1, moduleA2, moduleA3, moduleA4 ,moduleA5], teamID));
+    teams.add(Team(
+        'Team A', [moduleA1, moduleA2, moduleA3, moduleA4, moduleA5], teamID));
 
     // B team (1)
     teamID = 'B';
@@ -139,11 +166,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     Module moduleB3 = Module(this, teamID, 'B3', 7);
     Module moduleB4 = Module(this, teamID, 'B4', 8);
     Module moduleB5 = Module(this, teamID, 'B5', 9);
-    teams.add(Team('Team B', [moduleB1, moduleB2, moduleB3, moduleB4 ,moduleB5], teamID));
-
+    teams.add(Team(
+        'Team B', [moduleB1, moduleB2, moduleB3, moduleB4, moduleB5], teamID));
 
     gameInit();
     scoreboardResultService.addListener(_onScoreboardServiceUpdate);
+    scoreboardResultService.onCurrentResultDelivered =
+        _onScoreboardResultDelivered;
     unawaited(scoreboardResultService.initialize());
     unawaited(_loadPrefs());
   }
@@ -215,6 +244,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _suppressScoreboardFinalResult = false;
     _resumedFixtureMatchCode = null;
     _resumedFixtureVersion = null;
+    _fullTimeResultSignature = null;
 
     stopTimer();
 
@@ -414,10 +444,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         _resumedFixtureVersion = snapshot.scoreboardVersion;
         if (config != null) {
           // Matching config is present → arm the POST now.
-          _lastAppliedScoreboardSignature =
-              '${config.matchCode}:${config.version}:${config.durationSeconds}:'
-              '${config.homeIsLeft ? 'L' : 'R'}:'
-              '${config.homeTeamName}:${config.awayTeamName}';
+          _lastAppliedScoreboardSignature = config.signature;
           _suppressScoreboardFinalResult = false;
         } else {
           // Config not loaded yet → keep the POST suppressed until it arrives.
@@ -582,7 +609,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           stopAll(true);
           timerButtonText = 'REPEAT';
           gameOverAll();
-          _queueFinalResultSubmission();
+          _enterFullTimeResultReview();
           // The match is over: stop the OS autoConnect from chasing modules
           // that are powered down for good (e.g. a unit still off from a
           // late penalty). In-match these reconnect unbounded on purpose; at
@@ -706,9 +733,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
   }
 
-  void resetModuleNames(){
+  void resetModuleNames() {
     for (var team in teams) {
-      for (var module in team.modules.where((module) => module.isEnabled && module.hasCustomLabel)) {
+      for (var module in team.modules
+          .where((module) => module.isEnabled && module.hasCustomLabel)) {
         module.setLabel(module.defaultName);
       }
     }
@@ -727,11 +755,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     bool vibrateTriggered = false;
 
     for (var team in teams) {
-      for (var module in team.modules.where((module) => module.isEnabled && module.state == ModuleState.damage)) {
+      for (var module in team.modules.where(
+          (module) => module.isEnabled && module.state == ModuleState.damage)) {
         final penaltyBefore = module.penaltyTime;
         module.notifyTimer();
 
-        if (!_replaying && !vibrateTriggered && vibrationService.damageTimerEnabled && penaltyBefore > 0) {
+        if (!_replaying &&
+            !vibrateTriggered &&
+            vibrationService.damageTimerEnabled &&
+            penaltyBefore > 0) {
           final penaltyAfter = module.penaltyTime;
           if (vibrationService.damageTimerAlerts.contains(penaltyAfter)) {
             vibrateTriggered = true;
@@ -754,7 +786,6 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
     vibrationService.vibrateGameTimer();
   }
-
 
   void stopTimer() {
     _isGameRunning = false;
@@ -863,11 +894,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // Damage timers – one notification set per module currently in damage state.
     if (vibrationService.damageTimerEnabled) {
       for (final team in teams) {
-        for (final module in team.modules.where(
-            (m) => m.isEnabled && m.state == ModuleState.damage && m.penaltyTime > 0)) {
-          NotificationService.scheduleDamageAlerts(
-              module.moduleId, module.name, module.penaltyTime,
-              vibrationService.damageTimerAlerts);
+        for (final module in team.modules.where((m) =>
+            m.isEnabled &&
+            m.state == ModuleState.damage &&
+            m.penaltyTime > 0)) {
+          NotificationService.scheduleDamageAlerts(module.moduleId, module.name,
+              module.penaltyTime, vibrationService.damageTimerAlerts);
         }
       }
     }
@@ -885,7 +917,51 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     super.dispose();
   }
 
+  /// Called by the service the moment the active match's result is confirmed
+  /// delivered (HTTP 200). Defer the actual reset to a microtask: this fires
+  /// from inside the service's processOutbox, so resetting (which mutates the
+  /// service) inline would be re-entrant.
+  void _onScoreboardResultDelivered() {
+    scheduleMicrotask(_resetAfterScoreboardSubmission);
+  }
+
+  /// Return to the clean start state after a referee result is delivered, ready
+  /// for the next match (as if freshly launched): disconnect modules, restore
+  /// default team names/order, the operator's configured match length, and a
+  /// fresh 0-0 first half; drop the linked match (keeping the outbox audit) and
+  /// any saved snapshot. Only reached on a successful submission, so a queued or
+  /// failed result keeps the match on screen with its status instead.
+  void _resetAfterScoreboardSubmission() {
+    disconnectAll();
+    for (final team in teams) {
+      team.name = team.id == 'A' ? 'Team A' : 'Team B';
+    }
+    _lastAppliedScoreboardSignature = null;
+    _scoreboardHomeTeamId = null;
+    _scoreboardAwayTeamId = null;
+    _fullTimeResultSignature = null;
+    _resumedFixtureMatchCode = null;
+    _resumedFixtureVersion = null;
+    _suppressScoreboardFinalResult = false;
+    // The deep link had overridden the live periodTime; restore the operator's
+    // configured default (or the app default of 600 s when none is stored).
+    _periodTime = _prefs?.getInt(_periodTimeKey) ?? 600;
+    setTeamToDefaultOrder();
+    gameInit();
+    unawaited(scoreboardResultService.resetLinkedMatchAfterSubmission());
+    _clearMatchState();
+    notifyListeners();
+  }
+
   void _onScoreboardServiceUpdate() {
+    if (scoreboardResultService.pendingMatchConfig == null) {
+      // Pending cleared (confirmed/cancelled): reset the dedup so re-opening the
+      // same link later prompts again.
+      _lastPromptedPendingSignature = null;
+    } else {
+      _maybeFirePendingMatchPrompt();
+    }
+
     final config = scoreboardResultService.matchConfig;
     if (config != null) {
       _applyScoreboardMatchConfig(config);
@@ -893,13 +969,36 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     notifyListeners();
   }
 
+  /// Raise the "Load match?" prompt for a staged deep link, exactly once per
+  /// pending signature. Only advances [_lastPromptedPendingSignature] when the
+  /// callback is actually invoked, so a config that surfaces before Home
+  /// installs the callback is not silently consumed (the draining setter
+  /// re-runs this on registration).
+  void _maybeFirePendingMatchPrompt() {
+    final callback = _onRequestConfirmScoreboardMatch;
+    if (callback == null) return;
+    final pending = scoreboardResultService.pendingMatchConfig;
+    if (pending == null) return;
+    final signature = pending.signature;
+    if (_lastPromptedPendingSignature == signature) return;
+    _lastPromptedPendingSignature = signature;
+    callback(pending);
+  }
+
+  /// Called by Home when the "Load match?" dialog closes. Re-arms the prompt so
+  /// a newer link that arrived while the dialog was open (and was suppressed by
+  /// the dialog's re-entrancy guard) is shown next, and a stale Load/Cancel that
+  /// no-opped against a changed fixture doesn't strand the current pending one.
+  void onPendingMatchPromptClosed() {
+    _lastPromptedPendingSignature = null;
+    _maybeFirePendingMatchPrompt();
+  }
+
   void _applyScoreboardMatchConfig(ScoreboardMatchConfig config) {
-    final homeIsLeft = config.homeIsLeft;
     // Team names are part of the signature so a corrected schedule payload that
     // changes only a name (without bumping version/duration/side) still updates
     // the displayed names; the `if (!inGame)` guard below still gates timing.
-    final signature =
-        '${config.matchCode}:${config.version}:${config.durationSeconds}:${homeIsLeft ? 'L' : 'R'}:${config.homeTeamName}:${config.awayTeamName}';
+    final signature = config.signature;
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing
@@ -929,8 +1028,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     _lastAppliedScoreboardSignature = signature;
     _suppressScoreboardFinalResult = false;
-    _scoreboardHomeTeamId = homeIsLeft ? 'A' : 'B';
-    _scoreboardAwayTeamId = homeIsLeft ? 'B' : 'A';
+    _scoreboardHomeTeamId = config.homeIsLeft ? 'A' : 'B';
+    _scoreboardAwayTeamId = config.homeIsLeft ? 'B' : 'A';
 
     // Assign names by stable team ID, not by list position. If this re-runs
     // while the order is swapped (e.g. the version bump after a successful
@@ -951,48 +1050,128 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // bridge. The full-time clock display stays in sync separately via the
     // periodTime setter when settings change.
     if (!inGame) {
-      periodTime = config.durationSeconds;
+      // Set the LIVE match length from the link, but do NOT persist it as the
+      // operator's configured default (the `periodTime` setter would write it to
+      // prefs and clobber their setting). gameInit() applies it to the clock.
+      _periodTime = config.durationSeconds;
       gameInit();
-    } else if (reArmedFromSuppression &&
-        currentStage == MatchStage.fullTime) {
+    } else if (reArmedFromSuppression && currentStage == MatchStage.fullTime) {
       // The bound fixture's config only surfaced AFTER this resumed match had
-      // already run to full-time while suppressed. The sole
-      // _queueFinalResultSubmission() call site (the secondHalf -> fullTime
-      // tick) returned early because the result was suppressed and the config
-      // was absent, so nothing was ever queued and the snapshot was already
-      // cleared - the result would be lost forever (#53). Now that the bound
-      // fixture's config is here, submit it. enqueueFinalResult is idempotent
-      // per match_code, so this is safe even if an item somehow already exists.
-      _queueFinalResultSubmission();
+      // already run to full-time while suppressed. Now that the bound fixture's
+      // config is here, capture it as the review subject and surface the review
+      // flow instead of silently enqueueing.
+      _enterFullTimeResultReview();
     }
   }
 
-  void _queueFinalResultSubmission() {
-    final config = scoreboardResultService.matchConfig;
+  bool _canSubmitScoreboardResult([ScoreboardMatchConfig? config]) {
+    final matchConfig = config ?? scoreboardResultService.matchConfig;
     // Final gate before the POST: need a submittable fixture (non-empty code)
     // and a non-suppressed binding.
-    if (config == null || config.matchCode.isEmpty) return;
-    if (_suppressScoreboardFinalResult) return;
+    if (matchConfig == null || matchConfig.matchCode.isEmpty) return false;
+    if (_suppressScoreboardFinalResult) return false;
     // A resumed match is bound to its fixture: never POST if the live config has
     // drifted to a different fixture (e.g. a deep link opened mid-match). Belt-
     // and-suspenders with the suppress guard above.
     final resumedCode = _resumedFixtureMatchCode;
     if (resumedCode != null &&
         resumedCode.isNotEmpty &&
-        config.matchCode != resumedCode) {
-      return;
+        matchConfig.matchCode != resumedCode) {
+      return false;
+    }
+    return true;
+  }
+
+  bool get needsScoreboardResultReview {
+    final config = scoreboardResultService.matchConfig;
+    if (currentStage != MatchStage.fullTime) return false;
+    // The committed config must STILL be the exact fixture that just ended.
+    // Loading a different link at full time changes matchConfig, but its
+    // signature won't match the one captured at full time, so we never offer to
+    // submit the just-ended scores against a newly-loaded fixture.
+    if (_fullTimeResultSignature == null) return false;
+    if (config == null || config.signature != _fullTimeResultSignature) {
+      return false;
+    }
+    if (!_canSubmitScoreboardResult(config)) return false;
+    return !scoreboardResultService.hasResultFor(config.matchCode);
+  }
+
+  /// Capture the just-ended fixture as the result-review subject, then raise the
+  /// review affordance. Called at the secondHalf->fullTime tick and, for a
+  /// suppressed resume, when the bound fixture's config surfaces post-full-time.
+  void _enterFullTimeResultReview() {
+    final config = scoreboardResultService.matchConfig;
+    if (config != null && _canSubmitScoreboardResult(config)) {
+      _fullTimeResultSignature = config.signature;
+    }
+    _requestScoreboardResultReview();
+  }
+
+  void _requestScoreboardResultReview() {
+    if (!needsScoreboardResultReview) return;
+    onRequestReviewScoreboardResult?.call();
+  }
+
+  ({
+    String matchCode,
+    String signature,
+    String homeName,
+    String awayName,
+    int homeGoals,
+    int awayGoals,
+  }) buildScoreboardResultReview() {
+    final config = scoreboardResultService.matchConfig;
+    final homeIsLeft = config?.homeIsLeft ?? true;
+    final defaultHomeTeamId = homeIsLeft ? 'A' : 'B';
+    final defaultAwayTeamId = homeIsLeft ? 'B' : 'A';
+    final homeTeamId = _scoreboardHomeTeamId ?? defaultHomeTeamId;
+    final awayTeamId = _scoreboardAwayTeamId ?? defaultAwayTeamId;
+
+    return (
+      matchCode: config?.matchCode ?? '',
+      // Full fixture+revision identity captured at review time, so a later
+      // same-code change (side swap / version bump) is detected on submit.
+      signature: config?.signature ?? '',
+      homeName: _teamNameById(homeTeamId) ?? config?.homeTeamName ?? 'Home',
+      awayName: _teamNameById(awayTeamId) ?? config?.awayTeamName ?? 'Away',
+      homeGoals: _scoreByTeamId(homeTeamId) ?? 0,
+      awayGoals: _scoreByTeamId(awayTeamId) ?? 0,
+    );
+  }
+
+  Future<bool> submitScoreboardResult({
+    required String expectedSignature,
+    required int homeGoals,
+    required int awayGoals,
+    String? comment,
+    required bool homeConfirmed,
+    required bool awayConfirmed,
+  }) async {
+    if (!_canSubmitScoreboardResult()) return false;
+
+    // Identity guard: the review screen captured its scores/team mapping for one
+    // fixture revision. Compare the FULL signature (code + version + side +
+    // names), not just the match code: a same-code config change (e.g. a side
+    // swap or version bump from an organizer edit, or a new link confirmed at
+    // full time) would otherwise post the captured scores against a changed
+    // mapping/version. Refuse so the referee re-opens a fresh review instead.
+    if (scoreboardResultService.matchConfig?.signature != expectedSignature) {
+      return false;
     }
 
-    final defaultHomeTeamId = config.homeIsLeft ? 'A' : 'B';
-    final defaultAwayTeamId = config.homeIsLeft ? 'B' : 'A';
-    final homeGoals = _scoreByTeamId(_scoreboardHomeTeamId ?? defaultHomeTeamId) ?? 0;
-    final awayGoals = _scoreByTeamId(_scoreboardAwayTeamId ?? defaultAwayTeamId) ?? 0;
-
-    unawaited(scoreboardResultService.enqueueFinalResult(
+    final trimmedComment = comment?.trim();
+    final submitted = await scoreboardResultService.enqueueFinalResult(
       homeGoals: homeGoals,
       awayGoals: awayGoals,
-      comment: 'Submitted via RCJ Soccer RefMate',
-    ));
+      comment: trimmedComment == null || trimmedComment.isEmpty
+          ? null
+          : trimmedComment,
+      homeConfirmed: homeConfirmed,
+      awayConfirmed: awayConfirmed,
+    );
+    notifyListeners();
+    return submitted;
   }
 
   int? _scoreByTeamId(String? teamId) {
@@ -1003,7 +1182,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     return null;
   }
 
-
+  String? _teamNameById(String? teamId) {
+    if (teamId == null) return null;
+    for (final team in teams) {
+      if (team.id == teamId) return team.name;
+    }
+    return null;
+  }
 
   void playAll(bool removeDamage) async {
     for (var team in teams) {
@@ -1034,8 +1219,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // isConnected is false while autoConnect keeps retrying. Without this a
       // "disconnect all" would skip those modules, leaving them retrying and
       // later consuming GATT slots after the referee asked to disconnect.
-      for (var module in team.modules.where(
-          (module) => module.isEnabled && (module.isConnected || module.isConnecting))) {
+      for (var module in team.modules.where((module) =>
+          module.isEnabled && (module.isConnected || module.isConnecting))) {
         module.bleDisconnect();
       }
     }
@@ -1048,8 +1233,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // — during a match these reconnects are unbounded on purpose (invariant #5).
   void disconnectInactiveModules() {
     for (var team in teams) {
-      for (var module in team.modules.where(
-          (module) => module.isEnabled && module.isConnecting)) {
+      for (var module in team.modules
+          .where((module) => module.isEnabled && module.isConnecting)) {
         module.bleDisconnect();
       }
     }
@@ -1340,5 +1525,4 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     notifyListeners();
   }
-
 }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1270,7 +1270,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       homeConfirmed: homeConfirmed,
       awayConfirmed: awayConfirmed,
     );
-    notifyListeners();
+    // enqueueFinalResult already notifies on every outcome it can change
+    // (queued / already-tracked), and Game listens to the service and re-emits,
+    // so no extra notifyListeners() is needed here.
     return submitted;
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -596,7 +596,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         }
         _lastAppliedScoreboardSignature = config.signature;
         _suppressScoreboardFinalResult = false;
-        _enterFullTimeResultReview();
+        // Arm the delivery-reset signature DIRECTLY here, not via
+        // _enterFullTimeResultReview's unresolved-result gate. That gate guards
+        // the LIVE full-time tick so a REPEAT of the same fixture isn't reset by
+        // the first run's late 200 (RAVF001). But a *restored* full-time match IS
+        // the exact match its queued result belongs to: if the app was killed
+        // after Submit but before the 200, the outbox already holds a pending
+        // item (hasUnresolvedResultFor → true), and the gate would leave the
+        // signature null so the genuine 200 would never reset/clear the finished
+        // match. Review *visibility* is governed separately by
+        // needsScoreboardResultReview's own unresolved-result clause, so arming
+        // here does not surface the review while a result is in flight.
+        if (_canSubmitScoreboardResult(config)) {
+          _fullTimeResultSignature = config.signature;
+        }
+        _requestScoreboardResultReview();
       } else {
         // Config not loaded yet (the service's unawaited initialize() races the
         // snapshot load) → keep suppressed; _applyScoreboardMatchConfig re-arms

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1310,6 +1310,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   void _persistOrClearAtFullTime() {
     if (needsScoreboardResultReview) {
       _flushMatchStateNow();
+    } else if (_suppressScoreboardFinalResult &&
+        (_resumedFixtureMatchCode?.isNotEmpty ?? false)) {
+      // A resumed referee match can reach full time while STILL suppressed (its
+      // bound fixture's config hasn't surfaced yet), so needsScoreboardResultReview
+      // can't be true at this tick. Clearing here would make a kill in the
+      // config-load window unrecoverable: there is no outbox item yet (nothing
+      // POSTs until Submit) and the snapshot would be gone. Keep the snapshot
+      // instead — _buildSnapshot still records it as a referee binding
+      // (pendingReferee), a full-time referee snapshot is routed to
+      // _restoreFullTimeResultReview on cold launch, and the late config re-arms
+      // and re-persists the review. Same durability contract as RAVF003,
+      // extended to the suppressed-resume sub-case (RAVF001).
+      _flushMatchStateNow();
     } else {
       _clearMatchState();
     }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1228,7 +1228,17 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// suppressed resume, when the bound fixture's config surfaces post-full-time.
   void _enterFullTimeResultReview() {
     final config = scoreboardResultService.matchConfig;
-    if (config != null && _canSubmitScoreboardResult(config)) {
+    if (config != null &&
+        _canSubmitScoreboardResult(config) &&
+        // Don't arm the reset signature while a prior result for the SAME
+        // fixture is still in flight. REPEAT replays the same fixture: gameInit
+        // nulls _fullTimeResultSignature but the service keeps _matchConfig, so
+        // the second run's full time would otherwise re-arm — and a late 200
+        // from the FIRST run (same code+version -> isCurrentFixture) would then
+        // reset/disconnect the live second match. The fixture token is
+        // single-use, so a still-unresolved prior result already owns it and the
+        // review stays correctly suppressed (RAVF001, REPEAT same-fixture).
+        !scoreboardResultService.hasUnresolvedResultFor(config.matchCode)) {
       _fullTimeResultSignature = config.signature;
     }
     _requestScoreboardResultReview();

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1106,7 +1106,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       return false;
     }
     if (!_canSubmitScoreboardResult(config)) return false;
-    return !scoreboardResultService.hasResultFor(config.matchCode);
+    // A terminally-rejected (HTTP 401/422) result must NOT hide the review:
+    // it is correctable, and enqueueFinalResult accepts a fresh re-submit, so
+    // the referee needs a route back to the review screen (RAVF002). Any other
+    // tracked state (pending / conflict / submitted / retry-exhausted) still
+    // suppresses the affordance.
+    return !scoreboardResultService.hasUnresolvedResultFor(config.matchCode);
   }
 
   /// Capture the just-ended fixture as the result-review subject, then raise the

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1396,6 +1396,30 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       homeConfirmed: homeConfirmed,
       awayConfirmed: awayConfirmed,
     );
+    if (submitted) {
+      // Persist the referee's (possibly corrected) review scores onto the live
+      // teams and the resumable snapshot now that an outbox item owns them.
+      // Without this, a terminal 401/422 rejection re-opens the review (via
+      // hasUnresolvedResultFor) reading the ORIGINAL teams[*].score, so the
+      // correction would be silently lost and a blind re-submit would re-send
+      // the wrong values (RAVF004). teams[*].score is a plain field (no
+      // MQTT/bridge broadcast), so this updates local truth + the snapshot
+      // only; the POST payload already carries the homeGoals/awayGoals passed
+      // above. Map via the captured side mapping, with the same homeIsLeft
+      // fallback buildScoreboardResultReview uses.
+      final homeIsLeft =
+          scoreboardResultService.matchConfig?.homeIsLeft ?? true;
+      final homeTeamId = _scoreboardHomeTeamId ?? (homeIsLeft ? 'A' : 'B');
+      final awayTeamId = _scoreboardAwayTeamId ?? (homeIsLeft ? 'B' : 'A');
+      for (final team in teams) {
+        if (team.id == homeTeamId) {
+          team.score = homeGoals;
+        } else if (team.id == awayTeamId) {
+          team.score = awayGoals;
+        }
+      }
+      _flushMatchStateNow();
+    }
     // enqueueFinalResult already notifies on every outcome it can change
     // (queued / already-tracked), and Game listens to the service and re-emits,
     // so no extra notifyListeners() is needed here.

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1311,7 +1311,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (needsScoreboardResultReview) {
       _flushMatchStateNow();
     } else if (_suppressScoreboardFinalResult &&
-        (_resumedFixtureMatchCode?.isNotEmpty ?? false)) {
+        (_resumedFixtureMatchCode?.isNotEmpty ?? false) &&
+        !scoreboardResultService
+            .hasUnresolvedResultFor(_resumedFixtureMatchCode!)) {
       // A resumed referee match can reach full time while STILL suppressed (its
       // bound fixture's config hasn't surfaced yet), so needsScoreboardResultReview
       // can't be true at this tick. Clearing here would make a kill in the
@@ -1322,6 +1324,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // _restoreFullTimeResultReview on cold launch, and the late config re-arms
       // and re-persists the review. Same durability contract as RAVF003,
       // extended to the suppressed-resume sub-case (RAVF001).
+      //
+      // Mirror the unresolved-result guard in _enterFullTimeResultReview /
+      // needsScoreboardResultReview: ONLY keep the snapshot when no outbox item
+      // already owns this fixture's result. If one does — e.g. a REPEAT second
+      // run resumed-and-suppressed while the FIRST run's submission is still
+      // pending — persisting and later restoring+arming this snapshot would let
+      // the first run's late 200 reset the wrong run, the exact REPEAT hazard
+      // RAVF001 guards against. In that case fall through to clear, leaving the
+      // pending item's own durability/ownership untouched.
       _flushMatchStateNow();
     } else {
       _clearMatchState();

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -922,6 +922,18 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// from inside the service's processOutbox, so resetting (which mutates the
   /// service) inline would be re-entrant.
   void _onScoreboardResultDelivered() {
+    // A queued result can be delivered (200) only AFTER the referee has already
+    // left the post-match screen — e.g. tapped REPEAT to start a fresh match,
+    // which keeps the committed binding so the late 200 still reads as the
+    // "current fixture" in the service. Resetting then would disconnectAll() +
+    // gameInit() the new, live in-progress match (RAVF001). Only reset while we
+    // are STILL on the exact full-time match this delivery belongs to: REPEAT /
+    // a new match move the stage off fullTime and clear the captured full-time
+    // signature (gameInit), so this guard cleanly distinguishes the two.
+    if (currentStage != MatchStage.fullTime ||
+        _fullTimeResultSignature == null) {
+      return;
+    }
     scheduleMicrotask(_resetAfterScoreboardSubmission);
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -109,7 +109,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   // Callback to request showing the dialog
   void Function()? onRequestSwitchTeamOrderDialog;
-  void Function()? onRequestReviewScoreboardResult;
+
+  // Callback to open the full-screen result review. A DRAINING setter (mirrors
+  // [onRequestResumeMatch]): a cold launch can restore a killed referee match
+  // that reached full time with an unsubmitted result (RAVF003) and raise the
+  // review BEFORE Home registers this callback in didChangeDependencies. Firing
+  // on assignment lets whichever happens last (restore vs registration) open the
+  // review. The registered callback re-checks needsScoreboardResultReview and is
+  // idempotent, so firing on every assignment is safe.
+  void Function()? _onRequestReviewScoreboardResult;
+  void Function()? get onRequestReviewScoreboardResult =>
+      _onRequestReviewScoreboardResult;
+  set onRequestReviewScoreboardResult(void Function()? callback) {
+    _onRequestReviewScoreboardResult = callback;
+    if (callback != null) _requestScoreboardResultReview();
+  }
 
   // Callback to request the confirm-on-load ("Load match?") dialog. A DRAINING
   // setter, mirroring [onRequestResumeMatch]: scoreboardResultService.initialize()
@@ -210,13 +224,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       }
     }
 
-    // A usable in-progress match (not already finished) → stash and prompt the
-    // referee. Stage fullTime means the match was over, so nothing to resume.
-    if (snapshot != null &&
-        snapshot.inGame &&
-        _stageFromName(snapshot.stage) != MatchStage.fullTime) {
-      _pendingResume = snapshot;
-      _maybeFireResumePrompt();
+    // A usable snapshot → either offer a resume (mid-match) or, for a referee
+    // match killed at full time before its result was submitted, restore enough
+    // to re-offer the result review (RAVF003). A non-referee fullTime snapshot
+    // is terminal — nothing to resume — and is ignored as before.
+    if (snapshot != null && snapshot.inGame) {
+      final stage = _stageFromName(snapshot.stage);
+      if (stage != MatchStage.fullTime) {
+        _pendingResume = snapshot;
+        _maybeFireResumePrompt();
+      } else if (snapshot.isRefereeMatch &&
+          (snapshot.scoreboardMatchCode?.isNotEmpty ?? false)) {
+        _restoreFullTimeResultReview(snapshot);
+      }
     }
 
     // Prompt for notification permission once on first launch (one-shot), now
@@ -502,6 +522,52 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     notifyListeners();
   }
 
+  /// Cold-launch restore of a referee match that was killed at full time with
+  /// an unsubmitted result (RAVF003). Restores only what the result review needs
+  /// — final scores, team names/order and the scoreboard binding — at stage
+  /// fullTime, then re-offers the review (now, or when the bound fixture's config
+  /// surfaces). Deliberately does NOT restore modules or reconnect: the match is
+  /// over and the robots are off; the only thing being recovered is the result.
+  /// The snapshot stays on disk until the result is delivered (reset clears it)
+  /// or the referee starts a fresh match (REPEAT), so even a second kill in this
+  /// window is survivable.
+  void _restoreFullTimeResultReview(MatchSnapshot snapshot) {
+    _suppressPersist = true;
+    try {
+      currentStage = MatchStage.fullTime;
+      inGame = true;
+      timerButtonText = snapshot.timerButtonText;
+      _remainingTime = snapshot.remainingTime;
+      isTimeRunning = false;
+      _isGameRunning = false;
+      _restoreTeamOrderAndInfo(snapshot.teams);
+
+      _scoreboardHomeTeamId = snapshot.scoreboardHomeTeamId;
+      _scoreboardAwayTeamId = snapshot.scoreboardAwayTeamId;
+      _resumedFixtureMatchCode = snapshot.scoreboardMatchCode;
+      _resumedFixtureVersion = snapshot.scoreboardVersion;
+
+      final config = scoreboardResultService.matchConfig;
+      if (config != null && config.matchCode == snapshot.scoreboardMatchCode) {
+        // The bound fixture's config is already loaded → arm now and offer the
+        // review immediately.
+        _lastAppliedScoreboardSignature = config.signature;
+        _suppressScoreboardFinalResult = false;
+        _enterFullTimeResultReview();
+      } else {
+        // Config not loaded yet (the service's unawaited initialize() races the
+        // snapshot load) → keep suppressed; _applyScoreboardMatchConfig re-arms
+        // and raises the review at fullTime once the bound fixture surfaces.
+        _suppressScoreboardFinalResult = true;
+      }
+
+      _broadcastFullState();
+    } finally {
+      _suppressPersist = false;
+    }
+    notifyListeners();
+  }
+
   void _restoreTeamOrderAndInfo(List<TeamSnapshot> teamSnaps) {
     // Game() always builds teams as [A, B]. A swapped match was reordered by
     // toggleTeamOrder() reversing the list, and _teamColorHex + the UI color
@@ -615,9 +681,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           // late penalty). In-match these reconnect unbounded on purpose; at
           // full time we settle the ones still off to "Disconnected".
           disconnectInactiveModules();
-          // Match just ended: clear the snapshot rather than persisting a
-          // fullTime one (item 2 made this transition a persist point).
-          _clearMatchState();
+          _persistOrClearAtFullTime();
           break;
         default:
           debugPrint('unknown match stage');
@@ -1071,8 +1135,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // The bound fixture's config only surfaced AFTER this resumed match had
       // already run to full-time while suppressed. Now that the bound fixture's
       // config is here, capture it as the review subject and surface the review
-      // flow instead of silently enqueueing.
+      // flow instead of silently enqueueing. The full-time tick cleared the
+      // snapshot while suppressed (nothing to review yet); re-persist it now so a
+      // kill before Submit can resume the review (RAVF003).
       _enterFullTimeResultReview();
+      _persistOrClearAtFullTime();
     }
   }
 
@@ -1127,7 +1194,23 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
   void _requestScoreboardResultReview() {
     if (!needsScoreboardResultReview) return;
-    onRequestReviewScoreboardResult?.call();
+    _onRequestReviewScoreboardResult?.call();
+  }
+
+  /// At full time (or when a suppressed resume's fixture config surfaces
+  /// post-full-time), decide whether to persist or clear the snapshot. A referee
+  /// match with an unsubmitted result PERSISTS a full-time review snapshot so a
+  /// kill before Submit can resume the review (RAVF003) — nothing POSTs from the
+  /// snapshot; it only keeps the result alive for re-submission. Otherwise the
+  /// match is terminal and the snapshot is cleared (the #45 contract that a
+  /// finished match isn't resumed). Once the result is submitted/delivered the
+  /// outbox owns durability and the reset (or REPEAT) clears the snapshot.
+  void _persistOrClearAtFullTime() {
+    if (needsScoreboardResultReview) {
+      _flushMatchStateNow();
+    } else {
+      _clearMatchState();
+    }
   }
 
   ({

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -99,6 +99,22 @@ class ScoreboardMatchConfig {
     );
   }
 
+  /// Stable identity of a fixture+revision as displayed/applied. Used to dedupe
+  /// the confirm-on-load prompt and to guard confirm/cancel/submit against
+  /// acting on a different fixture than the one a stale dialog/review is showing.
+  ///
+  /// Built via jsonEncode of an ordered field list (not a delimiter-joined
+  /// string) so values containing the separator — e.g. a team name with a ':'
+  /// — cannot collide with a different fixture.
+  String get signature => jsonEncode(<dynamic>[
+        matchCode,
+        version,
+        durationSeconds,
+        homeIsLeft,
+        homeTeamName,
+        awayTeamName,
+      ]);
+
   Map<String, dynamic> toJson() => {
         'match_code': matchCode,
         'home_team': homeTeamName,
@@ -120,6 +136,8 @@ class ResultOutboxItem {
   final String matchCode;
   final int homeGoals;
   final int awayGoals;
+  final bool homeConfirmed;
+  final bool awayConfirmed;
   final int version;
   final String idempotencyKey;
   final String? comment;
@@ -138,6 +156,8 @@ class ResultOutboxItem {
     required this.matchCode,
     required this.homeGoals,
     required this.awayGoals,
+    this.homeConfirmed = false,
+    this.awayConfirmed = false,
     required this.version,
     required this.idempotencyKey,
     this.comment,
@@ -156,6 +176,8 @@ class ResultOutboxItem {
     Map<String, dynamic>? responseBody,
     String? errorMessage,
     int? retryCount,
+    bool? homeConfirmed,
+    bool? awayConfirmed,
     // A plain nullable parameter cannot distinguish "leave unchanged" from "set
     // to null" (both arrive as null), so an explicit flag is needed to actively
     // clear the response/error fields — e.g. on a successful submit or when a
@@ -171,6 +193,8 @@ class ResultOutboxItem {
       matchCode: matchCode,
       homeGoals: homeGoals,
       awayGoals: awayGoals,
+      homeConfirmed: homeConfirmed ?? this.homeConfirmed,
+      awayConfirmed: awayConfirmed ?? this.awayConfirmed,
       version: version,
       idempotencyKey: idempotencyKey,
       comment: comment,
@@ -213,6 +237,8 @@ class ResultOutboxItem {
       matchCode: json['match_code'] as String? ?? '',
       homeGoals: (json['home_goals'] as num?)?.toInt() ?? 0,
       awayGoals: (json['away_goals'] as num?)?.toInt() ?? 0,
+      homeConfirmed: json['home_confirmed'] as bool? ?? false,
+      awayConfirmed: json['away_confirmed'] as bool? ?? false,
       version: (json['version'] as num?)?.toInt() ?? 0,
       idempotencyKey: json['idempotency_key'] as String,
       comment: json['comment'] as String?,
@@ -235,6 +261,8 @@ class ResultOutboxItem {
         'match_code': matchCode,
         'home_goals': homeGoals,
         'away_goals': awayGoals,
+        'home_confirmed': homeConfirmed,
+        'away_confirmed': awayConfirmed,
         'version': version,
         'idempotency_key': idempotencyKey,
         'comment': comment,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -4,12 +4,14 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/screens/module_settings.dart';
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/team.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:flutter/services.dart';
 import 'package:rcj_scoreboard/screens/settings.dart';
+import 'package:rcj_scoreboard/screens/scoreboard_result_review.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
 import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
 import 'package:rcj_scoreboard/widgets/scrolling_status_text.dart';
@@ -30,6 +32,8 @@ class _HomeState extends State<Home> {
   Game? _game;
   void Function()? _switchOrderCallback;
   void Function()? _resumeCallback;
+  void Function(ScoreboardMatchConfig config)? _confirmCallback;
+  void Function()? _reviewCallback;
 
   @override
   void didChangeDependencies() {
@@ -46,6 +50,8 @@ class _HomeState extends State<Home> {
       final callbacks = setupGameCallbacks(_game!, context);
       _switchOrderCallback = callbacks.switchOrder;
       _resumeCallback = callbacks.resume;
+      _confirmCallback = callbacks.confirm;
+      _reviewCallback = callbacks.review;
     }
   }
 
@@ -54,11 +60,18 @@ class _HomeState extends State<Home> {
     // Clear the dialog callbacks we installed so the long-lived Game does not
     // retain closures capturing this disposed State's context. Guard on
     // identity so we never clear a newer Home's callback.
-    if (identical(_game?.onRequestSwitchTeamOrderDialog, _switchOrderCallback)) {
+    if (identical(
+        _game?.onRequestSwitchTeamOrderDialog, _switchOrderCallback)) {
       _game?.onRequestSwitchTeamOrderDialog = null;
     }
     if (identical(_game?.onRequestResumeMatch, _resumeCallback)) {
       _game?.onRequestResumeMatch = null;
+    }
+    if (identical(_game?.onRequestConfirmScoreboardMatch, _confirmCallback)) {
+      _game?.onRequestConfirmScoreboardMatch = null;
+    }
+    if (identical(_game?.onRequestReviewScoreboardResult, _reviewCallback)) {
+      _game?.onRequestReviewScoreboardResult = null;
     }
     super.dispose();
   }
@@ -149,7 +162,7 @@ class _HomeState extends State<Home> {
               onPressed: () {
                 _navigateToSettings(context, game);
               },
-                // Navigate to config page
+              // Navigate to config page
             ),
           ],
         ),
@@ -186,7 +199,8 @@ class _HomeState extends State<Home> {
                         child: Column(
                           children: [
                             GestureDetector(
-                              onLongPress: () => _editRemainingTime(context, game),
+                              onLongPress: () =>
+                                  _editRemainingTime(context, game),
                               child: Text(
                                   '${(game.remainingTime ~/ 60).toString().padLeft(2, '0')}:${(game.remainingTime % 60).toString().padLeft(2, '0')}',
                                   style: const TextStyle(fontSize: 36.0)),
@@ -203,24 +217,51 @@ class _HomeState extends State<Home> {
                             ),
                             SizedBox(
                               width: double.infinity,
-                              child: CriticalButton(
-                                singleTap: game.singleTapEnabled,
-                                onAction: () => game.toggleTimer(),
-                                style: ElevatedButton.styleFrom(
-                                  minimumSize: const Size(0, 36),
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                    vertical: 8,
-                                  ),
-                                  backgroundColor: (game.isGameRunning
-                                      ? (game.isTimerRunning
-                                          ? AppColors.red
-                                          : AppColors.green)
-                                      : AppColors.green),
-                                ),
-                                child: Text(game.timerButtonText,
-                                    style: const TextStyle(color: Colors.white)),
-                              ),
+                              // For a deep-link (referee) match at full time the
+                              // one action is to SUBMIT the result, not REPEAT
+                              // the same fixture — so swap the timer button for
+                              // "Submit result". This also avoids stacking two
+                              // buttons in this narrow column (which overflowed).
+                              child: game.needsScoreboardResultReview
+                                  ? ElevatedButton(
+                                      onPressed: () =>
+                                          _openScoreboardResultReview(
+                                              context, game),
+                                      style: ElevatedButton.styleFrom(
+                                        minimumSize: const Size(0, 36),
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 8,
+                                          vertical: 8,
+                                        ),
+                                        backgroundColor: AppColors.blue,
+                                        foregroundColor: Colors.white,
+                                      ),
+                                      child: const FittedBox(
+                                        fit: BoxFit.scaleDown,
+                                        child: Text('Submit result',
+                                            style:
+                                                TextStyle(color: Colors.white)),
+                                      ),
+                                    )
+                                  : CriticalButton(
+                                      singleTap: game.singleTapEnabled,
+                                      onAction: () => game.toggleTimer(),
+                                      style: ElevatedButton.styleFrom(
+                                        minimumSize: const Size(0, 36),
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 12,
+                                          vertical: 8,
+                                        ),
+                                        backgroundColor: (game.isGameRunning
+                                            ? (game.isTimerRunning
+                                                ? AppColors.red
+                                                : AppColors.green)
+                                            : AppColors.green),
+                                      ),
+                                      child: Text(game.timerButtonText,
+                                          style: const TextStyle(
+                                              color: Colors.white)),
+                                    ),
                             )
                           ],
                         ),
@@ -386,20 +427,22 @@ Widget buildTeamContainer(Team team, Game game) {
                     heightFactor: 0.7,
                     child: Container(
                       color: Colors.grey[800],
-                      padding: const EdgeInsets.symmetric(vertical: 20.0, horizontal: 20.0),
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 20.0, horizontal: 20.0),
                       child: TeamSettingsWidget(team: team, game: game),
                     ),
                   );
                 });
           },
           child: Container(
-
             // color bar for displaying team top mark
             decoration: BoxDecoration(
               color: Colors.transparent,
               border: Border(
                 top: BorderSide(
-                  color: team.id == "A" ? const Color(0xFF77FF00) : const Color(0xFFFF00FF), // Neon green or neon magenta
+                  color: team.id == "A"
+                      ? const Color(0xFF77FF00)
+                      : const Color(0xFFFF00FF), // Neon green or neon magenta
                   width: 5,
                 ),
               ),
@@ -498,19 +541,6 @@ Widget buildTeamContainer(Team team, Game game) {
 //   );
 // }
 //
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 class TeamSettingsWidget extends StatefulWidget {
   final Team team;
@@ -657,7 +687,8 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
   @override
   void initState() {
     super.initState();
-    _timeController = TextEditingController(text: _format(widget.game.remainingTime));
+    _timeController =
+        TextEditingController(text: _format(widget.game.remainingTime));
   }
 
   @override
@@ -748,11 +779,26 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
   }
 }
 
-/// Installs the half-time "switch team order" dialog and the cold-resume prompt
-/// callbacks on [game], returning the exact closures assigned so the caller can
-/// clear them on dispose (both capture [context]).
-({void Function() switchOrder, void Function() resume}) setupGameCallbacks(
-    Game game, BuildContext context) {
+Future<void> _openScoreboardResultReview(
+    BuildContext context, Game game) async {
+  if (!game.needsScoreboardResultReview) return;
+  await Navigator.push(
+    context,
+    MaterialPageRoute(
+      builder: (context) => ScoreboardResultReviewScreen(game: game),
+    ),
+  );
+}
+
+/// Installs the half-time "switch team order", cold-resume, scoreboard-load,
+/// and scoreboard-result-review callbacks on [game], returning the exact
+/// closures assigned so the caller can clear them on dispose.
+({
+  void Function() switchOrder,
+  void Function() resume,
+  void Function(ScoreboardMatchConfig config) confirm,
+  void Function() review,
+}) setupGameCallbacks(Game game, BuildContext context) {
   // A local function declaration (not a `final ... = () {}` variable) to satisfy
   // the analyzer's prefer_function_declarations_over_variables lint, which CI
   // runs as fatal (`flutter analyze --fatal-infos`).
@@ -762,36 +808,41 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
       barrierDismissible: false,
       builder: (context) => AlertDialog(
         backgroundColor: Colors.grey[800],
-        title: const Text("Switch Team Order", style: TextStyle(color: Colors.white)),
-        content: const Text("Do you want to switch the team order for the second half?"),
-        actions: [Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Expanded(
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.grey[600],
+        title: const Text("Switch Team Order",
+            style: TextStyle(color: Colors.white)),
+        content: const Text(
+            "Do you want to switch the team order for the second half?"),
+        actions: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.grey[600],
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop(false); // Keep current order
+                  },
+                  child:
+                      const Text("No", style: TextStyle(color: Colors.white)),
                 ),
-                onPressed: () {
-                  Navigator.of(context).pop(false); // Keep current order
-                },
-                child: const Text("No", style: TextStyle(color: Colors.white)),
               ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.grey[600],
+              const SizedBox(width: 16),
+              Expanded(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.grey[600],
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop(true); // Switch order
+                  },
+                  child:
+                      const Text("Yes", style: TextStyle(color: Colors.white)),
                 ),
-                onPressed: () {
-                  Navigator.of(context).pop(true); // Switch order
-                },
-                child: const Text("Yes", style: TextStyle(color: Colors.white)),
               ),
-            ),
-          ],
-        ),
+            ],
+          ),
         ],
       ),
     );
@@ -800,6 +851,7 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
       game.toggleTeamOrder(); // Switch team order
     }
   }
+
   game.onRequestSwitchTeamOrderDialog = callback;
 
   // Cold-resume prompt (#45). Non-destructive: Resume is the prominent default;
@@ -819,61 +871,209 @@ class _TimeSettingsWidgetState extends State<TimeSettingsWidget> {
       await showDialog<void>(
         context: context,
         barrierDismissible: false,
-      builder: (dialogContext) => PopScope(
-        canPop: false,
-        child: AlertDialog(
-          backgroundColor: Colors.grey[800],
-          title: const Text('Resume match in progress?',
-              style: TextStyle(color: Colors.white)),
-          content: Text(_resumeMatchBody(snapshot),
-              style: const TextStyle(color: Colors.white)),
-          actions: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                Expanded(
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.grey[600],
-                    ),
-                    onPressed: () async {
-                      final confirmed = await _confirmDiscardMatch(dialogContext);
-                      if (confirmed == true) {
-                        await game.discardPendingMatch();
-                        if (dialogContext.mounted) {
-                          Navigator.of(dialogContext).pop();
+        builder: (dialogContext) => PopScope(
+          canPop: false,
+          child: AlertDialog(
+            backgroundColor: Colors.grey[800],
+            title: const Text('Resume match in progress?',
+                style: TextStyle(color: Colors.white)),
+            content: Text(_resumeMatchBody(snapshot),
+                style: const TextStyle(color: Colors.white)),
+            actions: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.grey[600],
+                      ),
+                      onPressed: () async {
+                        final confirmed =
+                            await _confirmDiscardMatch(dialogContext);
+                        if (confirmed == true) {
+                          await game.discardPendingMatch();
+                          if (dialogContext.mounted) {
+                            Navigator.of(dialogContext).pop();
+                          }
                         }
-                      }
-                    },
-                    child: const Text('Discard',
-                        style: TextStyle(color: Colors.white)),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.green[600],
+                      },
+                      child: const Text('Discard',
+                          style: TextStyle(color: Colors.white)),
                     ),
-                    onPressed: () {
-                      game.resumePendingMatch();
-                      Navigator.of(dialogContext).pop();
-                    },
-                    child: const Text('Resume',
-                        style: TextStyle(color: Colors.white)),
                   ),
-                ),
-              ],
-            ),
-          ],
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.green[600],
+                      ),
+                      onPressed: () {
+                        game.resumePendingMatch();
+                        Navigator.of(dialogContext).pop();
+                      },
+                      child: const Text('Resume',
+                          style: TextStyle(color: Colors.white)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
-      ),
       );
     });
   }
+
   game.onRequestResumeMatch = resumeCallback;
 
-  return (switchOrder: callback, resume: resumeCallback);
+  var confirmDialogOpen = false;
+  void confirmCallback(ScoreboardMatchConfig config) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // Re-entrancy guard (mirrors reviewRouteOpen): a second deep link arriving
+      // while this dialog is open must not stack a second dialog. The dialog's
+      // expectedSignature keeps its Load/Cancel bound to the match it displays,
+      // and onPendingMatchPromptClosed re-arms the prompt on close so a newer
+      // pending link is shown next.
+      if (confirmDialogOpen) return;
+      if (!context.mounted) return;
+      confirmDialogOpen = true;
+      // Capture the displayed match's identity so Load/Cancel can't act on a
+      // newer pending link that replaced it after this dialog was built.
+      final expectedSignature = config.signature;
+      final duration = _formatMatchDuration(config.durationSeconds);
+      final details = <String>[
+        if (config.venueShortName.isNotEmpty)
+          'Field ${config.venueShortName} · $duration'
+        else
+          duration,
+        if (game.inGame) '⚠ This replaces the match in progress.',
+      ];
+      try {
+        await showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) => PopScope(
+            canPop: false,
+            child: AlertDialog(
+              backgroundColor: Colors.grey[800],
+              title: const Text('Load match?',
+                  style: TextStyle(color: Colors.white)),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${config.homeTeamName} vs ${config.awayTeamName}',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final line in details)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        line,
+                        style: TextStyle(
+                          color: line.startsWith('⚠')
+                              ? Colors.orangeAccent
+                              : Colors.white70,
+                          fontWeight: line.startsWith('⚠')
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              actions: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.grey[600],
+                        ),
+                        onPressed: () {
+                          game.scoreboardResultService.cancelPendingMatch(
+                              expectedSignature: expectedSignature);
+                          Navigator.of(dialogContext).pop();
+                        },
+                        child: const Text('Cancel',
+                            style: TextStyle(color: Colors.white)),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green[600],
+                        ),
+                        onPressed: () async {
+                          await game.scoreboardResultService
+                              .confirmPendingMatch(
+                                  expectedSignature: expectedSignature);
+                          if (dialogContext.mounted) {
+                            Navigator.of(dialogContext).pop();
+                          }
+                        },
+                        child: const Text('Load',
+                            style: TextStyle(color: Colors.white)),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      } finally {
+        confirmDialogOpen = false;
+        // Re-arm: show a newer pending link that was suppressed while this
+        // dialog was open, or one a stale (no-op) action left unhandled.
+        game.onPendingMatchPromptClosed();
+      }
+    });
+  }
+
+  game.onRequestConfirmScoreboardMatch = confirmCallback;
+
+  var reviewRouteOpen = false;
+  void reviewCallback() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (reviewRouteOpen) return;
+      if (!context.mounted) return;
+      if (!game.needsScoreboardResultReview) return;
+      reviewRouteOpen = true;
+      try {
+        await _openScoreboardResultReview(context, game);
+      } finally {
+        reviewRouteOpen = false;
+      }
+    });
+  }
+
+  game.onRequestReviewScoreboardResult = reviewCallback;
+
+  return (
+    switchOrder: callback,
+    resume: resumeCallback,
+    confirm: confirmCallback,
+    review: reviewCallback,
+  );
+}
+
+/// Human-readable match length for the confirm-on-load dialog. Whole minutes
+/// show as "N min"; a sub-minute duration shows as "N s" (never the misleading
+/// "0 min" that `seconds ~/ 60` produces for e.g. a 30 s test match); a mixed
+/// duration shows "N min M s".
+String _formatMatchDuration(int seconds) {
+  if (seconds <= 0) return '0 s';
+  final minutes = seconds ~/ 60;
+  final secs = seconds % 60;
+  if (minutes == 0) return '$secs s';
+  if (secs == 0) return '$minutes min';
+  return '$minutes min $secs s';
 }
 
 String _resumeMatchBody(MatchSnapshot snapshot) {
@@ -913,8 +1113,8 @@ Future<bool?> _confirmDiscardMatch(BuildContext context) {
       canPop: false,
       child: AlertDialog(
         backgroundColor: Colors.grey[800],
-        title: const Text('Discard match?',
-            style: TextStyle(color: Colors.white)),
+        title:
+            const Text('Discard match?', style: TextStyle(color: Colors.white)),
         content: const Text(
             'This permanently deletes the saved match and cannot be undone.',
             style: TextStyle(color: Colors.white)),

--- a/lib/screens/scoreboard_result_review.dart
+++ b/lib/screens/scoreboard_result_review.dart
@@ -1,0 +1,382 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/utils/colors.dart';
+import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
+
+/// Outcome of a submit attempt, derived from the outbox item's state shortly
+/// after enqueuing, so the referee gets a clear message about what happened.
+enum _SubmitOutcome { sent, conflict, rejected, queued }
+
+class ScoreboardResultReviewScreen extends StatefulWidget {
+  final Game game;
+
+  const ScoreboardResultReviewScreen({required this.game, super.key});
+
+  @override
+  State<ScoreboardResultReviewScreen> createState() =>
+      _ScoreboardResultReviewScreenState();
+}
+
+class _ScoreboardResultReviewScreenState
+    extends State<ScoreboardResultReviewScreen> {
+  late final ({
+    String matchCode,
+    String signature,
+    String homeName,
+    String awayName,
+    int homeGoals,
+    int awayGoals,
+  }) _review;
+  late int _homeGoals;
+  late int _awayGoals;
+  bool _homeConfirmed = false;
+  bool _awayConfirmed = false;
+  bool _submitting = false;
+  final TextEditingController _commentController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _review = widget.game.buildScoreboardResultReview();
+    _homeGoals = _review.homeGoals;
+    _awayGoals = _review.awayGoals;
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  int _clampScore(int value) => value < 0 ? 0 : value;
+
+  Future<void> _submit() async {
+    if (_submitting) return;
+    // Capture before the async gaps so we never touch a stale context after the
+    // screen pops (the SnackBar rides the app-root messenger and survives it).
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    setState(() => _submitting = true);
+
+    final enqueued = await widget.game.submitScoreboardResult(
+      expectedSignature: _review.signature,
+      homeGoals: _homeGoals,
+      awayGoals: _awayGoals,
+      comment: _commentController.text,
+      homeConfirmed: _homeConfirmed,
+      awayConfirmed: _awayConfirmed,
+    );
+    if (!mounted) return;
+    if (!enqueued) {
+      setState(() => _submitting = false);
+      messenger.showSnackBar(const SnackBar(
+        content: Text(
+            'Could not submit — the result may already be submitted or the '
+            'match changed.'),
+      ));
+      return;
+    }
+
+    // The result is now queued; the POST runs in the background. Watch the
+    // outbox item briefly so we can tell the referee the actual outcome.
+    final outcome = await _awaitOutcome(_review.matchCode);
+    if (!mounted) return;
+    messenger.showSnackBar(SnackBar(content: Text(_outcomeMessage(outcome))));
+    navigator.pop();
+  }
+
+  /// Poll the outbox for this match's item and classify its state. On a 200 the
+  /// reset to the clean start state fires separately; on a conflict/rejection
+  /// the match stays on the home screen with its error status so the referee can
+  /// decide. A still-pending item (offline / slow) is reported as queued.
+  Future<_SubmitOutcome> _awaitOutcome(String matchCode) async {
+    final service = widget.game.scoreboardResultService;
+    for (var i = 0; i < 20; i++) {
+      ResultOutboxItem? item;
+      for (final entry in service.outbox) {
+        if (entry.matchCode == matchCode) item = entry;
+      }
+      if (item != null) {
+        switch (item.state) {
+          case ResultSubmissionState.submitted:
+            return _SubmitOutcome.sent;
+          case ResultSubmissionState.conflict:
+            return _SubmitOutcome.conflict;
+          case ResultSubmissionState.failed:
+            return _SubmitOutcome.rejected;
+          case ResultSubmissionState.pending:
+            break;
+        }
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+    return _SubmitOutcome.queued;
+  }
+
+  String _outcomeMessage(_SubmitOutcome outcome) {
+    switch (outcome) {
+      case _SubmitOutcome.sent:
+        return 'Result sent successfully ✓';
+      case _SubmitOutcome.conflict:
+        return 'Already recorded on the server — check the status to decide.';
+      case _SubmitOutcome.rejected:
+        return 'Submission rejected — the link may be invalid or expired.';
+      case _SubmitOutcome.queued:
+        return 'No connection — saved and will send automatically.';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        iconTheme: const IconThemeData(color: Colors.white),
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Submit result',
+                style: TextStyle(color: Colors.white, fontSize: 18)),
+            Text(
+              _review.matchCode,
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // ---- Final result ---- (team names live here, so no separate
+              // header line above is needed)
+              _sectionHeader(
+                'Final result',
+                'The score sent to the scoreboard. Correct it here if needed.',
+              ),
+              _scoreEditor(
+                label: _review.homeName,
+                value: _homeGoals,
+                onChanged: (value) =>
+                    setState(() => _homeGoals = _clampScore(value)),
+              ),
+              const SizedBox(height: 10),
+              _scoreEditor(
+                label: _review.awayName,
+                value: _awayGoals,
+                onChanged: (value) =>
+                    setState(() => _awayGoals = _clampScore(value)),
+              ),
+              const SizedBox(height: 18),
+
+              // ---- Team confirmation ----
+              _sectionHeader(
+                'Team confirmation',
+                'Tick a team that agrees with the result.',
+              ),
+              _confirmTile(
+                name: _review.homeName,
+                value: _homeConfirmed,
+                onChanged: (value) =>
+                    setState(() => _homeConfirmed = value ?? false),
+              ),
+              _confirmTile(
+                name: _review.awayName,
+                value: _awayConfirmed,
+                onChanged: (value) =>
+                    setState(() => _awayConfirmed = value ?? false),
+              ),
+              const SizedBox(height: 18),
+
+              // ---- Comment ----
+              _sectionHeader(
+                'Comment',
+                'Notes about the match (e.g. a protest or incident).',
+              ),
+              TextField(
+                controller: _commentController,
+                minLines: 2,
+                maxLines: 3,
+                style: const TextStyle(color: Colors.white),
+                decoration: InputDecoration(
+                  hintText: 'Add a note…',
+                  hintStyle: const TextStyle(color: Colors.white38),
+                  isDense: true,
+                  filled: true,
+                  fillColor: Colors.grey[850],
+                  border: const OutlineInputBorder(),
+                  enabledBorder: const OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.white24),
+                  ),
+                  focusedBorder: const OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.white70),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _submitting
+                          ? null
+                          : () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.arrow_back),
+                      label: const Text('Cancel'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: const BorderSide(color: Colors.white54),
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    // Submit is a deliberate, post-match action (not an in-match
+                    // robot/score/timer control), so the double-tap accidental-
+                    // touch guard isn't needed here — always single-tap.
+                    child: CriticalButton(
+                      singleTap: true,
+                      onAction:
+                          _submitting ? () {} : () => unawaited(_submit()),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.green,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          if (_submitting)
+                            const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor:
+                                    AlwaysStoppedAnimation<Color>(Colors.white),
+                              ),
+                            )
+                          else
+                            const Icon(Icons.send),
+                          const SizedBox(width: 8),
+                          Text(_submitting ? 'Sending…' : 'Submit'),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Section heading in the app's white/gray scheme — a thin rule for visual
+  // separation (instead of a coloured title) plus a white label and gray hint.
+  Widget _sectionHeader(String title, String hint) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Divider(color: Colors.white24, height: 1, thickness: 1),
+          const SizedBox(height: 10),
+          Text(
+            title.toUpperCase(),
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.1,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            hint,
+            style: const TextStyle(color: Colors.white54, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _confirmTile({
+    required String name,
+    required bool value,
+    required ValueChanged<bool?> onChanged,
+  }) {
+    return CheckboxListTile(
+      value: value,
+      onChanged: onChanged,
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      title: Text(name, style: const TextStyle(color: Colors.white)),
+      subtitle: const Text(
+        'Confirmed by team',
+        style: TextStyle(color: Colors.white70),
+      ),
+      activeColor: AppColors.green,
+      checkColor: Colors.black,
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  Widget _scoreEditor({
+    required String label,
+    required int value,
+    required ValueChanged<int> onChanged,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.white24),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white, fontSize: 16),
+            ),
+          ),
+          IconButton(
+            onPressed: () => onChanged(value - 1),
+            icon: const Icon(Icons.remove_circle_outline),
+            color: Colors.white,
+          ),
+          SizedBox(
+            width: 44,
+            child: Text(
+              value.toString(),
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 24,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          IconButton(
+            onPressed: () => onChanged(value + 1),
+            icon: const Icon(Icons.add_circle_outline),
+            color: Colors.white,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/scoreboard_result_review.dart
+++ b/lib/screens/scoreboard_result_review.dart
@@ -88,32 +88,25 @@ class _ScoreboardResultReviewScreenState
     navigator.pop();
   }
 
-  /// Poll the outbox for this match's item and classify its state. On a 200 the
-  /// reset to the clean start state fires separately; on a conflict/rejection
-  /// the match stays on the home screen with its error status so the referee can
-  /// decide. A still-pending item (offline / slow) is reported as queued.
+  /// Watch the outbox for this match's outcome. On a 200 the reset to the clean
+  /// start state fires separately; on a conflict/rejection the match stays on
+  /// the home screen with its error status so the referee can decide. A
+  /// still-pending item at the deadline (offline OR a slow-but-succeeding POST —
+  /// the request timeout is longer than this poll) is reported as queued.
   Future<_SubmitOutcome> _awaitOutcome(String matchCode) async {
-    final service = widget.game.scoreboardResultService;
-    for (var i = 0; i < 20; i++) {
-      ResultOutboxItem? item;
-      for (final entry in service.outbox) {
-        if (entry.matchCode == matchCode) item = entry;
-      }
-      if (item != null) {
-        switch (item.state) {
-          case ResultSubmissionState.submitted:
-            return _SubmitOutcome.sent;
-          case ResultSubmissionState.conflict:
-            return _SubmitOutcome.conflict;
-          case ResultSubmissionState.failed:
-            return _SubmitOutcome.rejected;
-          case ResultSubmissionState.pending:
-            break;
-        }
-      }
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+    final state =
+        await widget.game.scoreboardResultService.awaitOutboxOutcome(matchCode);
+    switch (state) {
+      case ResultSubmissionState.submitted:
+        return _SubmitOutcome.sent;
+      case ResultSubmissionState.conflict:
+        return _SubmitOutcome.conflict;
+      case ResultSubmissionState.failed:
+        return _SubmitOutcome.rejected;
+      case ResultSubmissionState.pending:
+      case null:
+        return _SubmitOutcome.queued;
     }
-    return _SubmitOutcome.queued;
   }
 
   String _outcomeMessage(_SubmitOutcome outcome) {
@@ -125,7 +118,11 @@ class _ScoreboardResultReviewScreenState
       case _SubmitOutcome.rejected:
         return 'Submission rejected — the link may be invalid or expired.';
       case _SubmitOutcome.queued:
-        return 'No connection — saved and will send automatically.';
+        // The item is still pending at the deadline: this is EITHER offline OR
+        // a slow-but-succeeding POST (the request timeout outlives this poll),
+        // so the wording must not assert "no connection". It is saved either way
+        // and the persistent status corrects to ✓ once it lands.
+        return 'Saved — sending in the background.';
     }
   }
 

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -14,7 +14,8 @@ class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key, required this.game});
 
   @override
-  State<SettingsScreen> createState() => _SettingsScreenState();}
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
 
 class _SettingsScreenState extends State<SettingsScreen> {
   late SetItem _selectedGameDuration;
@@ -54,14 +55,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _selectedGameDuration =
-        _gameDurations.firstWhere((item) => item.values == widget.game.periodTime, orElse: () => _gameDurations[4]);
-    _selectedHalftimeBreak = _halftimeBreaks.firstWhere((item) => item.values == widget.game.halfTimeDuration,
+    _selectedGameDuration = _gameDurations.firstWhere(
+        (item) => item.values == widget.game.periodTime,
+        orElse: () => _gameDurations[4]);
+    _selectedHalftimeBreak = _halftimeBreaks.firstWhere(
+        (item) => item.values == widget.game.halfTimeDuration,
         orElse: () => _halftimeBreaks[2]);
-    _selectedNumberOfPlayers = _numberOfPlayersList.firstWhere((item) => item.values == widget.game.numberOfPlayers,
+    _selectedNumberOfPlayers = _numberOfPlayersList.firstWhere(
+        (item) => item.values == widget.game.numberOfPlayers,
         orElse: () => _numberOfPlayersList[1]);
-    _selectedPenaltyTime =
-        _penaltyTimes.firstWhere((item) => item.values == widget.game.penaltyTime, orElse: () => _penaltyTimes[1]);
+    _selectedPenaltyTime = _penaltyTimes.firstWhere(
+        (item) => item.values == widget.game.penaltyTime,
+        orElse: () => _penaltyTimes[1]);
   }
 
   @override
@@ -157,9 +162,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                 ),
                                 SettingStatus(
                                   title: 'Venue',
-                                  status: config?.venueShortName.isNotEmpty == true
-                                      ? config!.venueShortName
-                                      : 'Not loaded',
+                                  status:
+                                      config?.venueShortName.isNotEmpty == true
+                                          ? config!.venueShortName
+                                          : 'Not loaded',
                                 ),
                                 SettingStatus(
                                   title: 'Outbox',
@@ -184,7 +190,53 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                   title: 'Clear linked match',
                                   buttonText: 'Clear',
                                   onPressed: () {
-                                    service.clearLinkedMatchData();
+                                    // Clearing wipes the whole outbox. Confirm
+                                    // first if any results haven't been
+                                    // confirmed sent, so a stray tap can't
+                                    // silently discard undelivered results
+                                    // (RAVF003). Nothing undelivered → clear
+                                    // straight away (no friction).
+                                    final undelivered =
+                                        service.undeliveredCount;
+                                    if (undelivered == 0) {
+                                      service.clearLinkedMatchData();
+                                      return;
+                                    }
+                                    final plural = undelivered == 1 ? '' : 's';
+                                    showDialog(
+                                      context: context,
+                                      builder: (ctx) => AlertDialog(
+                                        title:
+                                            const Text('Clear linked match?'),
+                                        content: Text(
+                                          '$undelivered result$plural '
+                                          '${undelivered == 1 ? 'has' : 'have'} '
+                                          'not been confirmed sent to the '
+                                          'scoreboard yet. Clearing the linked '
+                                          'match permanently discards '
+                                          '${undelivered == 1 ? 'it' : 'them'} '
+                                          '— ${undelivered == 1 ? 'it' : 'they'} '
+                                          'will not be sent.',
+                                        ),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(ctx).pop(),
+                                            child: const Text('Cancel'),
+                                          ),
+                                          TextButton(
+                                            style: TextButton.styleFrom(
+                                              foregroundColor: Colors.red,
+                                            ),
+                                            onPressed: () {
+                                              Navigator.of(ctx).pop();
+                                              service.clearLinkedMatchData();
+                                            },
+                                            child: const Text('Clear anyway'),
+                                          ),
+                                        ],
+                                      ),
+                                    );
                                   },
                                 ),
                               ],
@@ -255,7 +307,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                             ? 'Connecting...'
                                             : bridgeState ==
                                                     BridgeConnectionState.error
-                                                ? (widget.game.bleBridgeService.lastErrorMessage ?? 'Error')
+                                                ? (widget.game.bleBridgeService
+                                                        .lastErrorMessage ??
+                                                    'Error')
                                                 : 'Disconnected',
                                   ),
                                   SettingInputField(
@@ -625,7 +679,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             ),
                             Padding(
                               padding: EdgeInsets.symmetric(vertical: 4.0),
-                              child: Text('AI co-authors: Claude (Anthropic) '
+                              child: Text(
+                                  'AI co-authors: Claude (Anthropic) '
                                   '& Codex (OpenAI) '
                                   '& GitHub Copilot (Microsoft)',
                                   style: TextStyle(fontSize: 14)),
@@ -678,7 +733,8 @@ class SettingsSection extends StatelessWidget {
   final ValueChanged<bool>? onToggle;
 
   const SettingsSection(
-      {super.key, required this.title,
+      {super.key,
+      required this.title,
       required this.settings,
       this.locked = false,
       this.enabled,
@@ -698,7 +754,8 @@ class SettingsSection extends StatelessWidget {
               Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
                 Text(
                   title,
-                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  style: const TextStyle(
+                      fontSize: 18, fontWeight: FontWeight.bold),
                 ),
                 if (enabled != null && onToggle != null)
                   Switch(
@@ -724,7 +781,8 @@ class SettingDropdownButton extends StatelessWidget {
   final List<SetItem> options;
   final ValueChanged<SetItem?> onChanged;
 
-  const SettingDropdownButton({super.key,
+  const SettingDropdownButton({
+    super.key,
     required this.title,
     required this.value,
     required this.options,
@@ -764,7 +822,8 @@ class SettingButton extends StatelessWidget {
   final String buttonText;
   final Function()? onPressed;
 
-  const SettingButton({super.key,
+  const SettingButton({
+    super.key,
     required this.title,
     required this.buttonText,
     required this.onPressed,
@@ -785,7 +844,8 @@ class SettingButton extends StatelessWidget {
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.grey[700],
               ),
-              child: Text(buttonText, style: const TextStyle(color: Colors.white)),
+              child:
+                  Text(buttonText, style: const TextStyle(color: Colors.white)),
             ),
           )
         ],
@@ -842,7 +902,8 @@ class SettingInputField extends StatefulWidget {
   final ValueChanged<String> onChanged;
   final bool isPassword;
 
-  const SettingInputField({super.key,
+  const SettingInputField({
+    super.key,
     required this.title,
     required this.initialValue,
     required this.onChanged,
@@ -850,7 +911,7 @@ class SettingInputField extends StatefulWidget {
   });
 
   @override
-  State <SettingInputField> createState() => _SettingInputFieldState();
+  State<SettingInputField> createState() => _SettingInputFieldState();
 }
 
 class _SettingInputFieldState extends State<SettingInputField> {
@@ -925,7 +986,7 @@ class SettingStatus extends StatefulWidget {
   const SettingStatus({super.key, required this.title, required this.status});
 
   @override
-  State <SettingStatus> createState() => _SettingStatusState();
+  State<SettingStatus> createState() => _SettingStatusState();
 }
 
 class _SettingStatusState extends State<SettingStatus> {
@@ -1115,7 +1176,10 @@ class SetItem {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is SetItem && runtimeType == other.runtimeType && values == other.values && name == other.name;
+      other is SetItem &&
+          runtimeType == other.runtimeType &&
+          values == other.values &&
+          name == other.name;
 
   @override
   int get hashCode => values.hashCode ^ name.hashCode;
@@ -1197,7 +1261,8 @@ class _ModulePresetsSectionState extends State<ModulePresetsSection> {
     widget.game.applyPreset(preset);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Loaded "${preset.name}" – connecting robots...')),
+        SnackBar(
+            content: Text('Loaded "${preset.name}" – connecting robots...')),
       );
     }
   }

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -104,6 +104,29 @@ class ScoreboardResultService with ChangeNotifier {
   static bool _isTerminalRejection(ResultOutboxItem item) =>
       item.state == ResultSubmissionState.failed &&
       (item.responseStatus == 401 || item.responseStatus == 422);
+
+  /// Polls this match's outbox item until it reaches a terminal state
+  /// (submitted / conflict / failed) or [timeout] elapses, returning that
+  /// state — or null if the item is still pending (offline / slow) at the
+  /// deadline. Centralizes the busy-poll the review screen used inline.
+  Future<ResultSubmissionState?> awaitOutboxOutcome(
+    String matchCode, {
+    Duration timeout = const Duration(seconds: 4),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      ResultOutboxItem? item;
+      for (final entry in _outbox) {
+        if (entry.matchCode == matchCode) item = entry;
+      }
+      if (item != null && item.state != ResultSubmissionState.pending) {
+        return item.state;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    return null;
+  }
+
   bool get hasConflict => conflictCount > 0;
   int get pendingCount => _outbox
       .where((item) => item.state == ResultSubmissionState.pending)

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -142,6 +142,14 @@ class ScoreboardResultService with ChangeNotifier {
   int get submittedCount => _outbox
       .where((item) => item.state == ResultSubmissionState.submitted)
       .length;
+
+  /// Outbox items NOT yet confirmed delivered to the scoreboard (anything other
+  /// than a 200/submitted: pending, conflict, or failed). Used to warn before
+  /// "Clear linked match" — which calls [clearLinkedMatchData] and wipes the
+  /// whole outbox — permanently discards undelivered results (RAVF003).
+  int get undeliveredCount => _outbox
+      .where((item) => item.state != ResultSubmissionState.submitted)
+      .length;
   List<ResultOutboxItem> get outbox => List.unmodifiable(_outbox);
 
   Future<void> initialize() async {

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -89,6 +89,11 @@ class ScoreboardResultService with ChangeNotifier {
   }
 
   bool get hasToken => _token != null && _token!.isNotEmpty;
+
+  /// Whether [matchCode] has ANY outbox item, in any state (the audit-trail
+  /// view). The review gate uses [hasUnresolvedResultFor] instead, so this is
+  /// retained only for tests asserting an item was recorded.
+  @visibleForTesting
   bool hasResultFor(String matchCode) =>
       _outbox.any((item) => item.matchCode == matchCode);
 

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -24,6 +24,8 @@ class ScoreboardResultService with ChangeNotifier {
 
   final AppLinks _appLinks = AppLinks();
   final Uuid _uuid = const Uuid();
+  final http.Client _httpClient;
+  final bool _ownsHttpClient;
 
   SharedPreferences? _prefs;
   StreamSubscription<Uri>? _linkSub;
@@ -32,13 +34,28 @@ class ScoreboardResultService with ChangeNotifier {
   String? _token;
   Uri _baseUri = _defaultBaseUri;
   ScoreboardMatchConfig? _matchConfig;
+  String? _pendingToken;
+  Uri? _pendingBaseUri;
+  ScoreboardMatchConfig? _pendingMatchConfig;
   List<ResultOutboxItem> _outbox = [];
   bool _isSubmitting = false;
   String _statusMessage = 'Awaiting link';
 
+  /// Fired once when the CURRENTLY-linked match's result is confirmed delivered
+  /// (HTTP 200). Lets the app return to its clean start state only after a
+  /// successful submission — never on a queued/failed/conflicted one (those keep
+  /// the match on screen with its error status so the referee can decide). Not
+  /// fired for a late response that belongs to an already-replaced match.
+  void Function()? onCurrentResultDelivered;
+
+  ScoreboardResultService({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client(),
+        _ownsHttpClient = httpClient == null;
+
   String _authValue(String token) => '$_bearerScheme $token';
 
   ScoreboardMatchConfig? get matchConfig => _matchConfig;
+  ScoreboardMatchConfig? get pendingMatchConfig => _pendingMatchConfig;
   String get statusMessage => _statusMessage;
 
   /// Test-only seam: simulate a match config (and its credentials) surfacing
@@ -57,10 +74,27 @@ class ScoreboardResultService with ChangeNotifier {
     if (baseUri != null) _baseUri = baseUri;
     notifyListeners();
   }
+
+  @visibleForTesting
+  void debugApplyPendingMatchConfig(
+    ScoreboardMatchConfig config, {
+    required String token,
+    required Uri baseUri,
+  }) {
+    _pendingToken = token;
+    _pendingBaseUri = baseUri;
+    _pendingMatchConfig = config;
+    _statusMessage = 'Confirm to load match';
+    notifyListeners();
+  }
+
   bool get hasToken => _token != null && _token!.isNotEmpty;
+  bool hasResultFor(String matchCode) =>
+      _outbox.any((item) => item.matchCode == matchCode);
   bool get hasConflict => conflictCount > 0;
-  int get pendingCount =>
-      _outbox.where((item) => item.state == ResultSubmissionState.pending).length;
+  int get pendingCount => _outbox
+      .where((item) => item.state == ResultSubmissionState.pending)
+      .length;
   int get conflictCount => _outbox
       .where((item) => item.state == ResultSubmissionState.conflict)
       .length;
@@ -117,14 +151,22 @@ class ScoreboardResultService with ChangeNotifier {
       // defaults until the background refresh returns or times out. The
       // stale-response guard in refreshMatchConfig keeps the eventual network
       // result authoritative.
-      if (_matchConfig != null) {
+      // Restore a persistent "✓ Submitted" confirmation from the stored outbox
+      // so a delivered result still reads as sent after an app restart (Part C),
+      // rather than reverting to a generic status the background refresh sets.
+      final submitted = _submittedStatusForCommittedMatch();
+      if (submitted != null) {
+        _statusMessage = submitted;
+      }
+      if (_matchConfig != null || submitted != null) {
         notifyListeners();
       }
       unawaited(refreshMatchConfig().catchError((error) {
         debugPrint('ScoreboardResultService: initial refresh failed: $error');
       }));
       unawaited(processOutbox().catchError((error) {
-        debugPrint('ScoreboardResultService: initial outbox run failed: $error');
+        debugPrint(
+            'ScoreboardResultService: initial outbox run failed: $error');
       }));
     } else if (_matchConfig != null) {
       _statusMessage = 'Stored match ready';
@@ -135,6 +177,9 @@ class ScoreboardResultService with ChangeNotifier {
   void disposeService() {
     _retryTimer?.cancel();
     _linkSub?.cancel();
+    if (_ownsHttpClient) {
+      _httpClient.close();
+    }
   }
 
   Future<void> _attachDeepLinkListener() async {
@@ -151,7 +196,8 @@ class ScoreboardResultService with ChangeNotifier {
     _linkSub = _appLinks.uriLinkStream.listen(
       (uri) {
         unawaited(handleDeepLink(uri).catchError((error) {
-          debugPrint('ScoreboardResultService: deep link handling failed: $error');
+          debugPrint(
+              'ScoreboardResultService: deep link handling failed: $error');
         }));
       },
       onError: (error) =>
@@ -166,26 +212,15 @@ class ScoreboardResultService with ChangeNotifier {
     final rawToken = parsed.token;
     if (rawToken.isEmpty) return;
 
-    final tokenChanged = rawToken != _token;
-    _token = rawToken;
-    _baseUri = parsed.baseUri;
-    _statusMessage = 'Link received';
-
-    if (tokenChanged) {
-      // Drop the previous match config the moment a different link arrives, so a
-      // slow or failing fetch under the new token cannot leave the new token
-      // paired with the old match's matchCode/version (which enqueueFinalResult
-      // would otherwise submit). The new config is repopulated by the fetch
-      // below on success.
-      _matchConfig = null;
-      await _prefs?.remove(_prefsMatchKey);
-    }
-
-    await _prefs?.setString(_prefsTokenKey, rawToken);
-    await _prefs?.setString(_prefsBaseUrlKey, _baseUri.toString());
-
+    _pendingToken = rawToken;
+    _pendingBaseUri = parsed.baseUri;
+    _pendingMatchConfig = null;
+    _statusMessage = 'Confirm to load match';
     notifyListeners();
-    await refreshMatchConfig();
+    await _fetchPendingMatchConfig(
+      token: rawToken,
+      requestBase: parsed.baseUri,
+    );
   }
 
   /// Parses HTTPS referee links and the custom `rcjrefmate://r/<token>` links.
@@ -270,6 +305,45 @@ class ScoreboardResultService with ChangeNotifier {
     return false;
   }
 
+  /// GET the match config for [token]/[requestBase] and map the HTTP outcome to
+  /// a parsed config (on 200) plus a human status string. Pure network+parse;
+  /// the stale-response guard and which field (committed vs pending) to write is
+  /// the caller's responsibility, since each path tracks a different identity.
+  ///
+  /// `status` is only consumed on the FAILURE branches (config == null) — both
+  /// callers set their own success message (the committed path prefers a
+  /// persisted "✓ Submitted", the pending path shows "Confirm to load match").
+  Future<({ScoreboardMatchConfig? config, String status})> _requestMatchConfig(
+    String token,
+    Uri requestBase,
+  ) async {
+    final endpoint = requestBase.replace(path: '/api/v1/soccer/match/');
+    try {
+      final response = await _httpClient.get(
+        endpoint,
+        headers: {'Authorization': _authValue(token)},
+      ).timeout(_requestTimeout);
+
+      if (response.statusCode == 200) {
+        final decoded = jsonDecode(response.body);
+        if (decoded is Map<String, dynamic>) {
+          return (
+            config: ScoreboardMatchConfig.fromJson(decoded),
+            status: 'Match loaded',
+          );
+        }
+        return (config: null, status: 'Bad match data');
+      } else if (response.statusCode == 401) {
+        return (config: null, status: 'Link expired');
+      } else {
+        return (config: null, status: 'Load failed (${response.statusCode})');
+      }
+    } catch (e) {
+      debugPrint('ScoreboardResultService: match load failed: $e');
+      return (config: null, status: 'Load failed (net)');
+    }
+  }
+
   Future<void> refreshMatchConfig() async {
     final token = _token;
     if (token == null || token.isEmpty) {
@@ -279,49 +353,145 @@ class ScoreboardResultService with ChangeNotifier {
     }
 
     final requestBase = _baseUri;
-    final endpoint = requestBase.replace(path: '/api/v1/soccer/match/');
+    final outcome = await _requestMatchConfig(token, requestBase);
 
-    try {
-      final response = await http
-          .get(
-            endpoint,
-            headers: {'Authorization': _authValue(token)},
-          )
-          .timeout(_requestTimeout);
+    // Discard a stale response: a newer link or a clear may have changed the
+    // active token/base URL while this request was in flight. Applying it now
+    // would pair the current token with a different (or cleared) match.
+    if (_token != token || _baseUri != requestBase) {
+      return;
+    }
 
-      // Discard a stale response: a newer link or a clear may have changed the
-      // active token/base URL while this request was in flight. Applying it now
-      // would pair the current token with a different (or cleared) match.
-      if (_token != token || _baseUri != requestBase) {
-        return;
-      }
-
-      if (response.statusCode == 200) {
-        final json = jsonDecode(response.body);
-        if (json is Map<String, dynamic>) {
-          _matchConfig = ScoreboardMatchConfig.fromJson(json);
-          await _prefs?.setString(_prefsMatchKey, jsonEncode(json));
-          _statusMessage = 'Match loaded';
-        } else {
-          _statusMessage = 'Bad match data';
-        }
-      } else if (response.statusCode == 401) {
-        _statusMessage = 'Link expired';
-      } else {
-        _statusMessage = 'Load failed (${response.statusCode})';
-      }
-    } catch (e) {
-      _statusMessage = 'Load failed (net)';
-      debugPrint('ScoreboardResultService: match load failed: $e');
+    if (outcome.config != null) {
+      _matchConfig = outcome.config;
+      await _prefs?.setString(
+          _prefsMatchKey, jsonEncode(outcome.config!.toJson()));
+      // Preserve a prior "✓ Submitted" confirmation across a refresh (Part C):
+      // refreshing the config must not make a delivered result look un-sent.
+      // _matchConfig is non-null here, so this is the submitted status or
+      // 'Match loaded'.
+      _statusMessage = _committedMatchStatus();
+    } else {
+      _statusMessage = outcome.status;
     }
 
     notifyListeners();
   }
 
+  Future<void> _fetchPendingMatchConfig({
+    required String token,
+    required Uri requestBase,
+  }) async {
+    final outcome = await _requestMatchConfig(token, requestBase);
+
+    // Stale guard: a newer link (or a confirm/cancel) may have replaced the
+    // pending target while this request was in flight.
+    if (_pendingToken != token || _pendingBaseUri != requestBase) {
+      return;
+    }
+
+    if (outcome.config != null) {
+      _pendingMatchConfig = outcome.config;
+      _statusMessage = 'Confirm to load match';
+    } else {
+      _pendingMatchConfig = null;
+      _statusMessage = outcome.status;
+    }
+
+    notifyListeners();
+  }
+
+  /// `'✓ Submitted <code>'` if the currently-committed match already has a
+  /// delivered (submitted) outbox item, else null. Lets a successful submit's
+  /// confirmation persist across refreshes and app restarts (Part C of #51).
+  String? _submittedStatusForCommittedMatch() {
+    final config = _matchConfig;
+    if (config == null) return null;
+    final submitted = _outbox.any((item) =>
+        item.matchCode == config.matchCode &&
+        item.state == ResultSubmissionState.submitted);
+    return submitted ? '✓ Submitted ${config.matchCode}' : null;
+  }
+
+  Future<void> confirmPendingMatch({String? expectedSignature}) async {
+    final token = _pendingToken;
+    final baseUri = _pendingBaseUri;
+    final config = _pendingMatchConfig;
+    if (token == null || token.isEmpty || baseUri == null || config == null) {
+      _statusMessage = _committedMatchStatus();
+      notifyListeners();
+      return;
+    }
+
+    // A stale "Load match?" dialog (a newer link replaced the pending match
+    // after the dialog was built) must not commit the wrong fixture: the
+    // dialog passes the signature it displayed; bail if it no longer matches.
+    if (expectedSignature != null && config.signature != expectedSignature) {
+      notifyListeners();
+      return;
+    }
+
+    // Promote the pending match to committed SYNCHRONOUSLY, before any awaited
+    // prefs write. A deep link can arrive (handleDeepLink) during those awaits;
+    // doing the in-memory swap + pending clear up front means such a newer link
+    // re-stages _pending* AFTER this point and is not wiped by the clear below.
+    _token = token;
+    _baseUri = baseUri;
+    _matchConfig = config;
+    _pendingToken = null;
+    _pendingBaseUri = null;
+    _pendingMatchConfig = null;
+    _statusMessage = 'Match loaded';
+    notifyListeners();
+
+    // Persist with the match config written LAST, and the previous one removed
+    // FIRST. A kill between these writes must never leave the new token/base
+    // paired with the PREVIOUS match's config on disk — initialize() reads them
+    // back independently and would surface the wrong fixture (offline, before a
+    // refresh can correct it). Worst case here is new creds + no stored config,
+    // which the next refresh repopulates from the (new) token.
+    await _prefs?.remove(_prefsMatchKey);
+    await _prefs?.setString(_prefsTokenKey, token);
+    await _prefs?.setString(_prefsBaseUrlKey, baseUri.toString());
+    await _prefs?.setString(_prefsMatchKey, jsonEncode(config.toJson()));
+
+    unawaited(processOutbox());
+  }
+
+  void cancelPendingMatch({String? expectedSignature}) {
+    // A stale Cancel must only discard the link the dialog was showing. Bail if
+    // the loaded pending config no longer matches the dialog's signature — and
+    // also when it is null, which means a newer link replaced it and is still
+    // fetching (clearing then would silently drop that newer link).
+    if (expectedSignature != null &&
+        (_pendingMatchConfig == null ||
+            _pendingMatchConfig!.signature != expectedSignature)) {
+      notifyListeners();
+      return;
+    }
+    _pendingToken = null;
+    _pendingBaseUri = null;
+    _pendingMatchConfig = null;
+    // Preserve a "✓ Submitted" confirmation if the still-committed match was
+    // already delivered (Part C): cancelling a mistaken second link must not
+    // make the first match's submitted result look un-sent.
+    _statusMessage = _committedMatchStatus();
+    notifyListeners();
+  }
+
+  /// Status to show when no link is staged: the persistent submitted
+  /// confirmation if the committed match was delivered, else a generic
+  /// loaded/awaiting message.
+  String _committedMatchStatus() =>
+      _submittedStatusForCommittedMatch() ??
+      (_matchConfig == null ? 'Awaiting link' : 'Match loaded');
+
   Future<bool> enqueueFinalResult({
     required int homeGoals,
     required int awayGoals,
     String? comment,
+    bool homeConfirmed = false,
+    bool awayConfirmed = false,
   }) async {
     final token = _token;
     final matchConfig = _matchConfig;
@@ -353,6 +523,8 @@ class ScoreboardResultService with ChangeNotifier {
       matchCode: matchConfig.matchCode,
       homeGoals: homeGoals,
       awayGoals: awayGoals,
+      homeConfirmed: homeConfirmed,
+      awayConfirmed: awayConfirmed,
       version: matchConfig.version,
       idempotencyKey: _uuid.v4(),
       comment: comment,
@@ -405,6 +577,9 @@ class ScoreboardResultService with ChangeNotifier {
     _token = null;
     _baseUri = _defaultBaseUri;
     _matchConfig = null;
+    _pendingToken = null;
+    _pendingBaseUri = null;
+    _pendingMatchConfig = null;
     _outbox = [];
     _statusMessage = 'Awaiting link';
 
@@ -414,6 +589,30 @@ class ScoreboardResultService with ChangeNotifier {
       await prefs.remove(_prefsBaseUrlKey);
       await prefs.remove(_prefsMatchKey);
       await prefs.remove(_prefsOutboxKey);
+    }
+
+    notifyListeners();
+  }
+
+  /// Drop the live link (token/config/pending) and return to "Awaiting link"
+  /// AFTER a result was delivered, but KEEP the outbox as the delivered-result
+  /// audit trail (and so any other not-yet-delivered items still retry). Unlike
+  /// [clearLinkedMatchData] this never wipes the outbox. The delivered item
+  /// carries its own token/baseUrl, so clearing the live link cannot strand it.
+  Future<void> resetLinkedMatchAfterSubmission() async {
+    _token = null;
+    _baseUri = _defaultBaseUri;
+    _matchConfig = null;
+    _pendingToken = null;
+    _pendingBaseUri = null;
+    _pendingMatchConfig = null;
+    _statusMessage = 'Awaiting link';
+
+    final prefs = _prefs;
+    if (prefs != null) {
+      await prefs.remove(_prefsTokenKey);
+      await prefs.remove(_prefsBaseUrlKey);
+      await prefs.remove(_prefsMatchKey);
     }
 
     notifyListeners();
@@ -435,9 +634,6 @@ class ScoreboardResultService with ChangeNotifier {
       ];
       for (final id in pendingIds) {
         await _submitItem(id);
-      }
-      if (_shouldClearLinkedDataAfterSubmission()) {
-        await clearLinkedMatchData();
       }
     } finally {
       _isSubmitting = false;
@@ -464,13 +660,15 @@ class ScoreboardResultService with ChangeNotifier {
     final payload = {
       'home_goals': item.homeGoals,
       'away_goals': item.awayGoals,
+      'home_confirmed': item.homeConfirmed,
+      'away_confirmed': item.awayConfirmed,
       'version': item.version,
       'idempotency_key': item.idempotencyKey,
       if (item.comment?.isNotEmpty ?? false) 'comment': item.comment,
     };
 
     try {
-      final response = await http
+      final response = await _httpClient
           .post(
             endpoint,
             headers: {
@@ -494,6 +692,16 @@ class ScoreboardResultService with ChangeNotifier {
       final index = _outbox.indexWhere((entry) => entry.id == id);
       if (index == -1) return;
 
+      // The POST uses the item's OWN token/baseUrl, so it can complete after the
+      // referee already loaded a different match (or the same code at a new
+      // revision). The outbox item state is always updated (durability), but the
+      // visible status + the committed match's version are only touched when the
+      // live config is still this item's exact fixture revision — matchCode AND
+      // version — so a late response can't stamp the wrong match.
+      final isCurrentFixture = _matchConfig != null &&
+          _matchConfig!.matchCode == item.matchCode &&
+          _matchConfig!.version == item.version;
+
       if (response.statusCode == 200) {
         _outbox[index] = item.copyWith(
           state: ResultSubmissionState.submitted,
@@ -501,8 +709,14 @@ class ScoreboardResultService with ChangeNotifier {
           responseBody: body,
           clearError: true,
         );
-        _statusMessage = 'Result sent ✓';
-        _updateMatchVersionFromResponse(body);
+        if (isCurrentFixture) {
+          _statusMessage = '✓ Submitted ${item.matchCode}';
+          _updateMatchVersionFromResponse(body);
+          // The active match's result is now delivered: signal the app to
+          // return to its clean start state. Fired only on a confirmed 200 for
+          // the still-current fixture, so a queued/failed result never resets.
+          onCurrentResultDelivered?.call();
+        }
       } else if (response.statusCode == 409) {
         _outbox[index] = item.copyWith(
           state: ResultSubmissionState.conflict,
@@ -510,7 +724,7 @@ class ScoreboardResultService with ChangeNotifier {
           responseBody: body,
           errorMessage: body?['reason']?.toString() ?? 'conflict',
         );
-        _statusMessage = 'Conflict — review';
+        if (isCurrentFixture) _statusMessage = 'Conflict — review';
       } else if (response.statusCode == 401 || response.statusCode == 422) {
         _outbox[index] = item.copyWith(
           state: ResultSubmissionState.failed,
@@ -518,7 +732,9 @@ class ScoreboardResultService with ChangeNotifier {
           responseBody: body,
           errorMessage: body?['reason']?.toString() ?? 'request rejected',
         );
-        _statusMessage = 'Rejected (${response.statusCode})';
+        if (isCurrentFixture) {
+          _statusMessage = 'Rejected (${response.statusCode})';
+        }
       } else {
         _markRetriableFailure(
           index: index,
@@ -526,6 +742,7 @@ class ScoreboardResultService with ChangeNotifier {
           responseStatus: response.statusCode,
           responseBody: body,
           errorMessage: 'temporary_error_${response.statusCode}',
+          updateStatus: isCurrentFixture,
         );
       }
     } catch (e) {
@@ -533,10 +750,14 @@ class ScoreboardResultService with ChangeNotifier {
       // have been cleared meanwhile).
       final index = _outbox.indexWhere((entry) => entry.id == id);
       if (index != -1) {
+        final isCurrentFixture = _matchConfig != null &&
+            _matchConfig!.matchCode == item.matchCode &&
+            _matchConfig!.version == item.version;
         _markRetriableFailure(
           index: index,
           item: item,
           errorMessage: 'network_error',
+          updateStatus: isCurrentFixture,
         );
       }
       debugPrint('ScoreboardResultService: submit failed: $e');
@@ -559,6 +780,10 @@ class ScoreboardResultService with ChangeNotifier {
     int? responseStatus,
     Map<String, dynamic>? responseBody,
     required String errorMessage,
+    // Only mutate the visible status when this item is still the committed
+    // match's fixture; a late failure for an old item must not relabel the
+    // currently-loaded match.
+    bool updateStatus = true,
   }) {
     final nextRetryCount = item.retryCount + 1;
     if (nextRetryCount >= _maxSubmissionRetries) {
@@ -569,7 +794,7 @@ class ScoreboardResultService with ChangeNotifier {
         responseBody: responseBody,
         errorMessage: 'max_retries_reached',
       );
-      _statusMessage = 'Sync failed ($nextRetryCount×)';
+      if (updateStatus) _statusMessage = 'Sync failed ($nextRetryCount×)';
       return;
     }
 
@@ -580,7 +805,9 @@ class ScoreboardResultService with ChangeNotifier {
       responseBody: responseBody,
       errorMessage: errorMessage,
     );
-    _statusMessage = 'Will retry ($nextRetryCount/$_maxSubmissionRetries)';
+    if (updateStatus) {
+      _statusMessage = 'Will retry ($nextRetryCount/$_maxSubmissionRetries)';
+    }
   }
 
   void _updateMatchVersionFromResponse(Map<String, dynamic>? body) {
@@ -594,15 +821,5 @@ class ScoreboardResultService with ChangeNotifier {
       status: 'COMPLETED',
     );
     _prefs?.setString(_prefsMatchKey, jsonEncode(_matchConfig!.toJson()));
-  }
-
-  bool _shouldClearLinkedDataAfterSubmission() {
-    // Only auto-clear once EVERY queued result is submitted. The previous check
-    // (any submitted && none pending/conflict) ignored terminal `failed` items,
-    // so a different match's rejected result would be silently wiped — and the
-    // outbox is its only persisted copy — the moment any other item succeeded.
-    return _outbox.isNotEmpty &&
-        _outbox.every(
-            (entry) => entry.state == ResultSubmissionState.submitted);
   }
 }

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -91,6 +91,19 @@ class ScoreboardResultService with ChangeNotifier {
   bool get hasToken => _token != null && _token!.isNotEmpty;
   bool hasResultFor(String matchCode) =>
       _outbox.any((item) => item.matchCode == matchCode);
+
+  /// True if [matchCode] has an outbox item that should still BLOCK re-opening
+  /// the full-time result review. Every state blocks EXCEPT a terminal rejection
+  /// (HTTP 401/422): that result is correctable, so the review must stay
+  /// reachable for the referee to fix and re-submit (RAVF002). A retry-exhausted
+  /// transient failure (5xx / network) is NOT terminal here and keeps blocking —
+  /// it is re-sent via [retryPendingNow], not by re-opening the review.
+  bool hasUnresolvedResultFor(String matchCode) => _outbox.any(
+      (item) => item.matchCode == matchCode && !_isTerminalRejection(item));
+
+  static bool _isTerminalRejection(ResultOutboxItem item) =>
+      item.state == ResultSubmissionState.failed &&
+      (item.responseStatus == 401 || item.responseStatus == 422);
   bool get hasConflict => conflictCount > 0;
   int get pendingCount => _outbox
       .where((item) => item.state == ResultSubmissionState.pending)

--- a/lib/services/scoreboard_result_service.dart
+++ b/lib/services/scoreboard_result_service.dart
@@ -159,12 +159,27 @@ class ScoreboardResultService with ChangeNotifier {
     final outboxRaw = _prefs!.getString(_prefsOutboxKey);
     if (outboxRaw != null && outboxRaw.isNotEmpty) {
       try {
-        final list = jsonDecode(outboxRaw) as List<dynamic>;
-        _outbox = list
-            .whereType<Map>()
-            .map((item) =>
-                ResultOutboxItem.fromJson(Map<String, dynamic>.from(item)))
-            .toList();
+        final decoded = jsonDecode(outboxRaw);
+        if (decoded is List) {
+          // Parse each item independently. ResultOutboxItem.fromJson force-casts
+          // required fields (id, base_url, token, idempotency_key), so a single
+          // malformed or partially-written entry would otherwise throw and
+          // discard the WHOLE outbox — silently stranding every other pending
+          // submission (its delivery + 20s retry would never run again). Skip
+          // only the bad entry and keep the valid ones.
+          final restored = <ResultOutboxItem>[];
+          for (final item in decoded) {
+            if (item is! Map) continue;
+            try {
+              restored.add(
+                  ResultOutboxItem.fromJson(Map<String, dynamic>.from(item)));
+            } catch (e) {
+              debugPrint(
+                  'ScoreboardResultService: skipping malformed outbox item: $e');
+            }
+          }
+          _outbox = restored;
+        }
       } catch (e) {
         debugPrint('ScoreboardResultService: outbox parse failed: $e');
       }

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1496,6 +1496,72 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();
     });
+
+    testWidgets(
+        'a side-swap during the kill window re-maps home/away on restore',
+        (tester) async {
+      // The match ended with team A (left) 4 - team B (right) 2 and was killed
+      // before Submit. While the app was dead the organizer flipped the fixture
+      // to home_is_left=false, so "home" is now the RIGHT side (team B). The
+      // snapshot persisted the STALE mapping (home=A) AND the pre-swap names
+      // (A='Reds'=home, B='Blues'=away); the restore must re-derive BOTH the
+      // home/away->teamId mapping and the labels from the CURRENT config,
+      // otherwise it would POST team A's 4 goals as "home" (the value bug) and/or
+      // show 'Blues' as the home label (the label bug).
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(
+          matchCode: 'M-SIDESWAP',
+          version: 3,
+          homeIsLeft: false,
+          homeTeamName: 'Reds',
+          awayTeamName: 'Blues',
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 4,
+        scoreB: 2,
+        nameA: 'Reds', // pre-swap labels (homeIsLeft was true: A=home=Reds)
+        nameB: 'Blues',
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-SIDESWAP',
+        scoreboardVersion: 3,
+        scoreboardHomeTeamId: 'A', // stale pre-swap mapping
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.matchCode, 'M-SIDESWAP');
+      expect(review.homeGoals, 2,
+          reason: 'home is now the right side (team B = 2) after the swap');
+      expect(review.awayGoals, 4,
+          reason: 'away is now the left side (team A = 4) after the swap');
+      expect(review.homeName, 'Reds',
+          reason:
+              'home label must follow the re-derived mapping (team B=Reds)');
+      expect(review.awayName, 'Blues',
+          reason:
+              'away label must follow the re-derived mapping (team A=Blues)');
+
+      final result = await submitCurrentReview(tester, game, 'M-SIDESWAP');
+      expect(result.homeGoals, 2);
+      expect(result.awayGoals, 4);
+      expect(result.version, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
   });
 
   group('scoreboard team naming (#53)', () {

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1311,6 +1311,111 @@ void main() {
     });
   });
 
+  group('full-time result durability (RAVF003)', () {
+    testWidgets('a killed full-time referee match is restored into the review',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-KILL', version: 3),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      // A full-time referee snapshot: the match ended but the result was never
+      // submitted before the app was killed.
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 4,
+        scoreB: 2,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-KILL',
+        scoreboardVersion: 3,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump(); // let a suppressed restore re-arm via the config
+
+      expect(game.pendingResume, isNull,
+          reason: 'a finished match is not offered for a plain resume');
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      // The draining setter opens the review the moment Home registers it.
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () => reviewRequests++;
+      expect(reviewRequests, 1);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.matchCode, 'M-KILL');
+      expect(review.homeGoals, 4, reason: 'home is team A');
+      expect(review.awayGoals, 2, reason: 'away is team B');
+
+      final result = await submitCurrentReview(tester, game, 'M-KILL');
+      expect(result.homeGoals, 4);
+      expect(result.awayGoals, 2);
+      expect(result.version, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'the full-time tick persists a review snapshot, then REPEAT clears it',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-DUR', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 3,
+        scoreB: 0,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-DUR',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      game.resumePendingMatch();
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      // The full-time tick PERSISTS a review snapshot (does not clear it), so a
+      // kill before Submit is recoverable.
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (s) => s.stage == 'fullTime' && s.isRefereeMatch,
+      );
+      expect(saved.scoreboardMatchCode, 'M-DUR');
+      expect(saved.teams.firstWhere((t) => t.id == 'A').score, 3);
+
+      // Once the referee starts a fresh match (REPEAT), the snapshot is cleared.
+      game.toggleTimer(); // GAME OVER branch -> gameInit + clear
+      expect(game.currentStage, MatchStage.firstHalf);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump();
+        if (MatchStateStore(prefs).load() == null) break;
+      }
+      expect(MatchStateStore(prefs).load(), isNull,
+          reason: 'REPEAT must clear the persisted full-time snapshot');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('scoreboard team naming (#53)', () {
     Team teamById(Game game, String id) =>
         game.teams.firstWhere((t) => t.id == id);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -178,6 +178,25 @@ void main() {
     }
   }
 
+  Future<ResultOutboxItem> submitCurrentReview(
+    WidgetTester tester,
+    Game game,
+    String matchCode,
+  ) async {
+    final review = game.buildScoreboardResultReview();
+    expect(review.matchCode, matchCode);
+    final submitted = await game.submitScoreboardResult(
+      expectedSignature: review.signature,
+      homeGoals: review.homeGoals,
+      awayGoals: review.awayGoals,
+      comment: null,
+      homeConfirmed: false,
+      awayConfirmed: false,
+    );
+    expect(submitted, isTrue);
+    return waitForOutboxItem(tester, game, matchCode);
+  }
+
   group('cold-launch detection', () {
     testWidgets('an in-progress snapshot is offered for resume',
         (tester) async {
@@ -416,9 +435,24 @@ void main() {
       expect(saved.scoreboardHomeTeamId, 'B');
       expect(saved.scoreboardAwayTeamId, 'A');
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
-      final result = await waitForOutboxItem(tester, game, 'M-53');
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 5,
+          reason: 'home score comes from restored team id B');
+      expect(review.awayGoals, 2,
+          reason: 'away score comes from restored team id A');
+
+      final result = await submitCurrentReview(tester, game, 'M-53');
 
       expect(result.homeGoals, 5,
           reason: 'home score comes from restored team id B');
@@ -471,9 +505,24 @@ void main() {
       expect(saved.scoreboardAwayTeamId, 'B');
       expect(game.teams[0].id, 'B');
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
-      final result = await waitForOutboxItem(tester, game, 'M-SWAP');
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 3,
+          reason: 'home score follows team A even after side swap');
+      expect(review.awayGoals, 1,
+          reason: 'away score follows team B even after side swap');
+
+      final result = await submitCurrentReview(tester, game, 'M-SWAP');
 
       expect(result.homeGoals, 3,
           reason: 'home score follows team A even after side swap');
@@ -517,8 +566,15 @@ void main() {
       expect(saved.scoreboardHomeTeamId, isNull);
       expect(saved.scoreboardAwayTeamId, isNull);
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
+      expect(reviewRequests, 0);
+      expect(game.needsScoreboardResultReview, isFalse);
       await expectNoOutboxItem(tester, game, 'Y');
 
       await tester.pump(const Duration(milliseconds: 1500));
@@ -529,7 +585,7 @@ void main() {
         (tester) async {
       // Organizer edited the fixture during the kill window: same match_code,
       // newer version. The drift guard keys on match_code only, so this must
-      // re-arm and submit the LIVE config version, not drift-suppress.
+      // re-arm and submit the LIVE config version after review, not drift-suppress.
       await _seedScoreboardPrefs(
         prefs,
         _scoreboardConfig(matchCode: 'M-VER', version: 9),
@@ -552,9 +608,16 @@ void main() {
       await settleScoreboardConfig(tester, game);
 
       game.resumePendingMatch();
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
-      final result = await waitForOutboxItem(tester, game, 'M-VER');
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
+      final result = await submitCurrentReview(tester, game, 'M-VER');
 
       expect(result.homeGoals, 1);
       expect(result.awayGoals, 4);
@@ -565,12 +628,13 @@ void main() {
       game.dispose();
     });
 
-    testWidgets('late-arriving fixture config re-arms a suppressed resume (#53)',
+    testWidgets(
+        'late-arriving fixture config re-arms a suppressed resume (#53)',
         (tester) async {
       // The scoreboard config loads via a separate unawaited initialize() and
       // may not have surfaced before the referee taps Resume. Resume then
       // suppresses; when the SAME fixture's config arrives it must re-arm (the
-      // suppress latch is not one-way), and the final POST must fire.
+      // suppress latch is not one-way), and the final review must open.
       await persist(_snap(
         stage: 'secondHalf',
         remainingTime: 1,
@@ -589,9 +653,7 @@ void main() {
 
       game.resumePendingMatch(); // suppressed: bound fixture remembered as M-LATE
 
-      // Now the fixture's config arrives and notifies listeners. A dead local
-      // base URL makes the resulting submit network call fail instantly
-      // (connection refused) instead of hitting the real host.
+      // Now the fixture's config arrives and notifies listeners.
       game.scoreboardResultService.debugApplyMatchConfig(
         ScoreboardMatchConfig.fromJson(
           _scoreboardConfig(matchCode: 'M-LATE', version: 3),
@@ -601,14 +663,24 @@ void main() {
       );
       await tester.pump();
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
-      final result = await waitForOutboxItem(tester, game, 'M-LATE');
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
 
-      expect(result.homeGoals, 6,
-          reason: 're-armed mapping: home is team A');
-      expect(result.awayGoals, 0,
-          reason: 're-armed mapping: away is team B');
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 6, reason: 're-armed mapping: home is team A');
+      expect(review.awayGoals, 0, reason: 're-armed mapping: away is team B');
+
+      final result = await submitCurrentReview(tester, game, 'M-LATE');
+
+      expect(result.homeGoals, 6, reason: 're-armed mapping: home is team A');
+      expect(result.awayGoals, 0, reason: 're-armed mapping: away is team B');
       expect(result.version, 3);
 
       await tester.pump(const Duration(milliseconds: 1500));
@@ -616,14 +688,12 @@ void main() {
     });
 
     testWidgets(
-        'late config after full-time still submits a suppressed resume (#53)',
+        'late config after full-time still opens review for suppressed resume (#53)',
         (tester) async {
       // Regression: a resumed referee match can reach full-time WHILE STILL
-      // suppressed (its fixture config has not surfaced yet). The sole
-      // _queueFinalResultSubmission() call site is the secondHalf->fullTime
-      // tick, which returns early under suppression, and the same tick clears
-      // the snapshot - so without re-submitting on late config arrival the
-      // result is lost forever. The late config must drive the POST.
+      // suppressed (its fixture config has not surfaced yet). The full-time
+      // tick cannot open review while suppressed, and the same tick clears the
+      // snapshot - so the late config must surface the review affordance.
       await persist(_snap(
         stage: 'secondHalf',
         remainingTime: 1,
@@ -642,11 +712,18 @@ void main() {
 
       game.resumePendingMatch(); // suppressed: bound fixture remembered as M-LFT
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       // Drive to full-time BEFORE the config surfaces. The suppressed full-time
       // tick must NOT queue anything yet.
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
       expect(game.currentStage, MatchStage.fullTime);
+      expect(reviewRequests, 0);
+      expect(game.needsScoreboardResultReview, isFalse);
       await expectNoOutboxItem(tester, game, 'M-LFT');
 
       // Now the bound fixture's config finally arrives, after full-time.
@@ -659,7 +736,14 @@ void main() {
       );
       await tester.pump();
 
-      final result = await waitForOutboxItem(tester, game, 'M-LFT');
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 4, reason: 'home is team A');
+      expect(review.awayGoals, 2, reason: 'away is team B');
+
+      final result = await submitCurrentReview(tester, game, 'M-LFT');
       expect(result.homeGoals, 4, reason: 'home is team A');
       expect(result.awayGoals, 2, reason: 'away is team B');
       expect(result.version, 3);
@@ -675,7 +759,8 @@ void main() {
       game.dispose();
     });
 
-    testWidgets('suppressed resume re-persists the binding for a 2nd kill (#53)',
+    testWidgets(
+        'suppressed resume re-persists the binding for a 2nd kill (#53)',
         (tester) async {
       // Config not loaded at resume → binding is suppressed. The snapshot it
       // RE-SAVES must still be a referee match with the binding intact, so a
@@ -744,9 +829,22 @@ void main() {
       await tester.pump();
       expect(game.teams[0].id, 'B', reason: 'team order stayed swapped');
 
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
       game.startTimer();
       await tester.pump(const Duration(seconds: 1));
-      final result = await waitForOutboxItem(tester, game, 'M-LSWAP');
+      expect(reviewRequests, 1);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 1,
+          reason: 'home is team A (id), not teams[0] which is B');
+      expect(review.awayGoals, 7, reason: 'away is team B');
+
+      final result = await submitCurrentReview(tester, game, 'M-LSWAP');
 
       expect(result.homeGoals, 1,
           reason: 'home is team A (id), not teams[0] which is B');
@@ -756,7 +854,8 @@ void main() {
       game.dispose();
     });
 
-    testWidgets('a different fixture mid-suppressed-resume cannot hijack it (#53)',
+    testWidgets(
+        'a different fixture mid-suppressed-resume cannot hijack it (#53)',
         (tester) async {
       // Resume bound to M-HX with no config yet (suppressed). Then a DIFFERENT
       // fixture M-HY opens mid-match. It must be rejected: the re-saved snapshot
@@ -902,6 +1001,221 @@ void main() {
       expect(game.inGame, isFalse);
 
       expect(MatchStateStore(prefs).load(), isNull);
+      game.dispose();
+    });
+
+    testWidgets(
+        'confirm-on-load prompt fires when the callback is registered after '
+        'the link surfaces', (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      // A staged deep link surfaces BEFORE Home installs the confirm callback
+      // (the constructor-initialize vs didChangeDependencies race).
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-LOAD', version: 2),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      final prompts = <String>[];
+      // The draining setter must fire the already-pending prompt on assignment.
+      game.onRequestConfirmScoreboardMatch = (c) => prompts.add(c.matchCode);
+      expect(prompts, ['M-LOAD']);
+
+      // A redundant notify for the same pending config must not re-prompt.
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-LOAD', version: 2),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(prompts, ['M-LOAD']);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'submitScoreboardResult refuses when the committed fixture changed',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-ONE', version: 1),
+        ),
+        token: 'token-1',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      final review = game.buildScoreboardResultReview();
+      expect(review.matchCode, 'M-ONE');
+
+      // A new link is confirmed while the review screen (still showing M-ONE)
+      // is open, changing the committed fixture underneath it.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-TWO', version: 1),
+        ),
+        token: 'token-2',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      final ok = await game.submitScoreboardResult(
+        expectedSignature: review.signature, // captured for M-ONE
+        homeGoals: review.homeGoals,
+        awayGoals: review.awayGoals,
+        homeConfirmed: false,
+        awayConfirmed: false,
+      );
+      expect(ok, isFalse, reason: 'must not POST M-ONE scores against M-TWO');
+      expect(game.scoreboardResultService.outbox, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'submitScoreboardResult refuses a same-code config that changed sides',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-SIG', version: 1, homeIsLeft: true),
+        ),
+        token: 't',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      final review = game.buildScoreboardResultReview();
+
+      // Same match code, but the organizer swapped sides (homeIsLeft false):
+      // the captured review's signature no longer matches the live config.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-SIG', version: 1, homeIsLeft: false),
+        ),
+        token: 't',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      final ok = await game.submitScoreboardResult(
+        expectedSignature: review.signature,
+        homeGoals: review.homeGoals,
+        awayGoals: review.awayGoals,
+        homeConfirmed: false,
+        awayConfirmed: false,
+      );
+      expect(ok, isFalse,
+          reason: 'a same-code side swap must invalidate the captured review');
+      expect(game.scoreboardResultService.outbox, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a fixture-revision change at full time invalidates the result review',
+        (tester) async {
+      // Reach full time bound to M-END v1 (the review subject is captured).
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 3,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-END',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      game.resumePendingMatch();
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-END', version: 1),
+        ),
+        token: 'token-end',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+      final review = game.buildScoreboardResultReview();
+      expect(review.matchCode, 'M-END');
+
+      // The SAME fixture surfaces at a new revision after full time (organizer
+      // edit / refresh). matchCode still matches (so the #53 drift guard passes)
+      // but the captured full-time signature does not.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-END', version: 2),
+        ),
+        token: 'token-end',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      expect(game.needsScoreboardResultReview, isFalse,
+          reason: 'a revision change after full time invalidates the review');
+      final ok = await game.submitScoreboardResult(
+        expectedSignature: review.signature, // captured for v1
+        homeGoals: review.homeGoals,
+        awayGoals: review.awayGoals,
+        homeConfirmed: false,
+        awayConfirmed: false,
+      );
+      expect(ok, isFalse,
+          reason: 'must not post the v1 review against the v2 revision');
+      await expectNoOutboxItem(tester, game, 'M-END');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('onPendingMatchPromptClosed re-arms a still-pending prompt',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      final prompts = <String>[];
+      game.onRequestConfirmScoreboardMatch = (c) => prompts.add(c.matchCode);
+
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-RE', version: 1),
+        ),
+        token: 't',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(prompts, ['M-RE']);
+
+      // The dialog closed while the same link is still pending (e.g. a stale
+      // no-op Load/Cancel): the prompt must re-arm for it.
+      game.onPendingMatchPromptClosed();
+      expect(prompts, ['M-RE', 'M-RE']);
+
+      // Once the link is cleared, closing the prompt must NOT re-fire.
+      game.scoreboardResultService.cancelPendingMatch();
+      game.onPendingMatchPromptClosed();
+      expect(prompts, ['M-RE', 'M-RE']);
+
+      await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();
     });
   });

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1220,6 +1220,97 @@ void main() {
     });
   });
 
+  group('result-delivery reset guard (RAVF001)', () {
+    // Drive a live referee match to full time with its result eligible for
+    // review. The resume path is used purely as a concise way to land at
+    // secondHalf, 1 s from the end, with the scoreboard binding armed.
+    Future<Game> liveRefereeAtFullTime(
+      WidgetTester tester, {
+      required String matchCode,
+      int version = 1,
+      int scoreA = 3,
+      int scoreB = 1,
+    }) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: matchCode, version: version),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: scoreA,
+        scoreB: scoreB,
+        isRefereeMatch: true,
+        scoreboardMatchCode: matchCode,
+        scoreboardVersion: version,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      game.resumePendingMatch();
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+      return game;
+    }
+
+    testWidgets('a late 200 after REPEAT does not reset the new live match',
+        (tester) async {
+      final game = await liveRefereeAtFullTime(tester, matchCode: 'M-RPT');
+      await submitCurrentReview(tester, game, 'M-RPT');
+
+      // Referee taps REPEAT: gameInit() starts a brand-new match and clears the
+      // captured full-time signature. Make the new match visibly non-default so
+      // a stray reset is observable.
+      game.toggleTimer(); // GAME OVER branch -> gameInit
+      expect(game.currentStage, MatchStage.firstHalf);
+      game.teams[0].score = 7;
+      game.startTimer();
+      expect(game.inGame, isTrue);
+
+      // The original queued result now lands (HTTP 200). It is still the
+      // service's "current fixture", so the delivery callback fires - but the
+      // referee has moved on, so it must NOT disconnect/reinit the live match.
+      game.scoreboardResultService.onCurrentResultDelivered!();
+      await tester
+          .pump(); // drain the reset microtask (if the guard let it run)
+
+      expect(game.teams[0].score, 7, reason: 'live match score must survive');
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isTrue);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a 200 while still on the full-time match resets to clean start',
+        (tester) async {
+      final game = await liveRefereeAtFullTime(tester,
+          matchCode: 'M-DLV', scoreA: 5, scoreB: 2);
+      // A custom name proves the reset restores defaults.
+      game.teams.firstWhere((t) => t.id == 'A').name = 'Eagles';
+      await submitCurrentReview(tester, game, 'M-DLV');
+
+      game.scoreboardResultService.onCurrentResultDelivered!();
+      await tester.pump(); // drain the reset microtask
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+      expect(teamA.name, 'Team A');
+      expect(teamA.score, 0);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('scoreboard team naming (#53)', () {
     Team teamById(Game game, String id) =>
         game.teams.firstWhere((t) => t.id == id);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1822,6 +1822,40 @@ void main() {
     });
   });
 
+  group('clear-linked-match undelivered guard (RAVF003)', () {
+    testWidgets('undeliveredCount counts every non-submitted outbox item',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-CLR', version: 1),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await _seedOutbox(prefs, [
+        _outboxItem(matchCode: 'P', state: ResultSubmissionState.pending),
+        _outboxItem(matchCode: 'C', state: ResultSubmissionState.conflict),
+        _outboxItem(
+          matchCode: 'F',
+          state: ResultSubmissionState.failed,
+          responseStatus: 401,
+        ),
+        _outboxItem(matchCode: 'S', state: ResultSubmissionState.submitted),
+      ]);
+      final game = Game();
+      await settleLoad(tester);
+      await tester.pump();
+
+      // The Settings "Clear linked match" confirm dialog keys on this: warn
+      // only when undelivered results would be lost (pending/conflict/failed),
+      // never counting an already-delivered (submitted) item.
+      expect(game.scoreboardResultService.undeliveredCount, 3);
+      expect(game.scoreboardResultService.submittedCount, 1);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('scoreboard team naming (#53)', () {
     Team teamById(Game game, String id) =>
         game.teams.firstWhere((t) => t.id == id);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1748,6 +1748,80 @@ void main() {
     });
   });
 
+  group('review-edit write-back (RAVF004)', () {
+    testWidgets(
+        'a corrected review score is written to the teams and snapshot so a '
+        're-open shows the correction, not the original', (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-EDIT', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      // Cold-launch straight into a full-time review (no outbox item yet).
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 2,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-EDIT',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+
+      expect(game.needsScoreboardResultReview, isTrue);
+      final review = game.buildScoreboardResultReview();
+      expect(review.homeGoals, 2, reason: 'home is team A');
+      expect(review.awayGoals, 1, reason: 'away is team B');
+
+      // Referee corrects the score on the review screen before submitting.
+      final submitted = await game.submitScoreboardResult(
+        expectedSignature: review.signature,
+        homeGoals: 5,
+        awayGoals: 3,
+        comment: null,
+        homeConfirmed: false,
+        awayConfirmed: false,
+      );
+      expect(submitted, isTrue);
+
+      // The correction is written onto the live teams (home=A, away=B)...
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+      final teamB = game.teams.firstWhere((t) => t.id == 'B');
+      expect(teamA.score, 5, reason: 'home (team A) takes the corrected score');
+      expect(teamB.score, 3, reason: 'away (team B) takes the corrected score');
+
+      // ...the queued outbox item carries the corrected score...
+      final item = await waitForOutboxItem(tester, game, 'M-EDIT');
+      expect(item.homeGoals, 5);
+      expect(item.awayGoals, 3);
+
+      // ...and the persisted snapshot reflects it, so a kill+restore or a
+      // terminal-rejection re-open shows 5-3, not the original 2-1 (RAVF004).
+      final snap = await waitForSavedSnapshot(
+        tester,
+        (s) =>
+            s.scoreboardMatchCode == 'M-EDIT' &&
+            s.teams.firstWhere((t) => t.id == 'A').score == 5,
+      );
+      expect(snap.teams.firstWhere((t) => t.id == 'B').score, 3);
+
+      // A fresh review (as re-opened after a 401/422) now reads the correction.
+      final reopened = game.buildScoreboardResultReview();
+      expect(reopened.homeGoals, 5);
+      expect(reopened.awayGoals, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('scoreboard team naming (#53)', () {
     Team teamById(Game game, String id) =>
         game.teams.firstWhere((t) => t.id == id);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -75,6 +75,39 @@ Future<void> _seedScoreboardPrefs(
   }
 }
 
+Future<void> _seedOutbox(
+  SharedPreferences prefs,
+  List<ResultOutboxItem> items,
+) async {
+  await prefs.setString(
+    'scoreboard_result_outbox',
+    jsonEncode(items.map((item) => item.toJson()).toList()),
+  );
+}
+
+ResultOutboxItem _outboxItem({
+  required String matchCode,
+  required ResultSubmissionState state,
+  int? responseStatus,
+  int homeGoals = 0,
+  int awayGoals = 0,
+  int version = 1,
+}) =>
+    ResultOutboxItem(
+      id: 'item-$matchCode',
+      baseUrl: 'http://127.0.0.1:9',
+      token: 'test-token',
+      matchCode: matchCode,
+      homeGoals: homeGoals,
+      awayGoals: awayGoals,
+      version: version,
+      idempotencyKey: 'idem-$matchCode',
+      state: state,
+      responseStatus: responseStatus,
+      createdAt: DateTime.utc(2026),
+      updatedAt: DateTime.utc(2026),
+    );
+
 MatchSnapshot _snap({
   String stage = 'firstHalf',
   bool inGame = true,
@@ -1558,6 +1591,157 @@ void main() {
       expect(result.homeGoals, 2);
       expect(result.awayGoals, 4);
       expect(result.version, 3);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a restored full-time match with a pending result still resets when '
+        'that genuine 200 finally lands', (tester) async {
+      // Kill AFTER Submit but BEFORE the 200: on relaunch the outbox holds a
+      // pending item for the on-screen fixture, so the review stays suppressed
+      // (hasUnresolvedResultFor). But this restored match IS the one the result
+      // belongs to, so the delivery-reset signature must still be armed — when
+      // the genuine 200 arrives the finished match must reset/clear, not linger
+      // with modules connected and a snapshot on disk. The RAVF001 arm-gate must
+      // NOT swallow this (it only guards the live REPEAT tick).
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-P200', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await _seedOutbox(prefs, [
+        _outboxItem(
+          matchCode: 'M-P200',
+          state: ResultSubmissionState.pending,
+          homeGoals: 2,
+          awayGoals: 1,
+          version: 2,
+        ),
+      ]);
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 2,
+        scoreB: 1,
+        nameA: 'Eagles', // a custom name proves the reset restores defaults
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-P200',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+
+      // The pending item keeps the review closed...
+      expect(game.needsScoreboardResultReview, isFalse,
+          reason: 'a pending result suppresses the review affordance');
+
+      // ...but the genuine 200 for that same fixture must still reset.
+      game.scoreboardResultService.onCurrentResultDelivered!();
+      await tester.pump(); // drain the reset microtask
+
+      expect(game.currentStage, MatchStage.firstHalf,
+          reason: 'the delivered first-run result must reset the match');
+      expect(game.inGame, isFalse);
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+      expect(teamA.name, 'Team A');
+      expect(teamA.score, 0);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump();
+        if (MatchStateStore(prefs).load() == null) break;
+      }
+      expect(MatchStateStore(prefs).load(), isNull,
+          reason: 'a successful delivery must clear the persisted snapshot');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
+  group('review re-open gate through Game (RAVF002 e2e)', () {
+    testWidgets(
+        'a terminal 401 in the outbox still re-opens the full-time review',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-401E', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await _seedOutbox(prefs, [
+        _outboxItem(
+          matchCode: 'M-401E',
+          state: ResultSubmissionState.failed,
+          responseStatus: 401,
+          homeGoals: 2,
+          awayGoals: 1,
+          version: 2,
+        ),
+      ]);
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 2,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-401E',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+
+      expect(game.needsScoreboardResultReview, isTrue,
+          reason: 'a correctable 401 must leave the review reachable via Game');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('a still-pending outbox item keeps the review blocked',
+        (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(matchCode: 'M-PEND', version: 2),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await _seedOutbox(prefs, [
+        _outboxItem(
+          matchCode: 'M-PEND',
+          state: ResultSubmissionState.pending,
+          homeGoals: 2,
+          awayGoals: 1,
+          version: 2,
+        ),
+      ]);
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 2,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-PEND',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+
+      expect(game.needsScoreboardResultReview, isFalse,
+          reason: 'an in-flight result must keep the review suppressed');
 
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1344,6 +1344,53 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();
     });
+
+    testWidgets(
+        'REPEAT of the same fixture does not re-arm while the prior result is '
+        'in flight, so a late 200 cannot reset the second run', (tester) async {
+      // REPEAT replays the SAME fixture: gameInit nulls the full-time signature
+      // but the service keeps _matchConfig, so the second run reaches its own
+      // full time with the SAME match_code+version still "current". A late 200
+      // from the FIRST run must not reset/disconnect the second run (RAVF001,
+      // REPEAT same-fixture edge).
+      final game = await liveRefereeAtFullTime(tester, matchCode: 'M-REP');
+      await submitCurrentReview(tester, game, 'M-REP'); // first result queued
+      expect(
+          game.scoreboardResultService.hasUnresolvedResultFor('M-REP'), isTrue,
+          reason: 'the first run\'s result is still in flight after submit');
+
+      // Shorten the halves so the second run reaches full time in a few ticks.
+      game.periodTime = 1;
+      game.halfTimeDuration = 1;
+
+      game.toggleTimer(); // GAME OVER -> gameInit (firstHalf, signature cleared)
+      expect(game.currentStage, MatchStage.firstHalf);
+
+      // Drive the second run to full time via the clock only (no playAll fan-out
+      // timers). firstHalf -> halfTime (auto-starts) -> secondHalf (referee
+      // starts) -> fullTime.
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1)); // -> halfTime
+      expect(game.currentStage, MatchStage.halfTime);
+      await tester.pump(const Duration(seconds: 1)); // -> secondHalf
+      expect(game.currentStage, MatchStage.secondHalf);
+      game.teams[0].score = 5; // make the live second run visibly non-default
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1)); // -> fullTime
+      expect(game.currentStage, MatchStage.fullTime);
+
+      // The guard kept the reset signature un-armed (a prior same-fixture result
+      // is still unresolved), so the late 200 is a no-op for the second run.
+      game.scoreboardResultService.onCurrentResultDelivered!();
+      await tester.pump(); // drain the reset microtask (if it wrongly ran)
+
+      expect(game.teams[0].score, 5,
+          reason: 'the second run must NOT be reset by the first run\'s 200');
+      expect(game.currentStage, MatchStage.fullTime);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
   });
 
   group('full-time result durability (RAVF003)', () {

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -1,5 +1,57 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/services/scoreboard_result_service.dart';
+
+class _FakeHttpClient extends http.BaseClient {
+  _FakeHttpClient(this.handler);
+
+  final FutureOr<http.Response> Function(http.BaseRequest request) handler;
+  final List<http.BaseRequest> requests = [];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    requests.add(request);
+    final response = await handler(request);
+    return http.StreamedResponse(
+      Stream<List<int>>.fromIterable([response.bodyBytes]),
+      response.statusCode,
+      headers: response.headers,
+      reasonPhrase: response.reasonPhrase,
+      request: request,
+    );
+  }
+}
+
+Map<String, dynamic> _matchJson({
+  String matchCode = 'M-1',
+  int version = 5,
+}) =>
+    {
+      'match_code': matchCode,
+      'home_team': {'name': 'Blue'},
+      'away_team': {'name': 'Red'},
+      'home_is_left': true,
+      'venue': '1',
+      'duration_seconds': 600,
+      'timezone': 'Europe/Prague',
+      'version': version,
+      'status': 'SCHEDULED',
+    };
+
+Future<void> _waitFor(
+  bool Function() condition, {
+  String reason = 'condition was not met',
+}) async {
+  for (var i = 0; i < 20; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail(reason);
+}
 
 void main() {
   group('ScoreboardMatchConfig parsing', () {
@@ -38,6 +90,15 @@ void main() {
       expect(config.version, 0);
       expect(config.timezone, 'UTC');
     });
+
+    test('signature does not collide for separator-containing team names', () {
+      final a = ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M'))
+          .copyWith(homeTeamName: 'A:B', awayTeamName: 'C');
+      final b = ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M'))
+          .copyWith(homeTeamName: 'A', awayTeamName: 'B:C');
+      expect(a.signature, isNot(b.signature),
+          reason: 'a colon in a team name must not alias a different fixture');
+    });
   });
 
   group('ResultOutboxItem serialization', () {
@@ -50,6 +111,8 @@ void main() {
         matchCode: 'M-1',
         homeGoals: 3,
         awayGoals: 2,
+        homeConfirmed: true,
+        awayConfirmed: false,
         version: 5,
         idempotencyKey: 'idem-1',
         comment: 'via app',
@@ -67,6 +130,8 @@ void main() {
       expect(decoded.matchCode, item.matchCode);
       expect(decoded.homeGoals, item.homeGoals);
       expect(decoded.awayGoals, item.awayGoals);
+      expect(decoded.homeConfirmed, isTrue);
+      expect(decoded.awayConfirmed, isFalse);
       expect(decoded.idempotencyKey, item.idempotencyKey);
       expect(decoded.retryCount, item.retryCount);
       expect(decoded.state, ResultSubmissionState.pending);
@@ -88,6 +153,8 @@ void main() {
       });
 
       expect(decoded.retryCount, 0);
+      expect(decoded.homeConfirmed, isFalse);
+      expect(decoded.awayConfirmed, isFalse);
     });
   });
 
@@ -121,7 +188,8 @@ void main() {
       expect(submitted.responseStatus, 200);
     });
 
-    test('clearResponse + clearError wipe stale failure details on revival', () {
+    test('clearResponse + clearError wipe stale failure details on revival',
+        () {
       final revived = failedItem().copyWith(
         state: ResultSubmissionState.pending,
         retryCount: 0,
@@ -140,6 +208,403 @@ void main() {
       expect(updated.errorMessage, 'temporary_error_500');
       expect(updated.responseStatus, 500);
       expect(updated.responseBody, isNotNull);
+    });
+
+    test('copyWith can update confirmations', () {
+      final updated = failedItem().copyWith(
+        homeConfirmed: true,
+        awayConfirmed: true,
+      );
+      expect(updated.homeConfirmed, isTrue);
+      expect(updated.awayConfirmed, isTrue);
+    });
+  });
+
+  group('ScoreboardResultService staging', () {
+    test('handleDeepLink fetches pending config without committing token',
+        () async {
+      final client = _FakeHttpClient((request) {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/api/v1/soccer/match/');
+        return http.Response(
+            jsonEncode(_matchJson(matchCode: 'M-PENDING')), 200);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+
+      await service.handleDeepLink(Uri(
+        scheme: 'rcjrefmate',
+        host: 'r',
+        pathSegments: ['fresh-token'],
+        queryParameters: {'base_url': 'http://127.0.0.1:8080'},
+      ));
+
+      expect(service.pendingMatchConfig?.matchCode, 'M-PENDING');
+      expect(service.matchConfig, isNull);
+      expect(service.hasToken, isFalse);
+      expect(service.statusMessage, 'Confirm to load match');
+
+      await service.confirmPendingMatch();
+      expect(service.pendingMatchConfig, isNull);
+      expect(service.matchConfig?.matchCode, 'M-PENDING');
+      expect(service.hasToken, isTrue);
+      expect(service.statusMessage, 'Match loaded');
+    });
+
+    test('cancelPendingMatch preserves committed match', () {
+      final service = ScoreboardResultService(
+          httpClient: _FakeHttpClient(
+        (_) => http.Response('{}', 500),
+      ));
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-COMMITTED')),
+        token: 'old-token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      service.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-PENDING')),
+        token: 'new-token',
+        baseUri: Uri.parse('http://127.0.0.1:8081'),
+      );
+
+      service.cancelPendingMatch();
+
+      expect(service.pendingMatchConfig, isNull);
+      expect(service.matchConfig?.matchCode, 'M-COMMITTED');
+      expect(service.hasToken, isTrue);
+      expect(service.statusMessage, 'Match loaded');
+    });
+
+    test('confirmPendingMatch ignores a stale dialog signature', () async {
+      final service = ScoreboardResultService(
+          httpClient: _FakeHttpClient((_) => http.Response('{}', 500)));
+      // A first link is staged, then a second link replaces it before the
+      // (stale) first dialog's Load is tapped.
+      final firstPending =
+          ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-A'));
+      service.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-B')),
+        token: 'token-b',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      await service.confirmPendingMatch(
+          expectedSignature: firstPending.signature);
+
+      // The stale Load must not commit the newer pending match.
+      expect(service.matchConfig, isNull);
+      expect(service.pendingMatchConfig?.matchCode, 'M-B');
+    });
+
+    test('cancelPendingMatch keeps a newer pending link on a stale signature',
+        () {
+      final service = ScoreboardResultService(
+          httpClient: _FakeHttpClient((_) => http.Response('{}', 500)));
+      final firstPending =
+          ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-A'));
+      service.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-B')),
+        token: 'token-b',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      service.cancelPendingMatch(expectedSignature: firstPending.signature);
+
+      // A stale Cancel must not discard the newer staged link.
+      expect(service.pendingMatchConfig?.matchCode, 'M-B');
+    });
+  });
+
+  group('ScoreboardResultService submission', () {
+    test('sends confirmations and keeps linked match after success', () async {
+      String? postBody;
+      final client = _FakeHttpClient((request) {
+        expect(request.method, 'POST');
+        if (request is http.Request) {
+          postBody = request.body;
+        }
+        return http.Response(jsonEncode({'version': 6}), 200);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-SUBMIT')),
+        token: 'token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      final queued = await service.enqueueFinalResult(
+        homeGoals: 4,
+        awayGoals: 3,
+        comment: 'checked',
+        homeConfirmed: true,
+        awayConfirmed: false,
+      );
+
+      expect(queued, isTrue);
+      expect(service.outbox.single.homeConfirmed, isTrue);
+      expect(service.outbox.single.awayConfirmed, isFalse);
+
+      await _waitFor(() => postBody != null, reason: 'POST was not sent');
+      final payload = jsonDecode(postBody!) as Map<String, dynamic>;
+      expect(payload['home_goals'], 4);
+      expect(payload['away_goals'], 3);
+      expect(payload['home_confirmed'], isTrue);
+      expect(payload['away_confirmed'], isFalse);
+      expect(payload['comment'], 'checked');
+
+      await _waitFor(
+        () => service.outbox.single.state == ResultSubmissionState.submitted,
+        reason: 'submission did not finish',
+      );
+      expect(service.matchConfig?.matchCode, 'M-SUBMIT');
+      expect(service.hasToken, isTrue);
+      expect(service.hasResultFor('M-SUBMIT'), isTrue);
+      expect(service.statusMessage, '✓ Submitted M-SUBMIT');
+    });
+
+    test('submitted confirmation survives a later config refresh', () async {
+      String? postBody;
+      final client = _FakeHttpClient((request) {
+        if (request.method == 'POST') {
+          if (request is http.Request) postBody = request.body;
+          return http.Response(jsonEncode({'version': 6}), 200);
+        }
+        // A subsequent GET refresh of the same match.
+        return http.Response(jsonEncode(_matchJson(matchCode: 'M-KEEP')), 200);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-KEEP')),
+        token: 'token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+      await _waitFor(() => postBody != null, reason: 'POST was not sent');
+      await _waitFor(
+        () => service.outbox.single.state == ResultSubmissionState.submitted,
+        reason: 'submission did not finish',
+      );
+      expect(service.statusMessage, '✓ Submitted M-KEEP');
+
+      // A refresh of the linked match must not make a delivered result look
+      // un-sent (Part C of #51).
+      await service.refreshMatchConfig();
+      expect(service.statusMessage, '✓ Submitted M-KEEP');
+    });
+
+    test('cancelling a staged link keeps a prior submitted confirmation',
+        () async {
+      final client = _FakeHttpClient((request) {
+        if (request.method == 'POST') {
+          return http.Response(jsonEncode({'version': 6}), 200);
+        }
+        return http.Response('{}', 500);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-DONE')),
+        token: 'token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      await service.enqueueFinalResult(homeGoals: 2, awayGoals: 1);
+      await _waitFor(() => service.statusMessage == '✓ Submitted M-DONE',
+          reason: 'submit did not confirm');
+
+      // Referee mistakenly scans another link then cancels it.
+      service.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-OTHER')),
+        token: 'other',
+        baseUri: Uri.parse('http://127.0.0.1:8081'),
+      );
+      service.cancelPendingMatch();
+
+      expect(service.matchConfig?.matchCode, 'M-DONE');
+      expect(service.statusMessage, '✓ Submitted M-DONE');
+    });
+
+    test('a late POST for an old match does not mutate the newly loaded match',
+        () async {
+      final postGate = Completer<void>();
+      final client = _FakeHttpClient((request) async {
+        if (request.method == 'POST') {
+          await postGate.future;
+          return http.Response(jsonEncode({'version': 99}), 200);
+        }
+        return http.Response('{}', 500);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _matchJson(matchCode: 'M-A', version: 1)),
+        token: 'token-a',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+
+      // A's POST is now in flight (blocked on the gate). Load a DIFFERENT match.
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _matchJson(matchCode: 'M-B', version: 2)),
+        token: 'token-b',
+        baseUri: Uri.parse('http://127.0.0.1:8081'),
+      );
+      expect(service.matchConfig?.matchCode, 'M-B');
+
+      // Release A's response; it must not stamp B with A's version/COMPLETED.
+      postGate.complete();
+      await _waitFor(
+        () => service.outbox.any((i) =>
+            i.matchCode == 'M-A' && i.state == ResultSubmissionState.submitted),
+        reason: 'A submission did not finish',
+      );
+      expect(service.matchConfig?.matchCode, 'M-B');
+      expect(service.matchConfig?.version, 2,
+          reason: "B's version must be untouched by A's response");
+      expect(service.matchConfig?.status, isNot('COMPLETED'));
+    });
+
+    test('a late POST for an old REVISION does not stamp the current revision',
+        () async {
+      final postGate = Completer<void>();
+      final client = _FakeHttpClient((request) async {
+        if (request.method == 'POST') {
+          await postGate.future;
+          return http.Response(jsonEncode({'version': 99}), 200);
+        }
+        return http.Response('{}', 500);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _matchJson(matchCode: 'M-R', version: 1)),
+        token: 't',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+
+      // The SAME fixture is re-applied at a new revision (organizer edit /
+      // refresh) while the v1 POST is still in flight.
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _matchJson(matchCode: 'M-R', version: 2)),
+        token: 't',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      postGate.complete();
+      await _waitFor(
+        () => service.outbox.single.state == ResultSubmissionState.submitted,
+        reason: 'submission did not finish',
+      );
+      expect(service.matchConfig?.version, 2,
+          reason: 'matchCode matches but the revision drifted; do not stamp');
+      expect(service.statusMessage, isNot('✓ Submitted M-R'));
+    });
+
+    test('a late failure for an old match does not relabel the current match',
+        () async {
+      final postGate = Completer<void>();
+      final client = _FakeHttpClient((request) async {
+        if (request.method == 'POST') {
+          await postGate.future;
+          return http.Response(jsonEncode({'reason': 'late'}), 409);
+        }
+        return http.Response('{}', 500);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-A')),
+        token: 'token-a',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+
+      // Load a different match while A's POST is in flight.
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-B')),
+        token: 'token-b',
+        baseUri: Uri.parse('http://127.0.0.1:8081'),
+      );
+
+      postGate.complete();
+      await _waitFor(
+        () => service.outbox.any((i) =>
+            i.matchCode == 'M-A' && i.state == ResultSubmissionState.conflict),
+        reason: "A's conflict was not recorded",
+      );
+      // The outbox item is marked conflict, but B's visible status must not read
+      // as conflicted because of A's late response.
+      expect(service.statusMessage, isNot('Conflict — review'));
+    });
+
+    test('a late retriable failure for an old match does not relabel status',
+        () async {
+      final postGate = Completer<void>();
+      final client = _FakeHttpClient((request) async {
+        if (request.method == 'POST') {
+          await postGate.future;
+          return http.Response('{}', 500); // retriable
+        }
+        return http.Response('{}', 500);
+      });
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-A')),
+        token: 'token-a',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+
+      // Load a different match while A's POST is in flight.
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-B')),
+        token: 'token-b',
+        baseUri: Uri.parse('http://127.0.0.1:8081'),
+      );
+
+      postGate.complete();
+      await _waitFor(
+        () =>
+            service.outbox.any((i) => i.matchCode == 'M-A' && i.retryCount > 0),
+        reason: "A's retriable failure was not recorded",
+      );
+      // A's late 500 bumps its retry count, but must not relabel B's status.
+      expect(service.statusMessage, isNot(startsWith('Will retry')));
+      expect(service.statusMessage, isNot(startsWith('Sync failed')));
+    });
+
+    test('cancel does not drop a newer link whose fetch is still in flight',
+        () async {
+      final gate = Completer<http.Response>();
+      final client = _FakeHttpClient((_) => gate.future); // GET hangs
+      final service = ScoreboardResultService(httpClient: client);
+
+      // Link A is already staged (dialog A would be open).
+      service.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-A')),
+        token: 'token-a',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+      final sigA = service.pendingMatchConfig!.signature;
+
+      // Link B arrives: pending token/base become B, pending config goes null
+      // while B's GET is in flight (hanging on the gate).
+      unawaited(service.handleDeepLink(Uri(
+        scheme: 'rcjrefmate',
+        host: 'r',
+        pathSegments: ['token-b'],
+        queryParameters: {'base_url': 'http://127.0.0.1:8081'},
+      )));
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pendingMatchConfig, isNull, reason: "B's fetch in flight");
+
+      // A stale Cancel for dialog A must NOT clear B's in-flight pending target.
+      service.cancelPendingMatch(expectedSignature: sigA);
+
+      gate.complete(
+          http.Response(jsonEncode(_matchJson(matchCode: 'M-B')), 200));
+      await _waitFor(() => service.pendingMatchConfig?.matchCode == 'M-B',
+          reason: 'B must still surface as pending after a stale cancel');
     });
   });
 }

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -392,6 +392,59 @@ void main() {
       expect(service.statusMessage, '✓ Submitted M-KEEP');
     });
 
+    test(
+        'a terminal 401 rejection unblocks the review for a re-submit '
+        '(RAVF002)', () async {
+      final client = _FakeHttpClient(
+          (request) => http.Response(jsonEncode({'reason': 'bad token'}), 401));
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-401')),
+        token: 'token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+      await _waitFor(
+        () =>
+            service.outbox.single.state == ResultSubmissionState.failed &&
+            service.outbox.single.responseStatus == 401,
+        reason: 'the 401 did not mark the item terminally failed',
+      );
+
+      // hasResultFor still sees the item (audit trail), but the review gate
+      // (hasUnresolvedResultFor) treats a terminal rejection as correctable, so
+      // the referee gets the Submit affordance back.
+      expect(service.hasResultFor('M-401'), isTrue);
+      expect(service.hasUnresolvedResultFor('M-401'), isFalse);
+
+      // A fresh enqueue is accepted (a corrected, second attempt).
+      final reSubmitted =
+          await service.enqueueFinalResult(homeGoals: 2, awayGoals: 0);
+      expect(reSubmitted, isTrue);
+    });
+
+    test('a 409 conflict keeps the review blocked (RAVF002)', () async {
+      final client = _FakeHttpClient((request) =>
+          http.Response(jsonEncode({'reason': 'already recorded'}), 409));
+      final service = ScoreboardResultService(httpClient: client);
+      service.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_matchJson(matchCode: 'M-409')),
+        token: 'token',
+        baseUri: Uri.parse('http://127.0.0.1:8080'),
+      );
+
+      await service.enqueueFinalResult(homeGoals: 1, awayGoals: 0);
+      await _waitFor(
+        () => service.outbox.single.state == ResultSubmissionState.conflict,
+        reason: 'the 409 did not record a conflict',
+      );
+
+      // A conflict is a terminal SERVER state the referee can't correct by
+      // re-submitting, so it must keep blocking the review.
+      expect(service.hasUnresolvedResultFor('M-409'), isTrue);
+    });
+
     test('cancelling a staged link keeps a prior submitted confirmation',
         () async {
       final client = _FakeHttpClient((request) {


### PR DESCRIPTION
Implements the referee match-lifecycle UX around the scoreboard deep-link flow. Closes #51.

Server contract for the two new confirmation fields: robocup-junior/rcj-scoreboard#81.

> **Review round 2 (@mrshu review-anvil report addressed)** — 4 follow-up commits on top of the original 4, each a focused fix with tests (analyze clean, 144 tests):
> - `a64fe5d` **RAVF001 (H)** — a late HTTP 200 for a result queued at full time no longer resets/disconnects a *later* match started via REPEAT (the reset is gated on still being on the just-ended full-time match).
> - `210f8c0` **RAVF002 (M)** — a terminal 401/422 rejection now re-opens the review so the referee can correct and re-submit (new `hasUnresolvedResultFor`; 409/pending/submitted/retry-exhausted still block).
> - `3a04eaa` **RAVF003 (H)** — a kill in the `[full time → before Submit]` window is now recoverable: a full-time **review snapshot** is persisted (never the outbox — nothing POSTs until Submit) and cold launch restores into the review. This replaces the inaccurate "covered by the outbox" claim below.
> - `6ce72d2` **nits** — RAVF004 toast reworded; outbox busy-poll centralized into `awaitOutboxOutcome`; redundant `notifyListeners` dropped.

## What & why

### A. Confirm-on-load (staged deep links)
Previously an incoming deep link was applied **silently** in `_applyScoreboardMatchConfig`, overwriting team names/timing with no confirmation. Now an incoming link is **staged** in `ScoreboardResultService` (`pendingMatchConfig` / `_pendingToken` / `_pendingBaseUri`) and `handleDeepLink` **no longer commits** the token/config swap. `Game` raises `onRequestConfirmScoreboardMatch` → a **"Load match?"** dialog (teams · field · length). `confirmPendingMatch()` promotes pending→committed on **Load**; `cancelPendingMatch()` discards on **Cancel**.

**Why staging:** the key property is that a deep link arriving **mid-match** can be Cancelled without clobbering the running match's result binding — the committed token/config (and therefore which fixture the final result POSTs to) is untouched until Load is confirmed.

### B. End-of-match review & submit
The `secondHalf → fullTime` tick **no longer auto-POSTs**. For a token match it opens a full-screen `ScoreboardResultReviewScreen`:
- **Final result** — editable home/away score, pre-filled from the live score mapped by team id (not position).
- **Team confirmation** — one checkbox per team, labelled with the real team name → `home_confirmed` / `away_confirmed`.
- **Comment** — free text.
- **Submit** — single-tap (deliberate post-match action; the in-match double-tap guard doesn't apply here). Shows **"Sending…"**, then a toast with the actual outcome.

On a **confirmed HTTP 200** the app resets to its clean start state (default names, operator's default match length, modules disconnected, "Awaiting link"). A **queued / offline / rejected / conflicted** result keeps the match on screen with its status so the referee can decide. For a referee match at full time the timer **REPEAT** button is replaced by **"Submit result"** (also the persistent re-entry if the referee Cancels the review).

### C. Persistent confirmation
Removed the auto-clear-after-submit (which made success and silent failure look identical). The submit outcome is surfaced via a toast — *Result sent successfully ✓* / *Already recorded* / *Rejected — link invalid* / *Saved — sending in the background* — backed by the existing persistent outbox + 20s auto-retry (survives an app kill).

### Plumbing
`home_confirmed` / `away_confirmed` threaded through `ResultOutboxItem` (json/copyWith, default `false` for legacy), `enqueueFinalResult`, and the POST body.

## Notable correctness work (from 4 rounds of multi-agent review)
The staging model exposed a family of races, all closed and regression-tested:
- Lost confirm-on-load prompt when the callback isn't installed yet → **draining setter** (mirrors `onRequestResumeMatch`).
- A stale/duplicate "Load match?" dialog committing the **wrong** pending link → `expectedSignature` guards on confirm/cancel + a re-entrancy guard; `confirmPendingMatch` promotes synchronously before the awaited prefs writes.
- Submitting against a fixture that changed mid-review → submit guards on the full `ScoreboardMatchConfig.signature` (jsonEncode-based, collision-free).
- A late POST for an **old** outbox item mutating the **currently-loaded** match → status/version updates gated on matchCode **and** version.
- Loading a new link at full time binding the just-ended scores to the new fixture → `_fullTimeResultSignature` gate on `needsScoreboardResultReview`.

## Durability & recovery (updated in round 2)
- **Result loss if the app is killed *before* Submit** — **fixed in round 2 (RAVF003)**. A full-time review snapshot is persisted (separate from the outbox, so nothing POSTs until the referee submits); cold launch restores into the review screen. Once submitted, the persistent outbox + 20s retry own delivery as before. *(The earlier claim that this window was "covered by the outbox" was inaccurate — the outbox entry only exists after Submit.)*
- **Re-editing a terminally rejected (401/422) result** — **fixed in round 2 (RAVF002)**. The review re-opens so the referee can correct and re-submit; a 409 conflict (a non-correctable server state) still routes to status/out-of-band as before.

## How to verify (no live server)
1. Run the stdlib mock of the two endpoints and tunnel it over USB:
   ```
   python3 -u mock_scoreboard.py            # GET /api/v1/soccer/match/ + POST .../result/
   adb -s <device> reverse tcp:8000 tcp:8000
   ```
   (mock + runbook: `docs/ai/tools/mock_scoreboard.py`, `docs/ai/07_SCOREBOARD_DEVICE_TESTING.md`)
2. Fire a referee link (debug build): `adb shell am start -a android.intent.action.VIEW -d 'rcjrefmate://r/<token>?base_url=http://127.0.0.1:8000'`
3. Check, in order:
   - **"Load match?"** dialog appears; **Cancel** changes nothing; re-fire → dialog again; **Load** applies names/timing.
   - Fire mid-match → dialog warns "⚠ This replaces the match in progress."; Cancel leaves the running match intact.
   - Drive to full time → review screen opens; edit a score, tick a team, add a comment, **Submit** → mock log shows the POST body incl. `home_confirmed`/`away_confirmed`/`comment`; toast **"Result sent successfully ✓"**; app resets to a clean "Awaiting link" start state.
   - Error injection (env vars on the mock): `RESULT_STATUS=409` (already recorded), `MATCH_STATUS=401` (expired link), stop the mock (offline) → each surfaces a distinct toast/status; offline stays queued and retries.
   - Force-stop + relaunch after a successful submit → starts clean (no stale "Submitted").

## Verification status
- `flutter analyze --fatal-infos` clean; **138** unit/widget tests pass.
- Device-verified end-to-end on a **Pixel 10 (Android 17)** against the mock (confirm-on-load + Cancel-safety, review/submit + POST body, success reset, persistent retry, restart, single-tap Submit, layout).

> Note: the final UI/UX polish (section layout, single-tap Submit, toasts, REPEAT→Submit swap, reset-on-success, duration formatting) landed **after** the review-anvil rounds — device-verified but not re-reviewed; flagged here for a reviewer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

