### PR TITLE
feat(scoreboard): auto-pair robot modules from server MACs (#70)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1225,6 +1225,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     final signature = config.signature;
     final isConfirmedNewFixtureLoad =
         confirmedSignature != null && confirmedSignature == signature && inGame;
+    // #70: auto-pair the robots' comm modules from the server MACs, but ONLY
+    // when this apply (re)loads/resets the match — a fresh link load (!inGame)
+    // or a confirmed "Load match?" overwrite. Capture the decision now, BEFORE
+    // gameInit() below flips `inGame`, so an incidental mid-match re-apply (a
+    // name/venue correction) never re-pairs modules the referee is actively
+    // using. The pairing itself runs at the END of this method.
+    final shouldAutoPairModules = !inGame || isConfirmedNewFixtureLoad;
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing
@@ -1354,6 +1361,34 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // kill before Submit can resume the review (RAVF003).
       _enterFullTimeResultReview();
       _persistOrClearAtFullTime();
+    }
+
+    // #70: pair each side's comm modules from the server MACs. Runs LAST so the
+    // enable/disable state gameInit() just applied is settled first —
+    // applyPresetConfig only connects an ENABLED module, and a disabled slot
+    // must not be left holding a live link. Off the START/STOP hot path
+    // (invariant #1): this is config-load time, clock stopped.
+    if (shouldAutoPairModules) {
+      _autoPairScoreboardModules(config);
+    }
+  }
+
+  void _autoPairScoreboardModules(ScoreboardMatchConfig config) {
+    // Map each side's MACs onto that side's fixed module slots, keyed by team ID
+    // (not list position) so a swapped team order can't cross the sides —
+    // mirroring the name loop. Only the slots the server supplies a MAC for are
+    // touched, so a partial list never clobbers a hand-paired spare slot; the
+    // server config is authoritative only for the modules it actually names.
+    // The empty label lets each slot fall back to its default name (A1..A5) via
+    // Module.name; applyPresetConfig is idempotent (skips a slot already on that
+    // MAC) so a version-bump re-apply won't churn live BLE links.
+    for (final team in teams) {
+      final macs = team.id == _scoreboardHomeTeamId
+          ? config.homeModuleMacs
+          : config.awayModuleMacs;
+      for (var i = 0; i < team.modules.length && i < macs.length; i++) {
+        team.modules[i].applyPresetConfig(macs[i], '');
+      }
     }
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -87,6 +87,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   WakelockService wakelockService = WakelockService();
   ScoreboardResultService scoreboardResultService = ScoreboardResultService();
   String? _lastAppliedScoreboardSignature;
+  // MAC-set fingerprint of the last module auto-pair (see
+  // _syncScoreboardModulePairing). Separate from _lastAppliedScoreboardSignature
+  // so a MAC-only change (e.g. a refresh on the upgrade path) still re-pairs even
+  // when the fixture signature is unchanged.
+  String? _lastPairedModuleMacsSignature;
   // Signature of the fixture the user just CONFIRMED loading (set by
   // [confirmScoreboardMatch]). Lets _applyScoreboardMatchConfig tell a
   // user-confirmed new-fixture Load — which must reset a match in
@@ -254,6 +259,16 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           (snapshot.scoreboardMatchCode?.isNotEmpty ?? false)) {
         _restoreFullTimeResultReview(snapshot);
       }
+    }
+
+    // #70: re-pair the linked fixture's modules now that the saved player count
+    // is loaded. On a cold start scoreboardResultService.initialize() may have
+    // run the first pairing while numberOfPlayers was still the default, leaving
+    // the extra slots disabled and unconnected; force a re-pair against the real
+    // count. Skip it when a mid-match resume is pending — that path restores
+    // modules from the snapshot, not from the fixture MACs.
+    if (_pendingResume == null) {
+      _syncScoreboardModulePairing(force: true);
     }
 
     // Prompt for notification permission once on first launch (one-shot), now
@@ -1107,6 +1122,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       team.name = team.id == 'A' ? 'Team A' : 'Team B';
     }
     _lastAppliedScoreboardSignature = null;
+    _lastPairedModuleMacsSignature = null;
     _scoreboardHomeTeamId = null;
     _scoreboardAwayTeamId = null;
     _fullTimeResultSignature = null;
