### PR TITLE
workaround(scoreboard): map the 25-min scheduling slot to 10+5+10 (#71)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -37,6 +37,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   static const int _defaultPlayersPerTeam = 2;
   static const int _noShowPenaltyGoalIntervalSeconds = 30;
   static const int _maxNoShowPenaltyGoalDifference = 10;
+  // Workaround (issue #71) for the scoreboard sending the 25-min scheduling
+  // SLOT as `duration_seconds` (rcj-scoreboard#108). A standard RCJ Soccer
+  // 25-min slot is 10+5+10 — two 10-min halves + a 5-min half-time break — so
+  // map that one value to a 10-min half + 5-min break instead of treating
+  // 25 min as the per-half length (which would run 2x25=50 min). Any other
+  // duration passes through unchanged until the server sends a real half time.
+  static const int _scoreboardSlot25MinSeconds = 25 * 60; // 1500
+  static const int _scoreboardSlot25HalfSeconds = 10 * 60; // 600
+  static const int _scoreboardSlot25HalfTimeSeconds = 5 * 60; // 300
 
   String timerButtonText = 'START';
   final int _maxPlayer = 5;
@@ -1337,6 +1346,19 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
   }
 
+  // Set the LIVE match timing from a scoreboard config, applying the #71
+  // 25-min-slot workaround. Sets the fields directly (NOT via the periodTime/
+  // halfTimeDuration setters) so the link's timing is used for this match only
+  // and never persisted as the operator's stored defaults.
+  void _applyScoreboardTiming(ScoreboardMatchConfig config) {
+    if (config.durationSeconds == _scoreboardSlot25MinSeconds) {
+      _periodTime = _scoreboardSlot25HalfSeconds;
+      _halfTimeDuration = _scoreboardSlot25HalfTimeSeconds;
+    } else {
+      _periodTime = config.durationSeconds;
+    }
+  }
+
   void _applyScoreboardMatchConfig(ScoreboardMatchConfig config) {
     // Team names AND venue are part of the signature (see
     // ScoreboardMatchConfig.signature) so a corrected schedule payload that
@@ -1446,7 +1468,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // Set the LIVE match length from the link, but do NOT persist it as the
       // operator's configured default (the `periodTime` setter would write it to
       // prefs and clobber their setting). gameInit() applies it to the clock.
-      _periodTime = config.durationSeconds;
+      // #71: a 25-min scheduling slot is mapped to a 10-min half + 5-min break.
+      _applyScoreboardTiming(config);
       gameInit();
     } else if (isConfirmedNewFixtureLoad) {
       // RAVF002: the referee confirmed the "Load match?" overwrite while a match
@@ -1465,7 +1488,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // and keeps retrying; its late 200 no longer matches the committed
       // fixture, so it can't reset this match (rule 3). Clear the stale snapshot
       // so a kill resumes the new match.
-      _periodTime = config.durationSeconds;
+      // #71: a 25-min scheduling slot is mapped to a 10-min half + 5-min break.
+      _applyScoreboardTiming(config);
       gameInit();
       setTeamToDefaultOrder();
       // Use the AWAITABLE clear (not the fire-and-forget _clearMatchState) and

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.10.4+14
+version: 0.10.4+15
 
 
 environment:

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -230,6 +230,60 @@ void main() {
     return waitForOutboxItem(tester, game, matchCode);
   }
 
+  group('scoreboard duration 25-min slot workaround (#71)', () {
+    testWidgets(
+        'a 25-min slot loads as a 10-min half + 5-min break, overriding the '
+        'operator defaults for this match', (tester) async {
+      // Seed distinct operator defaults so the mapping is unambiguous.
+      await prefs.setInt('game_period_time', 777);
+      await prefs.setInt('game_halftime_duration', 123);
+      final game = Game();
+      await settleLoad(tester);
+      expect(game.inGame, isFalse);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(
+              matchCode: 'M-25', version: 1, durationSeconds: 25 * 60),
+        ),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      expect(game.periodTime, 10 * 60,
+          reason: '25-min slot -> 10-min half (not 25 min per half)');
+      expect(game.halfTimeDuration, 5 * 60,
+          reason: '25-min slot -> 5-min half-time break');
+      expect(game.remainingTime, 10 * 60,
+          reason: 'gameInit sets the clock to the mapped 10-min half');
+      game.dispose();
+    });
+
+    testWidgets(
+        'a non-25-min duration passes through as the per-half length and '
+        'leaves the half-time break untouched', (tester) async {
+      await prefs.setInt('game_halftime_duration', 123);
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(
+              matchCode: 'M-15', version: 1, durationSeconds: 15 * 60),
+        ),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      expect(game.periodTime, 15 * 60,
+          reason: 'non-25 duration used directly as the per-half length');
+      expect(game.remainingTime, 15 * 60);
+      expect(game.halfTimeDuration, 123,
+          reason: 'workaround only remaps half-time for the 25-min slot');
+      game.dispose();
+    });
+  });
+
   group('cold-launch detection', () {
     testWidgets('an in-progress snapshot is offered for resume',
         (tester) async {


### PR DESCRIPTION
Closes #71.

## What

Temporary client-side workaround for the scoreboard sending the **25-min scheduling slot** as `duration_seconds` (root cause: rcj-scoreboard#108). A standard RCJ Soccer 25-min slot is **10 + 5 + 10** — two 10-min halves plus a 5-min half-time break — but the app treats `duration_seconds` as the *per-half* length, so a raw 1500 s runs **2×25 = 50 min**.

This maps the single value `1500` → **10-min half + 5-min break**. Any other duration passes through unchanged.

## How

- New `Game._applyScoreboardTiming(config)`:
  ```dart
  if (config.durationSeconds == 1500) { _periodTime = 600; _halfTimeDuration = 300; }
  else { _periodTime = config.durationSeconds; }
  ```
- Values are set **directly** (not via the `periodTime`/`halfTimeDuration` setters) so they apply to the **live match only** and are **not** persisted as the operator's configured defaults.
- Called at both apply sites in `_applyScoreboardMatchConfig` (the `!inGame` link load and the RAVF002 confirmed-Load reset).

## Scope / limitations

- Only `1500` is remapped; this is a **stopgap**. The real fix is server-side (rcj-scoreboard#108) sending a real per-half duration + half-time. **Remove this workaround once #108 lands.**

## Testing

- **+2 unit tests** in `test/game_recovery_test.dart` (group "scoreboard duration 25-min slot workaround (#71)"): 1500 → periodTime 600 / halfTime 300; a non-1500 duration passes through with half-time untouched.
- `flutter analyze` clean, **184 tests pass**.
- **Device-verified on Pixel 10** (debug build off this branch): loaded a `duration_seconds: 1500` match → first half showed **10:00**; ran the half out → half-time showed **5:00** ("Half-Time" stage). Full 10+5+10 confirmed on-device.

## Base

Targets `dev` (sits on top of the `main`→`dev` release-0.10.4 reconciliation + auto-pair #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
