### PR TITLE
ci(ios): add Xcode Cloud bootstrap for Flutter builds

### DIFF
--- a/ios/ci_scripts/README.md
+++ b/ios/ci_scripts/README.md
@@ -1,0 +1,51 @@
+# Xcode Cloud CI/CD
+
+This app builds for iOS on **Xcode Cloud**. Android + analysis stay on GitHub
+Actions (`.github/workflows/`); Xcode Cloud only owns the iOS archive / TestFlight
+/ App Store path, because that needs a signed macOS build Apple runs on their
+infrastructure.
+
+## What lives in the repo
+
+`ci_scripts/ci_post_clone.sh` — the only part of Xcode Cloud that is
+repo-defined. Xcode Cloud auto-runs any `ci_scripts/ci_post_clone.sh` (and the
+optional `ci_pre_xcodebuild.sh` / `ci_post_xcodebuild.sh`) it finds next to the
+selected Xcode workspace. Ours installs Flutter (pinned to the same version as
+GitHub CI) and generates `Generated.xcconfig` + Pods so the subsequent
+`xcodebuild` succeeds — Xcode Cloud images ship Xcode + CocoaPods but **not**
+Flutter.
+
+Keep the `FLUTTER_VERSION` in the script in lockstep with the
+`flutter-version:` pin in `.github/workflows/*.yml`.
+
+## What must be configured in App Store Connect (NOT in the repo)
+
+Xcode Cloud **workflows** (triggers, actions, environment) live server-side, in
+Xcode → Report navigator → Cloud, or App Store Connect → your app → Xcode Cloud.
+Create the workflow once:
+
+1. **Product / Xcode project**: workspace `ios/Runner.xcworkspace`, scheme
+   `Runner`. (Ensure the `Runner` scheme is marked *Shared* in Xcode so Xcode
+   Cloud can see it — `ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme`.)
+2. **Environment**: pick an Xcode version compatible with Flutter 3.44.0; leave
+   "Clean" off so caching helps. macOS default is fine.
+3. **Start conditions (triggers)** — suggested to mirror GitHub CI:
+   - Branch changes on `dev` → Build + Test (or Analyze) for fast feedback.
+   - Tag changes matching the release tags (e.g. `v*`) → Archive → TestFlight
+     (internal), matching `.github/workflows/release.yml`.
+4. **Actions**: Archive (iOS), and optionally Test. Post-actions: deliver to
+   TestFlight / App Store as desired.
+5. **Signing**: use Xcode Cloud's managed signing (recommended) or your uploaded
+   certificates/profiles. The bundle id is `com.robocup.rcjScoreboard`.
+
+## Local sanity check of the script
+
+You cannot run Xcode Cloud locally, but you can dry-run the bootstrap logic:
+
+```sh
+CI_PRIMARY_REPOSITORY_PATH="$(git rev-parse --show-toplevel)" \
+  sh ios/ci_scripts/ci_post_clone.sh
+```
+
+(That installs Flutter into `~/flutter` if missing — skip if you already manage
+Flutter yourself; the script guards against re-cloning.)

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Xcode Cloud post-clone bootstrap for this Flutter app.
+#
+# Xcode Cloud gives us a macOS image with Xcode + CocoaPods, but NOT Flutter.
+# It runs this script right after cloning the repo and BEFORE resolving
+# dependencies / running xcodebuild, so this is where we install Flutter and
+# generate everything the CocoaPods + xcodebuild steps rely on:
+#   1. install a pinned Flutter SDK (same version as .github CI: 3.44.0)
+#   2. precache the iOS engine artifacts
+#   3. `flutter pub get`
+#   4. `flutter build ios --config-only` — writes ios/Flutter/Generated.xcconfig
+#      (Podfile hard-requires it; see ios/Podfile `flutter_root`)
+#   5. `pod install`
+#
+# Apple runs ci_scripts from its own directory, so we always cd to the repo
+# root via $CI_PRIMARY_REPOSITORY_PATH (set by Xcode Cloud).
+#
+# See ios/ci_scripts/README.md for the App Store Connect workflow setup that
+# must accompany this script.
+
+set -e
+
+# Keep in lockstep with .github/workflows/*.yml (flutter-version: '3.44.0').
+FLUTTER_VERSION="3.44.0"
+FLUTTER_HOME="$HOME/flutter"
+
+echo "▸ Installing Flutter $FLUTTER_VERSION"
+if [ ! -d "$FLUTTER_HOME" ]; then
+  git clone https://github.com/flutter/flutter.git \
+    --depth 1 --branch "$FLUTTER_VERSION" "$FLUTTER_HOME"
+fi
+export PATH="$FLUTTER_HOME/bin:$PATH"
+
+# Xcode Cloud clones into a shallow, non-owned dir; mark it safe so git (which
+# Flutter shells out to) doesn't refuse "dubious ownership".
+git config --global --add safe.directory "$FLUTTER_HOME"
+
+flutter --version
+
+echo "▸ Precaching iOS artifacts"
+flutter precache --ios
+
+echo "▸ Resolving Dart dependencies"
+cd "$CI_PRIMARY_REPOSITORY_PATH"
+flutter pub get
+
+# Generate ios/Flutter/Generated.xcconfig (FLUTTER_ROOT etc.) without building —
+# this is what the Podfile and the Xcode build settings read.
+echo "▸ Generating iOS build configuration"
+flutter build ios --config-only --release --no-codesign
+
+echo "▸ Installing CocoaPods dependencies"
+cd "$CI_PRIMARY_REPOSITORY_PATH/ios"
+pod install
+
+echo "✓ ci_post_clone complete"


### PR DESCRIPTION
## Goal

Start iOS CI/CD on **Xcode Cloud**. Android + analyze/test stay on GitHub Actions; Xcode Cloud owns only the signed iOS archive → TestFlight/App Store path (that needs a macOS build on Apple's infra).

## What's in this PR (the repo-defined half)

Xcode Cloud images ship Xcode + CocoaPods but **not** Flutter, so `ios/ci_scripts/ci_post_clone.sh` bootstraps a build before `xcodebuild`:

1. install Flutter pinned to `3.44.0` (kept in lockstep with `.github/workflows/*.yml`)
2. `flutter precache --ios`
3. `flutter pub get`
4. `flutter build ios --config-only --release` — writes `ios/Flutter/Generated.xcconfig`, which the Podfile **hard-requires** (`flutter_root` raises without it)
5. `pod install`

`ios/ci_scripts/README.md` documents the rest.

## Follow-up: App Store Connect config (server-side, cannot be committed)

Xcode Cloud **workflows** (triggers, actions, signing) live in App Store Connect / Xcode, not the repo. After merge, create a workflow once:
- Workspace `ios/Runner.xcworkspace`, scheme `Runner` (already shared ✓)
- Suggested triggers mirroring GitHub CI: branch `dev` → Build/Test; tag `v*` → Archive → TestFlight (matches `release.yml`)
- Managed signing; bundle id `com.robocup.rcjScoreboard`

## Verification

- `sh -n` syntax check passes; script committed executable (`100755`).
- The `Runner` scheme is shared, so Xcode Cloud can select it.
- ⚠️ The full script can only be exercised by an actual Xcode Cloud run (installs Flutter on a macOS image), which isn't runnable here — the first cloud build will confirm end-to-end. The step **order** is chosen specifically to satisfy the Podfile's `Generated.xcconfig` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)