### PR TITLE
fix(scoreboard): reset the live match on a confirmed new-fixture Load (RAVF002, #68)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1517,6 +1517,21 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       return false;
     }
 
+    // Capture the side mapping BEFORE awaiting the enqueue. The signature guard
+    // above proved matchConfig.signature == expectedSignature, so this mapping is
+    // exactly the one the review screen submitted against. An already-in-flight
+    // refreshMatchConfig() can complete during the await below, reassign the
+    // committed config, and (for a same-fixture side swap) flip homeIsLeft —
+    // re-deriving the mapping AFTER the await would then write these goals onto
+    // the WRONG physical teams. Capturing here keeps the write-back correct
+    // regardless of a concurrent refresh, while still letting a benign
+    // version/name refresh through (the team IDs are stable, so the submitted
+    // homeGoals always belong to homeTeamId). Same homeIsLeft fallback as
+    // buildScoreboardResultReview.
+    final homeIsLeft = scoreboardResultService.matchConfig?.homeIsLeft ?? true;
+    final homeTeamId = _scoreboardHomeTeamId ?? (homeIsLeft ? 'A' : 'B');
+    final awayTeamId = _scoreboardAwayTeamId ?? (homeIsLeft ? 'B' : 'A');
+
     final trimmedComment = comment?.trim();
     final submitted = await scoreboardResultService.enqueueFinalResult(
       homeGoals: homeGoals,
@@ -1536,12 +1551,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // the wrong values (RAVF004). teams[*].score is a plain field (no
       // MQTT/bridge broadcast), so this updates local truth + the snapshot
       // only; the POST payload already carries the homeGoals/awayGoals passed
-      // above. Map via the captured side mapping, with the same homeIsLeft
-      // fallback buildScoreboardResultReview uses.
-      final homeIsLeft =
-          scoreboardResultService.matchConfig?.homeIsLeft ?? true;
-      final homeTeamId = _scoreboardHomeTeamId ?? (homeIsLeft ? 'A' : 'B');
-      final awayTeamId = _scoreboardAwayTeamId ?? (homeIsLeft ? 'B' : 'A');
+      // above. Map via the side mapping captured above (pre-await).
       for (final team in teams) {
         if (team.id == homeTeamId) {
           team.score = homeGoals;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -87,6 +87,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   WakelockService wakelockService = WakelockService();
   ScoreboardResultService scoreboardResultService = ScoreboardResultService();
   String? _lastAppliedScoreboardSignature;
+  // Signature of the fixture the user just CONFIRMED loading (set by
+  // [confirmScoreboardMatch]). Lets _applyScoreboardMatchConfig tell a
+  // user-confirmed new-fixture Load — which must reset a match in
+  // progress/finished (RAVF002) — apart from an automatic same-fixture refresh
+  // (version bump / #50 venue correction), which preserves the just-played
+  // scores. Keyed on the signature (not a bare flag) so a stale-dialog reject,
+  // which re-applies the UNCHANGED committed config, can never be mistaken for
+  // the confirmed Load. Consumed on the next apply.
+  String? _confirmedLoadSignature;
   String? _lastPromptedPendingSignature;
   String? _scoreboardHomeTeamId;
   String? _scoreboardAwayTeamId;
@@ -1050,7 +1059,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // gameInit() the new, live in-progress match (RAVF001). Only reset while we
     // are STILL on the exact full-time match this delivery belongs to: REPEAT /
     // a new match move the stage off fullTime and clear the captured full-time
-    // signature (gameInit), so this guard cleanly distinguishes the two.
+    // signature (gameInit), so this guard cleanly distinguishes the two. A late
+    // 200 for a result queued against a SINCE-REPLACED fixture can't reach here
+    // either: a confirmed new-fixture Load resets to firstHalf (RAVF002), so the
+    // stage guard rejects it, and the service only fires this for an item still
+    // matching the committed fixture.
     if (currentStage != MatchStage.fullTime ||
         _fullTimeResultSignature == null) {
       return;
@@ -1127,13 +1140,57 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _maybeFirePendingMatchPrompt();
   }
 
+  /// Confirm the staged "Load match?" deep link (called by Home's Load button).
+  /// Wraps the service promotion so the resulting _applyScoreboardMatchConfig
+  /// knows this is a USER-CONFIRMED Load — which must reset a match already in
+  /// progress/finished (RAVF002) — rather than an automatic same-fixture
+  /// refresh. confirmPendingMatch promotes + notifies SYNCHRONOUSLY, so the flag
+  /// is in place when the apply runs; the post-await clear is a belt-and-braces
+  /// reset in case a stale-dialog reject promoted nothing.
+  Future<void> confirmScoreboardMatch({String? expectedSignature}) async {
+    // Capture the signature of the fixture being confirmed so the resulting
+    // apply only treats THAT exact fixture as a confirmed Load. confirmPendingMatch
+    // promotes + notifies synchronously, so the apply runs while this is set; the
+    // finally clears it if a stale-dialog reject promoted nothing. Mirror
+    // confirmPendingMatch's own stale-dialog guard: only arm when the current
+    // pending fixture matches the dialog's expectedSignature, otherwise the
+    // promotion will be rejected and we must NOT arm (else a stale Load whose
+    // pending happens to share an unapplied committed config's signature could
+    // still trigger a reset).
+    final pendingSignature =
+        scoreboardResultService.pendingMatchConfig?.signature;
+    _confirmedLoadSignature = (pendingSignature != null &&
+            (expectedSignature == null ||
+                expectedSignature == pendingSignature))
+        ? pendingSignature
+        : null;
+    try {
+      await scoreboardResultService.confirmPendingMatch(
+          expectedSignature: expectedSignature);
+    } finally {
+      _confirmedLoadSignature = null;
+    }
+  }
+
   void _applyScoreboardMatchConfig(ScoreboardMatchConfig config) {
     // Team names AND venue are part of the signature (see
     // ScoreboardMatchConfig.signature) so a corrected schedule payload that
     // changes only a name or the venue (without bumping version/duration/side)
     // still updates the displayed names and the MQTT field (#50); the
     // `if (!inGame)` guard below still gates timing.
+    // Consume the "user confirmed a Load" signal up front so it never leaks to a
+    // later apply. It is the signature of the fixture the user confirmed: a
+    // confirmed Load (the warned "Load match?" overwrite) resets a match in
+    // progress/finished (RAVF002) whenever the applied config IS that fixture —
+    // including re-loading the SAME fixture (the dialog warns it replaces the
+    // match, so the intent is a clean start regardless of whether the fixture
+    // changed). A stale-dialog reject re-applies the unchanged committed config,
+    // whose signature won't match the confirmed one, so it never resets.
+    final confirmedSignature = _confirmedLoadSignature;
+    _confirmedLoadSignature = null;
     final signature = config.signature;
+    final isConfirmedNewFixtureLoad =
+        confirmedSignature != null && confirmedSignature == signature && inGame;
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing
@@ -1142,8 +1199,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // re-arrives, an early dedupe return here would skip the re-arm below and
     // leave the final result suppressed forever (#53). While suppressed, fall
     // through to the re-arm guard, which re-arms the bound fixture or rejects a
-    // different one.
-    if (!(inGame && _suppressScoreboardFinalResult) &&
+    // different one. A confirmed Load is never deduped away — re-loading the
+    // SAME fixture (same signature) must still reset.
+    if (!isConfirmedNewFixtureLoad &&
+        !(inGame && _suppressScoreboardFinalResult) &&
         _lastAppliedScoreboardSignature == signature) {
       return;
     }
@@ -1157,9 +1216,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       if (resumedCode == null ||
           resumedCode.isEmpty ||
           config.matchCode != resumedCode) {
-        return;
+        // A DIFFERENT fixture surfaced while this resume is still suppressed.
+        // Normally reject it (an automatic config must not retarget a suppressed
+        // match's result), but a user-CONFIRMED Load means the referee chose to
+        // abandon the resume for this fixture — fall through to the reset below.
+        if (!isConfirmedNewFixtureLoad) return;
+      } else {
+        reArmedFromSuppression = true;
       }
-      reArmedFromSuppression = true;
     }
     _lastAppliedScoreboardSignature = signature;
     _suppressScoreboardFinalResult = false;
@@ -1195,9 +1259,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // subscribers on the corrected field_N would otherwise see a previous
       // match's retained data (or nothing) until the next score/stage event.
       // Rebroadcast current state once, only when the topic actually changed, so
-      // an idempotent re-apply of the same field doesn't spam the bus.
+      // an idempotent re-apply of the same field doesn't spam the bus. Skip it
+      // for a confirmed new-fixture Load: that resets below and gameInit()
+      // broadcasts the clean 0-0 state to the new field — rebroadcasting here
+      // would briefly publish the PREVIOUS match's scores under the new fixture.
       // _broadcastFullState is off the robot START/STOP hot path (invariant #1).
-      if (inGame && mqttService.topic != previousTopic) {
+      if (inGame &&
+          !isConfirmedNewFixtureLoad &&
+          mqttService.topic != previousTopic) {
         _broadcastFullState();
       }
     }
@@ -1214,6 +1283,27 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // prefs and clobber their setting). gameInit() applies it to the clock.
       _periodTime = config.durationSeconds;
       gameInit();
+    } else if (isConfirmedNewFixtureLoad) {
+      // RAVF002: the referee confirmed the "Load match?" overwrite while a match
+      // is in progress or finished. The dialog warns it "replaces the match in
+      // progress", so reset to a clean match bound to the new fixture.
+      // gameInit() zeroes scores/clock/stage and clears the old full-time review
+      // subject + resumed binding (_fullTimeResultSignature,
+      // _resumedFixtureMatchCode, _suppressScoreboardFinalResult); the new
+      // fixture's names/side mapping were applied above and gameInit() leaves
+      // names untouched. gameInit() runs BEFORE setTeamToDefaultOrder() so the
+      // scores are already zeroed when the order toggle broadcasts — otherwise a
+      // second-half-swapped order would publish the previous match's scores
+      // under the new fixture's names. setTeamToDefaultOrder() then restores the
+      // default order for the new first half. gameInit() never touches the
+      // outbox, so an already-submitted result for the PREVIOUS fixture survives
+      // and keeps retrying; its late 200 no longer matches the committed
+      // fixture, so it can't reset this match (rule 3). Clear the stale snapshot
+      // so a kill resumes the new match.
+      _periodTime = config.durationSeconds;
+      gameInit();
+      setTeamToDefaultOrder();
+      _clearMatchState();
     } else if (reArmedFromSuppression && currentStage == MatchStage.fullTime) {
       // The bound fixture's config only surfaced AFTER this resumed match had
       // already run to full-time while suppressed. Now that the bound fixture's

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -344,6 +344,22 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _persistMatchState();
   }
 
+  /// Same as [_flushMatchStateNow] but awaits the underlying store write, for
+  /// paths where the persisted snapshot must be DURABLE before the caller
+  /// continues — e.g. the RAVF004 corrected-score write-back, whose whole
+  /// purpose is that a kill cannot resurface the pre-correction score on a later
+  /// terminal-rejection re-open. Forces the save (the explicit-flush intent),
+  /// bypassing the `_dirty` short-circuit, but still honours `_suppressPersist`
+  /// and a null store. Awaitable callers must be off the robot START/STOP hot
+  /// path (invariant #1).
+  Future<void> _flushMatchStateNowAndWait() async {
+    if (_suppressPersist) return;
+    final store = _stateStore;
+    if (store == null) return;
+    _dirty = false;
+    await store.save(_buildSnapshot());
+  }
+
   /// Public clear for intentional fresh-start paths outside the resume flow
   /// (e.g. Settings "Reset current game"). gameInit() deliberately does not
   /// clear the snapshot, so those paths must clear it explicitly or a killed
@@ -1153,8 +1169,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// knows this is a USER-CONFIRMED Load — which must reset a match already in
   /// progress/finished (RAVF002) — rather than an automatic same-fixture
   /// refresh. confirmPendingMatch promotes + notifies SYNCHRONOUSLY, so the flag
-  /// is in place when the apply runs; the post-await clear is a belt-and-braces
-  /// reset in case a stale-dialog reject promoted nothing.
+  /// is in place when the apply runs. After the await we await the snapshot clear
+  /// the reset stashed (RAVF002 durability), and the `finally` clears the
+  /// confirmed-load signals so a rejected/no-op promotion leaves nothing armed
+  /// for a later apply.
   Future<void> confirmScoreboardMatch({String? expectedSignature}) async {
     // Capture the signature of the fixture being confirmed so the resulting
     // apply only treats THAT exact fixture as a confirmed Load. confirmPendingMatch
@@ -1531,7 +1549,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           team.score = awayGoals;
         }
       }
-      _flushMatchStateNow();
+      // Await the snapshot write so the corrected scores are DURABLE before
+      // submit returns. enqueueFinalResult already persisted the outbox item
+      // durably; a kill in the gap between that and a fire-and-forget snapshot
+      // save would restore the OLD scores, and a later terminal 401/422 rejection
+      // would re-open the review reading the stale teams[*].score — the exact
+      // RAVF004 loss this write-back exists to prevent. submitScoreboardResult is
+      // async and awaited by the review screen, never the robot hot path.
+      await _flushMatchStateNowAndWait();
     }
     // enqueueFinalResult already notifies on every outcome it can change
     // (queued / already-tracked), and Game listens to the service and re-emits,

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -96,6 +96,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // which re-applies the UNCHANGED committed config, can never be mistaken for
   // the confirmed Load. Consumed on the next apply.
   String? _confirmedLoadSignature;
+  // Future of the resumable-snapshot clear started by a confirmed new-fixture
+  // Load reset (RAVF002). _applyScoreboardMatchConfig runs synchronously inside
+  // confirmPendingMatch's notify, so it cannot await the tombstone itself;
+  // instead it stashes the awaitable clear here and confirmScoreboardMatch (the
+  // only path that can reach the reset branch) awaits it before the Load dialog
+  // dismisses. An immediate kill must not preserve the snapshot of the match the
+  // referee just replaced — mirrors discardPendingMatch's awaited clear.
+  Future<void>? _confirmedLoadClear;
   String? _lastPromptedPendingSignature;
   String? _scoreboardHomeTeamId;
   String? _scoreboardAwayTeamId;
@@ -1167,8 +1175,16 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     try {
       await scoreboardResultService.confirmPendingMatch(
           expectedSignature: expectedSignature);
+      // If the synchronous apply above reset a live match (RAVF002), it stashed
+      // the awaitable snapshot clear; await it so the Load dialog does not dismiss
+      // before the tombstone lands. This await is on the dialog/Load path only,
+      // never the robot START/STOP hot path (invariant #1).
+      final clear = _confirmedLoadClear;
+      _confirmedLoadClear = null;
+      if (clear != null) await clear;
     } finally {
       _confirmedLoadSignature = null;
+      _confirmedLoadClear = null;
     }
   }
 
