### PR TITLE
fix(ios): opt out of iPad multitasking so portrait-only passes App Store validation

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,6 +70,12 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<!-- The app is portrait-only by design (see CLAUDE.md invariant #4). Opting
+	     out of iPad multitasking (Split View / Slide Over) lifts Apple's
+	     requirement to declare all four orientations, so App Store validation
+	     accepts the portrait-only orientation lists below. -->
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Problem

App Store Connect rejects the upload:

> Invalid bundle. The "UIInterfaceOrientationPortrait" orientations were provided for the UISupportedInterfaceOrientations Info.plist key in the `com.robocup.rcjScoreboard` bundle, but you need to include all of the "…Portrait,PortraitUpsideDown,LandscapeLeft,LandscapeRight" orientations to support iPad multitasking.

## Cause

The target ships to iPad (`TARGETED_DEVICE_FAMILY = "1,2"`). Any iPad app that can participate in multitasking (Split View / Slide Over) **must** declare all four interface orientations. The app declares only `UIInterfaceOrientationPortrait`, so validation fails.

## Fix

The app is **portrait-only by design** (CLAUDE.md invariant #4 — `SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])` pins portrait at runtime). Rather than declare landscape/upside-down orientations we deliberately don't support, opt out of iPad multitasking by adding `UIRequiresFullScreen = true` to `ios/Runner/Info.plist`. Apple's [documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/uisupportedinterfaceorientations) states the all-orientations requirement applies only to apps that support multitasking; opting out lifts it, so the portrait-only lists validate.

## Notes

- The **Runner app** target uses `INFOPLIST_FILE = Runner/Info.plist` (only **RunnerTests** has `GENERATE_INFOPLIST_FILE = YES`), and there are no `INFOPLIST_KEY_*` orientation overrides — so this key is authoritative for the `com.robocup.rcjScoreboard` bundle.
- Behavior is unchanged on iPhone; on iPad the app now always runs full-screen (no Split View), consistent with the existing portrait-only design.
- `plutil -lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)