### PR TITLE
refactor(ble): share iOS UUID-resolve helper + fix stale-scan bug in handleIosResult

### DIFF
--- a/lib/screens/module_settings.dart
+++ b/lib/screens/module_settings.dart
@@ -1,6 +1,4 @@
-import 'dart:io';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -9,7 +7,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/services/ble.dart';
-import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
+import 'package:rcj_scoreboard/utils/ble_address.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
 
 import 'mac_qr_scanner.dart';
@@ -232,14 +230,9 @@ class _ModuleSettingsScreen extends State<ModuleSettingsScreen> {
     super.dispose();
   }
 
-  var maskFormatter = MaskTextInputFormatter(
-    mask: (!kIsWeb && Platform.isIOS)
-        ? '########-####-####-####-############'
-        : '##:##:##:##:##:##',
-    filter: (!kIsWeb && Platform.isIOS)
-        ? {"#": RegExp('[0-9A-Fa-f-]')}
-        : {"#": RegExp('[0-9A-Fa-f:]')},
-  );
+  // Shared with the bridge address field via utils/ble_address.dart so both
+  // screens use the same UUID-vs-MAC mask.
+  final maskFormatter = buildBleAddressMask();
 
   @override
   Widget build(BuildContext context) {
@@ -347,15 +340,15 @@ class _ModuleSettingsScreen extends State<ModuleSettingsScreen> {
               controller: _controller,
               inputFormatters: [maskFormatter],
               decoration: InputDecoration(
-                labelText: (!kIsWeb && Platform.isIOS) ? 'Enter device UUID' : 'Enter MAC Address',
+                labelText: useIosBleUuid ? 'Enter device UUID' : 'Enter MAC Address',
                 labelStyle: const TextStyle(color: Colors.grey),
-                hintText: (!kIsWeb && Platform.isIOS) ? 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' :'xx:xx:xx:xx:xx:xx',
+                hintText: bleAddressHint,
                 hintStyle: const TextStyle(color: Colors.grey),
                 border: const OutlineInputBorder(),
 
               ),
               style: const TextStyle(color: Colors.white),
-              maxLength: (!kIsWeb && Platform.isIOS) ? 36 : 17,
+              maxLength: bleAddressMaxLength,
             ),
             const SizedBox(height: 8),
             Row(
@@ -489,7 +482,7 @@ class _ModuleSettingsScreen extends State<ModuleSettingsScreen> {
           if (result != null) {
             //result = 'RCJ-soccer_module-XX:XX:XX:XX:XX:XX'
             // --> map result (ble device name) to uuid
-            if(!kIsWeb && Platform.isIOS){
+            if (useIosBleUuid) {
               handleIosResult(result);
             } else {
               _controller.text = result;
@@ -499,34 +492,22 @@ class _ModuleSettingsScreen extends State<ModuleSettingsScreen> {
       );
     }
 
+    // QR codes encode a MAC, but iOS connects by CoreBluetooth UUID — resolve it
+    // via the shared BLE scan (utils/ble_address.dart), which uses the validated
+    // onScanResults lifecycle (NOT the replay-prone scanResults this used to call)
+    // and tears the scan down in finally.
     Future<void> handleIosResult(dynamic pResult) async {
-      bool validResult = false;
-      String? bleDeviceName = 'RCJs-m_$pResult';
-      debugPrint(bleDeviceName);
+      final resolvedUuid = await resolveIosDeviceUuid('$pResult');
 
-      await FlutterBluePlus.startScan(timeout: const Duration(seconds: 3));
-
-      await for (final results in FlutterBluePlus.scanResults.timeout(
-        const Duration(seconds: 3),
-        onTimeout: (sink) => sink.close(),
-      )) {
-        for (ScanResult r in results) {
-          if (r.device.platformName == bleDeviceName) {
-            //debugPrint('App-specific UUID: ${r.device.remoteId}');
-            _controller.text = r.device.remoteId.toString();
-            validResult = true;
-            await FlutterBluePlus.stopScan();
-            break;
-          }
+      if (resolvedUuid != null) {
+        if (mounted) {
+          _controller.text = resolvedUuid;
         }
-
-        if (validResult) break;
+        return;
       }
 
-      await FlutterBluePlus.stopScan();
-
       //Error handling if no device to mac was found
-      if (!validResult && mounted) {
+      if (mounted) {
         await showCupertinoDialog(
           context: context,
           builder: (BuildContext context) {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1,18 +1,13 @@
-import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 import '../models/game.dart';
 import '../services/ble_bridge_service.dart';
 import '../services/mqtt.dart';
 import '../services/notification_service.dart';
 import '../services/preset_service.dart';
 import '../services/vibration_service.dart';
+import '../utils/ble_address.dart';
 import '../utils/colors.dart';
 import 'mac_qr_scanner.dart';
 
@@ -59,19 +54,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     SetItem('90 sec', 90),
   ];
 
-  // On iOS a BLE device is addressed by a CoreBluetooth UUID, not a MAC. Mirror
-  // the per-module address field (module_settings.dart): mask + length differ by
-  // platform so the bridge address can be entered/edited correctly on iPhone.
-  static bool get _useIosUuid => !kIsWeb && Platform.isIOS;
-
-  final _bridgeAddressMask = MaskTextInputFormatter(
-    mask: _useIosUuid
-        ? '########-####-####-####-############'
-        : '##:##:##:##:##:##',
-    filter: _useIosUuid
-        ? {"#": RegExp('[0-9A-Fa-f-]')}
-        : {"#": RegExp('[0-9A-Fa-f:]')},
-  );
+  // iOS addresses a BLE device by a CoreBluetooth UUID, not a MAC; the mask,
+  // length and hint differ by platform. Shared with the per-module address field
+  // via utils/ble_address.dart so both screens stay in sync.
+  final _bridgeAddressMask = buildBleAddressMask();
 
   @override
   void initState() {
@@ -93,62 +79,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   // Apply a scanned bridge QR result to the bridge address. QR codes always
   // encode a MAC (mac_qr_scanner only accepts a 17-char MAC), but iOS cannot
-  // connect by MAC — it needs the device's CoreBluetooth UUID. So on iOS resolve
-  // the MAC to a UUID by BLE-scanning for the device that advertises that MAC in
-  // its name. The bridge advertises with the same `RCJs-m_<MAC>` name as a robot
-  // module. On Android the scanned MAC is the address, so it is applied directly.
-  //
-  // The scan lifecycle mirrors ModuleSettingsScreen.startScanning(): subscribe to
-  // onScanResults BEFORE startScan and clean up in finally. We deliberately do
-  // NOT use scanResults — it is a behavior stream that replays the previous
-  // scan's cached results (see module_settings.dart and commit 5e6b013), which
-  // could resolve the bridge to a stale device the current scan never saw.
+  // connect by MAC — it needs the device's CoreBluetooth UUID, so resolve it via
+  // the shared BLE scan (utils/ble_address.dart). On Android the scanned MAC is
+  // the address, so it is applied directly.
   Future<void> _applyBridgeQrResult(String macResult) async {
-    if (!_useIosUuid) {
+    if (!useIosBleUuid) {
       setState(() {
         widget.game.bleBridgeService.bridgeMacAddress = macResult;
       });
       return;
     }
 
-    // Match case-insensitively: the QR scanner accepts a lower- or upper-case
-    // MAC while the device may advertise the other case (the Android/bridge
-    // connect path already normalizes via toUpperCase()).
-    final bleDeviceName = 'RCJs-m_$macResult'.toUpperCase();
-    String? resolvedUuid;
-    StreamSubscription<List<ScanResult>>? scanSub;
-
-    try {
-      scanSub = FlutterBluePlus.onScanResults.listen((results) {
-        for (final ScanResult r in results) {
-          if (r.device.platformName.toUpperCase() == bleDeviceName) {
-            resolvedUuid ??= r.device.remoteId.toString();
-            // Stop as soon as the device is found rather than waiting out the
-            // full timeout: this resolves faster and shrinks the window in which
-            // this global scan overlaps the robot-control surface.
-            unawaited(FlutterBluePlus.stopScan());
-            break;
-          }
-        }
-      });
-
-      await FlutterBluePlus.startScan(timeout: const Duration(seconds: 3));
-      // Wait for the scan to stop (on match above, or on the timeout) before
-      // evaluating the result.
-      await FlutterBluePlus.isScanning.where((scanning) => !scanning).first;
-    } catch (e) {
-      // BLE off / permission denied / platform scan failure: do not let the
-      // button handler throw; fall through to the "No device found" dialog.
-      debugPrint('BleBridge: QR resolve scan error: $e');
-    } finally {
-      await scanSub?.cancel();
-      await FlutterBluePlus.stopScan();
-    }
+    final resolvedUuid = await resolveIosDeviceUuid(macResult);
 
     if (resolvedUuid != null) {
       if (mounted) {
         setState(() {
-          widget.game.bleBridgeService.bridgeMacAddress = resolvedUuid!;
+          widget.game.bleBridgeService.bridgeMacAddress = resolvedUuid;
         });
       }
       return;
@@ -367,16 +314,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                                 : 'Disconnected',
                                   ),
                                   SettingInputField(
-                                    title: _useIosUuid
+                                    title: useIosBleUuid
                                         ? 'Bridge UUID'
                                         : 'Bridge MAC',
                                     initialValue: widget
                                         .game.bleBridgeService.bridgeMacAddress,
                                     inputFormatters: [_bridgeAddressMask],
-                                    maxLength: _useIosUuid ? 36 : 17,
-                                    hintText: _useIosUuid
-                                        ? 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-                                        : 'xx:xx:xx:xx:xx:xx',
+                                    maxLength: bleAddressMaxLength,
+                                    hintText: bleAddressHint,
                                     onChanged: (value) {
                                       widget.game.bleBridgeService
                                           .bridgeMacAddress = value;

--- a/lib/utils/ble_address.dart
+++ b/lib/utils/ble_address.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
+
+/// Shared helpers for entering/resolving a BLE device address (robot modules
+/// and the BLE bridge alike).
+///
+/// On iOS a BLE peripheral is addressed by a CoreBluetooth UUID, not a MAC, so
+/// the address field and the QR-resolve flow differ by platform. These helpers
+/// are the single source of truth for that difference; `module_settings.dart`
+/// and `settings.dart` both use them.
+
+/// True when the device address is a CoreBluetooth UUID (iOS) rather than a MAC.
+bool get useIosBleUuid => !kIsWeb && Platform.isIOS;
+
+/// Input mask for the device-address field: a CoreBluetooth UUID on iOS, a
+/// colon-separated MAC on Android.
+MaskTextInputFormatter buildBleAddressMask() => MaskTextInputFormatter(
+      mask: useIosBleUuid
+          ? '########-####-####-####-############'
+          : '##:##:##:##:##:##',
+      filter: useIosBleUuid
+          ? {'#': RegExp('[0-9A-Fa-f-]')}
+          : {'#': RegExp('[0-9A-Fa-f:]')},
+    );
+
+/// Max length of the address field text (UUID vs MAC).
+int get bleAddressMaxLength => useIosBleUuid ? 36 : 17;
+
+/// Hint text for the address field.
+String get bleAddressHint => useIosBleUuid
+    ? 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+    : 'xx:xx:xx:xx:xx:xx';
+
+/// QR codes always encode a MAC (the scanner only accepts a 17-char MAC), but
+/// iOS cannot connect by MAC — it needs the device's CoreBluetooth UUID. Resolve
+/// [mac] to a UUID by BLE-scanning for the device that advertises that MAC in
+/// its name (`RCJs-m_<MAC>`, shared by robot modules and the bridge). Returns
+/// the resolved UUID, or null if no matching device was seen (BLE off /
+/// permission denied / not advertising / timeout).
+///
+/// Uses `onScanResults` with subscribe-before-`startScan` — NOT `scanResults`,
+/// which is a behavior stream that replays the previous scan's cached results
+/// and so could resolve to a stale device the current scan never saw. The scan
+/// is always torn down in `finally`, stops as soon as a match is found, and the
+/// name match is case-insensitive (the QR MAC may be lower- or upper-case).
+Future<String?> resolveIosDeviceUuid(String mac) async {
+  final targetName = 'RCJs-m_$mac'.toUpperCase();
+  String? resolved;
+  StreamSubscription<List<ScanResult>>? scanSub;
+
+  try {
+    scanSub = FlutterBluePlus.onScanResults.listen((results) {
+      for (final ScanResult r in results) {
+        if (r.device.platformName.toUpperCase() == targetName) {
+          resolved ??= r.device.remoteId.toString();
+          // Stop on match rather than waiting out the timeout: faster, and
+          // shrinks the window this global scan overlaps robot control.
+          unawaited(FlutterBluePlus.stopScan());
+          break;
+        }
+      }
+    });
+
+    await FlutterBluePlus.startScan(timeout: const Duration(seconds: 3));
+    // Wait for the scan to stop (on the match above, or on the timeout).
+    await FlutterBluePlus.isScanning.where((scanning) => !scanning).first;
+  } catch (e) {
+    // BLE off / permission denied / platform scan failure: swallow so the
+    // caller can surface a "not found" message instead of throwing.
+    debugPrint('resolveIosDeviceUuid scan error: $e');
+  } finally {
+    await scanSub?.cancel();
+    await FlutterBluePlus.stopScan();
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Follow-up to #65. Implements the two items the #65 review (`review-anvil`) deferred as worth doing in a separate PR, after auditing the findings:

1. **Extract a shared helper** (`lib/utils/ble_address.dart`) for the iOS BLE address concerns that were duplicated inline across `module_settings.dart` and `settings.dart` — `useIosBleUuid`, `buildBleAddressMask()`, `bleAddressMaxLength`, `bleAddressHint`, and the QR-MAC→UUID resolver `resolveIosDeviceUuid()`.
2. **Fix a real latent bug in `module_settings.dart`'s `handleIosResult`** by routing it through that shared (hardened) resolver.

## The bug being fixed

`handleIosResult` (the iOS robot-module QR-scan path, shipping today) still used `FlutterBluePlus.scanResults` — a **behavior stream that replays the previous scan's cached results** — so an iOS module QR scan could resolve to a **stale device the current scan never saw**. This is the same issue commit `5e6b013` fixed for `startScanning()` but never for `handleIosResult`. It also:
- had no `try/catch/finally` (a scan failure left a scan running),
- matched advertised names **case-sensitively** (a lower/upper-case QR MAC could fail to resolve), and
- waited out the full 3 s timeout after a match.

The shared `resolveIosDeviceUuid()` (the hardened version landed for the bridge in #65) fixes all four: `onScanResults` + subscribe-before-`startScan`, `try/catch/finally` cleanup, early-stop on match, case-insensitive name match.

## Changes

- **New** `lib/utils/ble_address.dart` — single source of truth for the UUID-vs-MAC field format and the iOS resolve scan.
- `lib/screens/settings.dart` — bridge field + `_applyBridgeQrResult` now use the shared helper (removes the inline copy added in #65).
- `lib/screens/module_settings.dart` — module field + `handleIosResult` now use the shared helper; drops the now-unused `dart:io` / `mask_text_input_formatter` imports.

No change to the robot START/STOP path or the bridge connection path.

## Stacking

Based on the **#65 branch** (`feat/ios-ble-bridge-identifier`), since `settings.dart`'s bridge resolver only exists there. **Merge #65 first** — GitHub will then auto-retarget this PR to `dev`.

## Testing

- `flutter analyze lib/` → No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)