@@ -1303,7 +1319,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _periodTime = config.durationSeconds;
       gameInit();
       setTeamToDefaultOrder();
-      _clearMatchState();
+      // Use the AWAITABLE clear (not the fire-and-forget _clearMatchState) and
+      // stash its future so confirmScoreboardMatch can await the tombstone before
+      // the Load dialog dismisses (RAVF002 durability). discardPendingMatch — the
+      // sibling destructive "replace the match" path — awaits its clear for the
+      // same reason: an immediate kill must not re-offer the replaced match. The
+      // synchronous part (_dirty=false + initiating the tombstone write) runs now;
+      // only the disk completion is awaited later, off the robot hot path.
+      _confirmedLoadClear = _clearMatchStateAndWait();
     } else if (reArmedFromSuppression && currentStage == MatchStage.fullTime) {
       // The bound fixture's config only surfaced AFTER this resumed match had
       // already run to full-time while suppressed. Now that the bound fixture's

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1010,9 +1010,11 @@ Future<void> _openScoreboardResultReview(
                           backgroundColor: Colors.green[600],
                         ),
                         onPressed: () async {
-                          await game.scoreboardResultService
-                              .confirmPendingMatch(
-                                  expectedSignature: expectedSignature);
+                          // Route through Game (not the service directly) so a
+                          // confirmed Load resets a match in progress/finished
+                          // (RAVF002).
+                          await game.confirmScoreboardMatch(
+                              expectedSignature: expectedSignature);
                           if (dialogContext.mounted) {
                             Navigator.of(dialogContext).pop();
                           }

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -1856,6 +1856,390 @@ void main() {
     });
   });
 
