### PR TITLE
fix(qr-scanner): stop camera feed leaking below the bottom status bar

### DIFF
--- a/lib/screens/mac_qr_scanner.dart
+++ b/lib/screens/mac_qr_scanner.dart
@@ -91,19 +91,25 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
             //scanWindow: Rect.fromCenter(center: Offset.zero, width: 500, height: 500),
 
           ),
-          SafeArea(
-            top: false,
-            child: Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                alignment: Alignment.bottomCenter,
-                height: 100,
-                color: Colors.black.withValues(alpha: 0.85),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    Expanded(child: Center(child: _buildBarcode(_barcode))),
-                  ],
+          Align(
+            alignment: Alignment.bottomCenter,
+            // The black background must reach the physical screen bottom so the
+            // live camera feed never shows through below the bar. The SafeArea
+            // is therefore INSIDE the coloured Container (padding the content up
+            // off the home indicator) rather than around it — otherwise the
+            // bottom safe-area inset stays uncovered and leaks the camera.
+            child: Container(
+              color: Colors.black.withValues(alpha: 0.85),
+              child: SafeArea(
+                top: false,
+                child: SizedBox(
+                  height: 100,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      Expanded(child: Center(child: _buildBarcode(_barcode))),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Problem

On the QR scanner screen there is a strip **all the way at the bottom that shows the live camera feed again**, instead of being part of the black status bar above it.

## Cause

The bottom status bar is a black `Container` placed *inside* `SafeArea(top: false)`. The SafeArea pads its child up by the bottom safe-area inset (the home-indicator region), so the black box stops short of the physical screen bottom. The full-screen `MobileScanner` sits underneath the whole `Stack`, so that uncovered inset strip leaks the camera preview.

## Fix (`lib/screens/mac_qr_scanner.dart`)

Move the `SafeArea` *inside* the coloured `Container`:
- the black background now extends to the physical screen bottom, covering the inset, and
- the content (barcode text) is still padded up off the home indicator.

No behavioural change to scanning/parsing.

## Testing

- `flutter analyze lib/screens/mac_qr_scanner.dart` → No issues found.
- On-device check on a phone with a bottom inset (notch/home-indicator) recommended to confirm the strip is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)