@@ -1135,6 +1151,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     final config = scoreboardResultService.matchConfig;
     if (config != null) {
       _applyScoreboardMatchConfig(config);
+      // Pair modules AFTER the apply so gameInit()'s enable/disable state is
+      // settled. Runs even when _applyScoreboardMatchConfig deduped on an
+      // unchanged fixture signature, so a refresh that only adds MACs (the
+      // upgrade path) still pairs — the MAC-signature dedupe inside keeps it a
+      // no-op otherwise.
+      _syncScoreboardModulePairing();
     }
     notifyListeners();
   }
@@ -1225,13 +1247,6 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     final signature = config.signature;
     final isConfirmedNewFixtureLoad =
         confirmedSignature != null && confirmedSignature == signature && inGame;
-    // #70: auto-pair the robots' comm modules from the server MACs, but ONLY
-    // when this apply (re)loads/resets the match — a fresh link load (!inGame)
-    // or a confirmed "Load match?" overwrite. Capture the decision now, BEFORE
-    // gameInit() below flips `inGame`, so an incidental mid-match re-apply (a
-    // name/venue correction) never re-pairs modules the referee is actively
-    // using. The pairing itself runs at the END of this method.
-    final shouldAutoPairModules = !inGame || isConfirmedNewFixtureLoad;
     // Dedupe on an unchanged signature - EXCEPT while a resumed match is still
     // suppressed. `_lastAppliedScoreboardSignature` is in-memory and is never
     // cleared when the service drops `_matchConfig` to null (a token-changing
@@ -1362,34 +1377,51 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       _enterFullTimeResultReview();
       _persistOrClearAtFullTime();
     }