+  group('new-fixture Load resets the live match (RAVF002)', () {
+    // Drive the real confirm path: stage a pending deep link, then
+    // game.confirmScoreboardMatch() (what Home's Load button calls). Only that
+    // user-confirmed path resets a match in progress/finished.
+    Future<void> confirmLoad(
+      WidgetTester tester,
+      Game game,
+      Map<String, dynamic> config,
+    ) async {
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(config),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      await game.confirmScoreboardMatch();
+      await tester.pump();
+    }
+
+    testWidgets(
+        'a confirmed Load of the SAME fixture still resets (not deduped away)',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-A', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      game.startTimer();
+      await tester.pump();
+      game.teams.firstWhere((t) => t.id == 'A').addScore(2);
+      await tester.pump();
+      expect(game.inGame, isTrue);
+
+      // Re-stage + confirm the SAME fixture (identical signature to the one
+      // already applied). The warned overwrite must still reset to a clean
+      // start, not be deduped away.
+      await confirmLoad(
+          tester, game, _scoreboardConfig(matchCode: 'M-A', version: 1));
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 0,
+          reason: 'a confirmed Load resets even for the same fixture');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a confirmed Load of a different fixture mid-match resets scores + '
+        'team order but keeps the outbox', (tester) async {
+      // A result the referee already submitted for the OLD fixture is queued.
+      await _seedOutbox(prefs, [
+        _outboxItem(
+          matchCode: 'M-OLD',
+          state: ResultSubmissionState.pending,
+          homeGoals: 1,
+          awayGoals: 0,
+        ),
+      ]);
+      final game = Game();
+      await settleLoad(tester);
+
+      // Load + start the OLD fixture, swap order (as in a 2nd half), score 2-1.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-OLD',
+          version: 1,
+          homeTeamName: 'Reds',
+          awayTeamName: 'Blues',
+        )),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      game.toggleTeamOrder(); // teams become [B, A]
+      await tester.pump();
+      game.startTimer();
+      await tester.pump();
+      game.teams.firstWhere((t) => t.id == 'A').addScore(2);
+      game.teams.firstWhere((t) => t.id == 'B').addScore(1);
+      await tester.pump();
+      expect(game.inGame, isTrue);
+
+      // Referee confirms loading a DIFFERENT fixture (the warned overwrite).
+      await confirmLoad(
+        tester,
+        game,
+        _scoreboardConfig(
+          matchCode: 'M-NEW',
+          version: 1,
+          durationSeconds: 120,
+          homeTeamName: 'Greens',
+          awayTeamName: 'Yellows',
+        ),
+      );
+
+      // Live match reset to a clean state bound to the NEW fixture.
+      expect(game.inGame, isFalse, reason: 'reset to loaded-not-started');
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 0);
+      expect(game.teams.firstWhere((t) => t.id == 'B').score, 0);
+      // New fixture is home_is_left:true → home=A=Greens, away=B=Yellows.
+      expect(game.teams.firstWhere((t) => t.id == 'A').name, 'Greens');
+      expect(game.teams.firstWhere((t) => t.id == 'B').name, 'Yellows');
+      // Default team order restored for the new first half (not left swapped).
+      expect(game.teams[0].id, 'A',
+          reason: 'a swapped order must not carry into the new match');
+      expect(game.teams[1].id, 'B');
+      // The new fixture's match length was adopted (M-NEW is 120 s).
+      expect(game.periodTime, 120,
+          reason:
+              'the new fixture duration replaces the previous match length');
+
+      // The previous fixture's queued result is untouched (rule 3).
+      expect(
+        game.scoreboardResultService.outbox
+            .where((i) => i.matchCode == 'M-OLD')
+            .length,
+        1,
+        reason: 'loading a new match must never wipe the outbox',
+      );
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a same-fixture refresh mid-match preserves the scores (not a Load)',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-SAME', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      game.startTimer();
+      await tester.pump();
+      game.teams.firstWhere((t) => t.id == 'A').addScore(3);
+      await tester.pump();
+
+      // SAME fixture, bumped version: an automatic refresh (no confirmed Load),
+      // so it must NOT reset. signature includes version, so it re-applies.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-SAME', version: 2)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      expect(game.inGame, isTrue,
+          reason: 'a same-fixture refresh must not reset the match');
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 3,
+          reason: 'just-played scores preserved on a same-fixture refresh');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a confirmed Load overrides a still-suppressed resume and resets to it',
+        (tester) async {
+      // Cold-resume a referee match bound to M-RES whose config has NOT yet
+      // surfaced (suppressed), in progress at 1-0.
+      await persist(_snap(
+        stage: 'firstHalf',
+        remainingTime: 200,
+        scoreA: 1,
+        scoreB: 0,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-RES',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.scoreboardResultService.matchConfig, isNull);
+      game.resumePendingMatch(); // suppressed: bound to M-RES, no config
+      await tester.pump();
+      expect(game.inGame, isTrue);
+
+      // User confirms loading a DIFFERENT fixture while still suppressed. The
+      // suppressed-resume rejection must NOT block an explicit Load.
+      await confirmLoad(
+        tester,
+        game,
+        _scoreboardConfig(
+          matchCode: 'M-OTHER',
+          version: 1,
+          homeTeamName: 'Greens',
+          awayTeamName: 'Yellows',
+        ),
+      );
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 0,
+          reason: 'a confirmed Load overrides the suppressed-resume rejection');
+      expect(game.teams.firstWhere((t) => t.id == 'A').name, 'Greens');
+      expect(game.scoreboardResultService.matchConfig?.matchCode, 'M-OTHER');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a delivered 200 still resets after the response bumped the committed '
+        'version (no regression)', (tester) async {
+      await _seedScoreboardPrefs(
+        prefs,
+        _scoreboardConfig(
+          matchCode: 'M-BUMP',
+          version: 2,
+          homeTeamName: 'Reds',
+          awayTeamName: 'Blues',
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await persist(_snap(
+        stage: 'fullTime',
+        remainingTime: 0,
+        scoreA: 2,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-BUMP',
+        scoreboardVersion: 2,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      await settleScoreboardConfig(tester, game);
+      await tester.pump();
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      // A successful POST returns a NEW version, which the service applies to the
+      // committed config (_updateMatchVersionFromResponse) BEFORE firing the
+      // delivery callback. Reproduce that committed-version bump, then deliver.
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(_scoreboardConfig(
+          matchCode: 'M-BUMP',
+          version: 3,
+          homeTeamName: 'Reds',
+          awayTeamName: 'Blues',
+        )),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      game.scoreboardResultService.onCurrentResultDelivered?.call();
+      await tester.pump();
+      await tester.pump();
+
+      // The genuine 200 must STILL reset the finished match to a clean start,
+      // even though the committed version no longer equals the full-time
+      // subject's (the reset keys on stage + a captured full-time signature, not
+      // on the post-response committed signature).
+      expect(game.currentStage, MatchStage.firstHalf,
+          reason: 'a genuine 200 must reset even after a version bump');
+      expect(game.teams.firstWhere((t) => t.id == 'A').name, 'Team A',
+          reason: 'reset restores default team names');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a STALE-dialog Load (rejected promotion) does not reset the live match',
+        (tester) async {
+      // Suppressed resume bound to M-RES (config not surfaced), in progress 1-0.
+      await persist(_snap(
+        stage: 'firstHalf',
+        remainingTime: 200,
+        scoreA: 1,
+        scoreB: 0,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-RES',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      game.resumePendingMatch(); // suppressed, bound to M-RES
+      await tester.pump();
+      expect(game.inGame, isTrue);
+
+      // A committed config for a DIFFERENT fixture arrives and is rejected by the
+      // suppressed-resume guard: committed becomes M-OLD but is NOT applied
+      // (so _lastAppliedScoreboardSignature stays unequal to it).
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-OLD', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      // A newer pending link is staged; the user taps a STALE Load whose
+      // expectedSignature no longer matches the pending fixture, so the service
+      // rejects the promotion. With a bare confirmed-load flag this would have
+      // re-applied committed M-OLD as a "new fixture" and wiped the resume; the
+      // signature-keyed signal must refuse (confirmed sig != applied sig).
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-B', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      await game.confirmScoreboardMatch(expectedSignature: 'stale-signature');
+      await tester.pump();
+
+      expect(game.inGame, isTrue,
+          reason: 'a rejected stale Load must not reset');
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 1,
+          reason: 'the suppressed resume scores must be preserved');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets(
+        'a stale Load whose pending shares the committed-but-unapplied '
+        "fixture's signature still does not reset", (tester) async {
+      await persist(_snap(
+        stage: 'firstHalf',
+        remainingTime: 200,
+        scoreA: 1,
+        scoreB: 0,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-RES',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      await settleLoad(tester);
+      game.resumePendingMatch();
+      await tester.pump();
+
+      // Committed M-OLD arrives, rejected by the suppress guard (unapplied).
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-OLD', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+
+      // Pending is now ALSO M-OLD (same signature as committed). The user taps a
+      // STALE older dialog whose expectedSignature is a DIFFERENT fixture, so the
+      // promotion is rejected. The confirmed signal must not arm (pending !=
+      // expectedSignature), so no reset despite pending == committed signature.
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+            _scoreboardConfig(matchCode: 'M-OLD', version: 1)),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      await game.confirmScoreboardMatch(
+          expectedSignature: 'stale-older-signature');
+      await tester.pump();
+
+      expect(game.inGame, isTrue,
+          reason: 'a rejected stale Load must not reset');
+      expect(game.teams.firstWhere((t) => t.id == 'A').score, 1,
+          reason: 'preserved even when pending shares the committed signature');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('scoreboard team naming (#53)', () {
     Team teamById(Game game, String id) =>
         game.teams.firstWhere((t) => t.id == id);


### PR DESCRIPTION
Resolves the **RAVF002** half of the fixture-isolation cluster in #68 (follow-up to #61 / #51).

> **Stacked on #61** — base branch is `feat/issue-51-referee-lifecycle`, so this diff is only the isolation commit. Once #61 merges to `dev`, GitHub auto-retargets this PR to `dev`. Please merge #61 first.

### What & why
When a referee match is in progress or finished and the referee confirms the **"Load match?"** overwrite dialog for a deep link, the dialog warns it *"replaces the match in progress"* — but the old code only reset scores/clock when `!inGame`, so the carried-over scores could be submitted as the **new** fixture's result.

Now Home's Load button calls `Game.confirmScoreboardMatch()`, which records the **confirmed fixture's signature** (only when the pending fixture matches the dialog's `expectedSignature`) before promoting the staged config. `_applyScoreboardMatchConfig` then resets to a clean match bound to the new fixture (`gameInit` → `setTeamToDefaultOrder` → clear snapshot) whenever the applied config **is** that confirmed fixture and `inGame` — overriding the suppressed-resume rejection and the dedupe early-return.

The three agreed rules (decided by @mato157):
1. **Confirmed new-fixture Load** → reset the live match to clean (0-0, new duration, new names, default order).
2. **Automatic same-fixture refresh** (version bump / #50 venue correction) → preserve the just-played scores.
3. **The outbox always survives a Load** — an already-submitted result keeps retrying; its late 200 can't reset a since-replaced match (`gameInit` never touches the outbox, and a Load moves the stage off full-time so the delivery guard rejects it).

### Design notes
- The signal is keyed on the **confirmed signature** (not a bare flag, not a matchCode tracker) — this defeats a stale-dialog reject re-applying the unchanged committed config, a missed reset during a suppressed resume, and a stale tracker after cold-restore.
- `gameInit()` runs **before** `setTeamToDefaultOrder()` and the venue rebroadcast is skipped for a Load, so only the clean 0-0 state is published (no wrong-score flicker on external displays).
- **R3-B** needs no separate guard and the naive signature check on the delivery handler *regressed* the happy path (the server bumps the committed version in the 200 body before the callback fires) — reverted; RAVF002 subsumes the scenario.

### Deferred (still tracked in #68)
**R2-A** — distinguishing a restored match's *own* pending result from a *different* run's needs result **run-provenance**; doing it naively re-opens the RAVF001/R2-B reset hazard (real data loss). The current guard is the safe default (R2-A is a no-data-loss annoyance). Left for a dedicated pass.

### Verification
- **5 rounds of codex review + an independent claude review** — each codex round fixed a real edge (regressing R3-B check, suppressed-resume Load, cold-restore staleness, team order, broadcast ordering, bare-bool→signature signal, stale-dialog arming guard, same-fixture-Load dedupe); final two passes clean, no material findings.
- **+7 unit tests** (same-fixture confirmed Load resets; different-fixture Load resets scores/order/duration and keeps the outbox; same-fixture refresh preserves; confirmed Load overrides a suppressed resume; a version-bumped 200 still resets; two stale-dialog rejects do not reset). **167 tests pass**, `flutter analyze --fatal-infos` clean.
- **Device-verified on a Pixel 10**: loaded match A (Red Robots vs Blue Bots), scored 1-0, then mid-match (it had even reached half-time with swapped order) loaded a different fixture B (Green Giants vs Yellow Yaks) → the live match reset to a clean **0-0**, new names, **00:30** (B's duration), default order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