-
-    // #70: pair each side's comm modules from the server MACs. Runs LAST so the
-    // enable/disable state gameInit() just applied is settled first —
-    // applyPresetConfig only connects an ENABLED module, and a disabled slot
-    // must not be left holding a live link. Off the START/STOP hot path
-    // (invariant #1): this is config-load time, clock stopped.
-    if (shouldAutoPairModules) {
-      _autoPairScoreboardModules(config);
-    }
   }
 
   void _autoPairScoreboardModules(ScoreboardMatchConfig config) {
     // Map each side's MACs onto that side's fixed module slots, keyed by team ID
-    // (not list position) so a swapped team order can't cross the sides —
-    // mirroring the name loop. Only the slots the server supplies a MAC for are
-    // touched, so a partial list never clobbers a hand-paired spare slot; the
-    // server config is authoritative only for the modules it actually names.
-    // The empty label lets each slot fall back to its default name (A1..A5) via
-    // Module.name; applyPresetConfig is idempotent (skips a slot already on that
-    // MAC) so a version-bump re-apply won't churn live BLE links.
+    // (not list position) so a swapped team order can't cross the sides. The
+    // home->id rule mirrors _deriveScoreboardSideMapping but is computed locally
+    // from config.homeIsLeft so pairing never depends on _scoreboardHomeTeamId
+    // being derived first (it can run before/independently of an apply). Only
+    // the slots the server supplies a MAC for are touched, so a partial list
+    // never clobbers a hand-paired spare slot; the server config is
+    // authoritative only for the modules it actually names. The empty label lets
+    // each slot fall back to its default name (A1..A5) via Module.name;
+    // applyPresetConfig is idempotent (skips a slot already on that MAC) so a
+    // re-pair won't churn live BLE links.
+    final homeId = config.homeIsLeft ? 'A' : 'B';
     for (final team in teams) {
-      final macs = team.id == _scoreboardHomeTeamId
-          ? config.homeModuleMacs
-          : config.awayModuleMacs;
+      final macs =
+          team.id == homeId ? config.homeModuleMacs : config.awayModuleMacs;
       for (var i = 0; i < team.modules.length && i < macs.length; i++) {
         team.modules[i].applyPresetConfig(macs[i], '');
       }
     }
+  }
+
+  /// Pair the linked fixture's modules if the MAC set (or side) changed since the
+  /// last pairing. Runs only between matches (`!inGame`) so a live match keeps
+  /// whatever the referee has connected. Deduped on a MAC signature — NOT the
+  /// fixture signature — so a refresh that adds MACs to an already-applied
+  /// fixture (e.g. the upgrade path where the persisted config predates the MAC
+  /// fields) still pairs even though `_applyScoreboardMatchConfig` deduped it
+  /// away. `force` bypasses the dedupe to re-pair after the saved player count
+  /// loads on a cold start (the first pass may have run while numberOfPlayers was
+  /// still the default, leaving the extra slots disabled and unconnected).
+  void _syncScoreboardModulePairing({bool force = false}) {
+    final config = scoreboardResultService.matchConfig;
+    if (config == null || inGame) return;
+    // A MAC-set fingerprint. MACs are validated hex + colons, so ','/'|' can't
+    // occur in them and this delimiter join can't alias two different sets
+    // (avoids pulling in dart:convert for a jsonEncode).
+    final macSignature = '${config.homeIsLeft}'
+        '|${config.homeModuleMacs.join(',')}'
+        '|${config.awayModuleMacs.join(',')}';
+    if (!force && macSignature == _lastPairedModuleMacsSignature) return;
+    _lastPairedModuleMacsSignature = macSignature;
+    _autoPairScoreboardModules(config);
   }
 
   bool _canSubmitScoreboardResult([ScoreboardMatchConfig? config]) {

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -14,6 +14,13 @@ class ScoreboardMatchConfig {
   final int version;
   final String status;
 
+  /// MAC addresses of the home/away robots' comm modules, ordered by robot
+  /// number (server payload keys `home_module_macs`/`away_module_macs`, #70).
+  /// The app maps these onto the fixed per-side module slots for auto-pairing.
+  /// Empty for older payloads that never carried them.
+  final List<String> homeModuleMacs;
+  final List<String> awayModuleMacs;
+
   const ScoreboardMatchConfig({
     required this.matchCode,
     required this.homeTeamName,
@@ -25,6 +32,8 @@ class ScoreboardMatchConfig {
     required this.timezone,
     required this.version,
     required this.status,
+    this.homeModuleMacs = const [],
+    this.awayModuleMacs = const [],
   });
 
   ScoreboardMatchConfig copyWith({
@@ -38,6 +47,8 @@ class ScoreboardMatchConfig {
     String? timezone,
     int? version,
     String? status,
+    List<String>? homeModuleMacs,
+    List<String>? awayModuleMacs,
   }) {
     return ScoreboardMatchConfig(
       matchCode: matchCode ?? this.matchCode,
@@ -50,6 +61,8 @@ class ScoreboardMatchConfig {
       timezone: timezone ?? this.timezone,
       version: version ?? this.version,
       status: status ?? this.status,
+      homeModuleMacs: homeModuleMacs ?? this.homeModuleMacs,
+      awayModuleMacs: awayModuleMacs ?? this.awayModuleMacs,
     );
   }
 
@@ -85,6 +98,14 @@ class ScoreboardMatchConfig {
         scheduledStartRaw == null ? null : DateTime.tryParse(scheduledStartRaw);
     final durationSeconds = (json['duration_seconds'] as num?)?.toInt() ?? 600;
 
+    List<String> moduleMacs(dynamic value) {
+      if (value is! List) return const [];
+      return value
+          .map((e) => e.toString().trim().toUpperCase())
+          .where((mac) => mac.isNotEmpty)
+          .toList();
+    }
+
     return ScoreboardMatchConfig(
       matchCode: (json['match_code']?.toString() ?? '').trim(),
       homeTeamName: teamName(json['home_team'], 'Home'),
@@ -96,6 +117,8 @@ class ScoreboardMatchConfig {
       timezone: (json['timezone']?.toString() ?? 'UTC').trim(),
       version: (json['version'] as num?)?.toInt() ?? 0,
       status: (json['status']?.toString() ?? '').toUpperCase(),
+      homeModuleMacs: moduleMacs(json['home_module_macs']),
+      awayModuleMacs: moduleMacs(json['away_module_macs']),
     );
   }
 
@@ -111,6 +134,12 @@ class ScoreboardMatchConfig {
   /// only the venue (same match/version) still re-applies and updates the MQTT
   /// field number (#50); this keeps the apply-dedupe and the cold-resume re-arm
   /// in lock-step on a single signature.
+  ///
+  /// The module MACs are deliberately NOT part of the signature: auto-pairing
+  /// runs at match (re)load (see Game._applyScoreboardMatchConfig), and folding
+  /// MACs into the fixture identity would make an out-of-band module-assignment
+  /// change re-trigger the "Load match?" overwrite and the result-review guards
+  /// mid-match. A MAC-only correction therefore does not force a re-pair.
   String get signature => jsonEncode(<dynamic>[
         matchCode,
         version,
@@ -132,6 +161,8 @@ class ScoreboardMatchConfig {
         'timezone': timezone,
         'version': version,
         'status': status,
+        'home_module_macs': homeModuleMacs,
+        'away_module_macs': awayModuleMacs,
       };
 }
 

--- a/test/scoreboard_module_pairing_test.dart
+++ b/test/scoreboard_module_pairing_test.dart
@@ -135,6 +135,29 @@ void main() {
     game.dispose();
   });
 
+  testWidgets(
+      'a later MAC set pairs even when the fixture signature is unchanged',
+      (tester) async {
+    final game = await loadedGame(tester);
+
+    // First apply: the same fixture with no module MACs — the pre-#70 persisted
+    // shape an upgrading user carries. Nothing to pair yet.
+    apply(game, _config());
+    await tester.pump();
+    expect(teamById(game, 'A').modules[0].macAddress, '');
+
+    // A refresh of the SAME fixture (identical signature fields) that now
+    // carries MACs. _applyScoreboardMatchConfig dedupes on the unchanged
+    // signature — MACs are not part of it — so the module sync is what must
+    // still pair the newly-arrived MAC.
+    apply(game, _config(homeMacs: ['A1:B2:C3:D4:E5:F6']));
+    await tester.pump();
+
+    expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
+
+    game.dispose();
+  });
+
   testWidgets('no module keys leaves every slot unpaired', (tester) async {
     final game = await loadedGame(tester);
 

--- a/test/scoreboard_module_pairing_test.dart
+++ b/test/scoreboard_module_pairing_test.dart
@@ -6,9 +6,7 @@
 // Uses testWidgets for the same reason as scoreboard_field_test/game_recovery_
 // test: the Game constructor stands up wakelock/notification/MQTT/bridge
 // services whose platform-channel calls reject asynchronously in the headless
-// test VM, which the widget binding tolerates. applyPresetConfig sets each
-// slot's macAddress synchronously (before the BLE connect), so the assertions
-// hold; a trailing pump drains the 100 ms connect fan-out so no Timer leaks.
+// test VM, which the widget binding tolerates.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -47,9 +45,18 @@ void main() {
     await prefs.clear();
   });
 
-  Future<void> settleLoad(WidgetTester tester) async {
+  // A loaded Game with every slot disabled. applyPresetConfig then sets each
+  // module's macAddress (the mapping under test) WITHOUT a real bleConnect(),
+  // which is unsupported in the headless test VM — mirroring game_recovery_
+  // test's disabled-during-restore pattern; on a real device the enabled slots
+  // connect as normal. numberOfPlayers is set AFTER the two pumps that drain the
+  // async _loadPrefs(), so its default (2) doesn't overwrite the 0.
+  Future<Game> loadedGame(WidgetTester tester) async {
+    final game = Game();
     await tester.pump();
     await tester.pump();
+    game.numberOfPlayers = 0;
+    return game;
   }
 
   Team teamById(Game game, String id) =>
@@ -63,8 +70,7 @@ void main() {
 
   testWidgets('pairs home MACs onto team A and away MACs onto team B',
       (tester) async {
-    final game = Game();
-    await settleLoad(tester);
+    final game = await loadedGame(tester);
 
     apply(
       game,
@@ -80,14 +86,12 @@ void main() {
     expect(teamById(game, 'A').modules[1].macAddress, '11:22:33:44:55:66');
     expect(teamById(game, 'B').modules[0].macAddress, 'AA:BB:CC:DD:EE:FF');
 
-    await tester.pump(const Duration(milliseconds: 400)); // drain connect fan-out
     game.dispose();
   });
 
   testWidgets('a right-side home maps home MACs onto team B (keyed by ID)',
       (tester) async {
-    final game = Game();
-    await settleLoad(tester);
+    final game = await loadedGame(tester);
 
     apply(
       game,
@@ -103,27 +107,23 @@ void main() {
     expect(teamById(game, 'B').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
     expect(teamById(game, 'A').modules[0].macAddress, 'AA:BB:CC:DD:EE:FF');
 
-    await tester.pump(const Duration(milliseconds: 400));
     game.dispose();
   });
 
   testWidgets('lower-case MACs are normalised to upper-case', (tester) async {
-    final game = Game();
-    await settleLoad(tester);
+    final game = await loadedGame(tester);
 
     apply(game, _config(homeMacs: ['a1:b2:c3:d4:e5:f6']));
     await tester.pump();
 
     expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
 
-    await tester.pump(const Duration(milliseconds: 400));
     game.dispose();
   });
 
   testWidgets('a partial MAC list only fills the slots it provides',
       (tester) async {
-    final game = Game();
-    await settleLoad(tester);
+    final game = await loadedGame(tester);
 
     apply(game, _config(homeMacs: ['A1:B2:C3:D4:E5:F6']));
     await tester.pump();
@@ -132,13 +132,11 @@ void main() {
     expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
     expect(teamById(game, 'A').modules[1].macAddress, '');
 
-    await tester.pump(const Duration(milliseconds: 400));
     game.dispose();
   });
 
   testWidgets('no module keys leaves every slot unpaired', (tester) async {
-    final game = Game();
-    await settleLoad(tester);
+    final game = await loadedGame(tester);
 
     apply(game, _config());
     await tester.pump();

--- a/test/scoreboard_module_pairing_test.dart
+++ b/test/scoreboard_module_pairing_test.dart
@@ -1,0 +1,152 @@
+// Tests for #70: a referee-link match auto-pairs each side's comm modules from
+// the server-provided MACs (home_module_macs / away_module_macs), mapping them
+// onto the fixed per-side module slots by team ID so a swapped side never
+// crosses the sides.
+//
+// Uses testWidgets for the same reason as scoreboard_field_test/game_recovery_
+// test: the Game constructor stands up wakelock/notification/MQTT/bridge
+// services whose platform-channel calls reject asynchronously in the headless
+// test VM, which the widget binding tolerates. applyPresetConfig sets each
+// slot's macAddress synchronously (before the BLE connect), so the assertions
+// hold; a trailing pump drains the 100 ms connect fan-out so no Timer leaks.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:rcj_scoreboard/models/game.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/models/team.dart';
+
+Map<String, dynamic> _config({
+  String matchCode = 'M-1',
+  bool homeIsLeft = true,
+  List<String> homeMacs = const [],
+  List<String> awayMacs = const [],
+}) =>
+    {
+      'match_code': matchCode,
+      'home_team': 'Home',
+      'away_team': 'Away',
+      'home_is_left': homeIsLeft,
+      'venue': '1',
+      'scheduled_start': null,
+      'duration_seconds': 600,
+      'timezone': 'Europe/Prague',
+      'version': 1,
+      'status': 'SCHEDULED',
+      'home_module_macs': homeMacs,
+      'away_module_macs': awayMacs,
+    };
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  });
+
+  Future<void> settleLoad(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump();
+  }
+
+  Team teamById(Game game, String id) =>
+      game.teams.firstWhere((t) => t.id == id);
+
+  void apply(Game game, Map<String, dynamic> config) {
+    game.scoreboardResultService.debugApplyMatchConfig(
+      ScoreboardMatchConfig.fromJson(config),
+    );
+  }
+
+  testWidgets('pairs home MACs onto team A and away MACs onto team B',
+      (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(
+      game,
+      _config(
+        homeIsLeft: true,
+        homeMacs: ['A1:B2:C3:D4:E5:F6', '11:22:33:44:55:66'],
+        awayMacs: ['AA:BB:CC:DD:EE:FF'],
+      ),
+    );
+    await tester.pump();
+
+    expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
+    expect(teamById(game, 'A').modules[1].macAddress, '11:22:33:44:55:66');
+    expect(teamById(game, 'B').modules[0].macAddress, 'AA:BB:CC:DD:EE:FF');
+
+    await tester.pump(const Duration(milliseconds: 400)); // drain connect fan-out
+    game.dispose();
+  });
+
+  testWidgets('a right-side home maps home MACs onto team B (keyed by ID)',
+      (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(
+      game,
+      _config(
+        homeIsLeft: false,
+        homeMacs: ['A1:B2:C3:D4:E5:F6'],
+        awayMacs: ['AA:BB:CC:DD:EE:FF'],
+      ),
+    );
+    await tester.pump();
+
+    // home_is_left:false binds home -> team B, away -> team A.
+    expect(teamById(game, 'B').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
+    expect(teamById(game, 'A').modules[0].macAddress, 'AA:BB:CC:DD:EE:FF');
+
+    await tester.pump(const Duration(milliseconds: 400));
+    game.dispose();
+  });
+
+  testWidgets('lower-case MACs are normalised to upper-case', (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, _config(homeMacs: ['a1:b2:c3:d4:e5:f6']));
+    await tester.pump();
+
+    expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
+
+    await tester.pump(const Duration(milliseconds: 400));
+    game.dispose();
+  });
+
+  testWidgets('a partial MAC list only fills the slots it provides',
+      (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, _config(homeMacs: ['A1:B2:C3:D4:E5:F6']));
+    await tester.pump();
+
+    // Only slot 0 was named; the rest stay unpaired.
+    expect(teamById(game, 'A').modules[0].macAddress, 'A1:B2:C3:D4:E5:F6');
+    expect(teamById(game, 'A').modules[1].macAddress, '');
+
+    await tester.pump(const Duration(milliseconds: 400));
+    game.dispose();
+  });
+
+  testWidgets('no module keys leaves every slot unpaired', (tester) async {
+    final game = Game();
+    await settleLoad(tester);
+
+    apply(game, _config());
+    await tester.pump();
+
+    for (final module in teamById(game, 'A').modules) {
+      expect(module.macAddress, '');
+    }
+
+    game.dispose();
+  });
+}

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -99,6 +99,47 @@ void main() {
       expect(a.signature, isNot(b.signature),
           reason: 'a colon in a team name must not alias a different fixture');
     });
+
+    test('parses per-side module MACs, normalising to upper-case', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_module_macs': ['a1:b2:c3:d4:e5:f6', '11:22:33:44:55:66'],
+        'away_module_macs': ['aa:bb:cc:dd:ee:ff'],
+      });
+
+      expect(config.homeModuleMacs, ['A1:B2:C3:D4:E5:F6', '11:22:33:44:55:66']);
+      expect(config.awayModuleMacs, ['AA:BB:CC:DD:EE:FF']);
+    });
+
+    test('defaults module MACs to empty lists for payloads without them', () {
+      final config = ScoreboardMatchConfig.fromJson(_matchJson());
+
+      expect(config.homeModuleMacs, isEmpty);
+      expect(config.awayModuleMacs, isEmpty);
+    });
+
+    test('drops blank/whitespace MAC entries', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_module_macs': ['A1:B2:C3:D4:E5:F6', '', '   '],
+      });
+
+      expect(config.homeModuleMacs, ['A1:B2:C3:D4:E5:F6']);
+    });
+
+    test('toJson/fromJson round-trips module MACs so a cold resume keeps them',
+        () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_module_macs': ['A1:B2:C3:D4:E5:F6'],
+        'away_module_macs': ['AA:BB:CC:DD:EE:FF'],
+      });
+
+      final restored = ScoreboardMatchConfig.fromJson(config.toJson());
+
+      expect(restored.homeModuleMacs, ['A1:B2:C3:D4:E5:F6']);
+      expect(restored.awayModuleMacs, ['AA:BB:CC:DD:EE:FF']);
+    });
   });
 
   group('ResultOutboxItem serialization', () {


### PR DESCRIPTION
## Why

A referee-link match (`GET /api/v1/soccer/match/`) never carried the robots' comm-module MACs, so every module had to be paired by hand. The scoreboard server now returns `home_module_macs`/`away_module_macs` (server-side half of #70 — robocup-junior/rcj-scoreboard#110). This is the **app-side half**: consume those keys and auto-pair on match load.

## What

- `ScoreboardMatchConfig` gains `homeModuleMacs`/`awayModuleMacs` (`List<String>`), threaded through the constructor, `copyWith`, `fromJson` (snake_case keys, upper-cased + blank-stripped) and `toJson` (so a cold resume keeps them).
- New `Game._autoPairScoreboardModules`, called at the **end** of `_applyScoreboardMatchConfig` so `gameInit()`'s enable/disable state is settled first (`applyPresetConfig` only connects an enabled module).
- Pairing is gated to load/reset applies (`!inGame || confirmed "Load match?"`), captured **before** `gameInit()` flips `inGame`, so an incidental mid-match name/venue correction never re-pairs live modules.
- Mapped by **team ID** (not list index) so a swapped side can't cross the sides; only the slots the server names are touched, sparing hand-paired spares.

## Design notes

- MACs are deliberately kept **out of `signature`** so an out-of-band module-assignment change can't re-trigger the "Load match?" overwrite or the result-review guards mid-match.
- Off the START/STOP hot path (invariant #1): config-load time, clock stopped; `applyPresetConfig` is idempotent on re-apply (skips a slot already on that MAC), so a version-bump re-apply won't churn live BLE links.

## Tests

- Model: parse/normalise/roundtrip of the MAC arrays.
- `Game` slot-mapping (`test/scoreboard_module_pairing_test.dart`): home/away, right-side home, lower-case, partial list, no keys.

> Authored in an environment without Flutter, so `flutter analyze`/`flutter test` were not run locally — relying on the PR quality gate to verify.

Closes #70 (app side). Pairs with robocup-junior/rcj-scoreboard#110.

cc @f-wllr @mato157