### PR TITLE
feat(match): show per-team inspection status and notes on load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,20 @@ Cross-platform **Android + iOS (iPhone)** Flutter app (portrait-only) that contr
 
 ## Where to read more
 See `docs/ai/00_CONTEXT_INDEX.md` for the full reading order and per-topic pointers.
+
+## Device-testing the scoreboard flow (local mock)
+Runbook: `docs/ai/07_SCOREBOARD_DEVICE_TESTING.md`; mock: `docs/ai/tools/mock_scoreboard.py`
+(stdlib GET/POST mock; now also serves `home/away_inspection_robots`). Flow:
+`adb reverse tcp:8000 tcp:8000` → start mock → `adb shell am start -a
+android.intent.action.VIEW -d 'rcjrefmate://r/tok?base_url=http://127.0.0.1:8000'`.
+Android app id is **`com.robocup.rcj_soccer`**.
+
+> **Env gotcha — `pkill -f mock_scoreboard.py` self-kills the shell (exit 144).**
+> A Bash tool call runs as `bash -c '…mock_scoreboard.py…'`, so its **own argv
+> contains the pattern** — `pkill -f mock_scoreboard.py` matches and kills the
+> launching shell before anything runs, surfacing as **exit code 144** (looks
+> like a network/sandbox block, but isn't). Fixes:
+> - **Launch** the mock as a `run_in_background` Bash task with **no** self-matching
+>   `pkill` in the same command (log to the scratchpad dir, not `/tmp`).
+> - **Kill** it with the bracket trick so the pattern can't match the killer:
+>   `pkill -f '[m]ock_scoreboard\.py'` (or kill by PID). Same rule for `pgrep`.

--- a/docs/ai/07_SCOREBOARD_DEVICE_TESTING.md
+++ b/docs/ai/07_SCOREBOARD_DEVICE_TESTING.md
@@ -1,0 +1,176 @@
+# Scoreboard deep-link flow — device testing runbook
+
+How to exercise the **scoreboard referee result flow** (deep link → match-config
+`GET` → full-time result `POST`) end-to-end on a real Android phone **without the
+live rcj-scoreboard server**, using a local stdlib mock + `adb`. Written so a
+future agent can repeat the test in minutes instead of re-deriving it.
+
+Relevant code: `lib/services/scoreboard_result_service.dart`,
+`lib/models/scoreboard_result.dart`, `lib/models/game.dart` (scoreboard parts).
+Background: `[[scoreboard_integration]]`, the PR is `copilot/issue-31-final-result-api` (#15).
+
+---
+
+## Why this setup (the non-obvious bits)
+
+- **Custom scheme, not the HTTPS App Link, in debug.** A debug build's HTTPS
+  App Link won't auto-verify (Android domain-verification state = "not
+  verified"), so it won't auto-open. Use the custom scheme `rcjrefmate://r/<token>`.
+- **`base_url` query override is debug-only.** `_parseDeepLink` accepts
+  `?base_url=http://127.0.0.1:8000` **only** in `kDebugMode`, and only for an
+  allowlisted local host (`localhost`, `127.0.0.1`, `::1`, `10.0.2.2`, RFC-1918).
+  This is how we point the app at the mock.
+- **`adb reverse`, not the LAN IP.** `adb reverse tcp:8000 tcp:8000` tunnels the
+  phone's `127.0.0.1:8000` to the host over USB. The Wi-Fi/LAN-IP path
+  (`192.168.x.y:8000`) is unreliable — a host firewall typically blocks inbound
+  from the phone. `127.0.0.1` is also in the debug allowlist, the LAN IP is not.
+- **The capability token is single-use** server-side: a successful `POST`
+  consumes it. The `GET` does **not**. So you can re-`GET` freely, but to test a
+  *fresh* submit, restart the mock (resets its consumed flag) or use a new token.
+
+---
+
+## Prerequisites
+
+- Flutter 3.44.0 toolchain on `PATH` (`flutter`, `dart`). `python3` for the mock.
+- Phone connected, USB debugging authorized: `adb devices` shows `device`
+  (not `unauthorized`/`offline`). If it drops: `adb kill-server && adb start-server`
+  then `adb reconnect`, and physically re-plug if still missing.
+- App package id: **`com.robocup.rcj_soccer`**.
+
+---
+
+## The mock server
+
+`docs/ai/tools/mock_scoreboard.py` — stdlib mock of both endpoints:
+`GET /api/v1/soccer/match/` and `POST /api/v1/soccer/match/result/` (exact path
+match, trailing slash **required** — matches the server's `APPEND_SLASH`).
+
+Match it serves: **Red Robots vs Blue Bots**, `home_is_left=true`, `Field 1`,
+`duration_seconds=30` (short halves so a full match is ~1 min, not 20).
+
+Env-var error injection:
+| Var | Effect |
+|---|---|
+| `PORT` | listen port (default 8000) |
+| `RESULT_STATUS` | force the `POST` status (e.g. `409`, `401`, `422`, `500`) |
+| `MATCH_STATUS` | force the `GET` status (e.g. `401`, `500`) |
+| `HANG` | seconds to sleep before responding (test the 15 s client timeout: `HANG=20`) |
+| `TOKEN` | expected bearer token (default: accept any non-empty) |
+
+Run it **with `-u`** (Python block-buffers stdout to a file otherwise, so the log
+looks empty) and as a tracked background task (no inner `&`, which gets orphaned
+on shell exit):
+
+```bash
+python3 -u docs/ai/tools/mock_scoreboard.py > /tmp/mock.log 2>&1   # run_in_background: true
+# self-test from host (expect 401, no auth):
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8000/api/v1/soccer/match/
+```
+
+---
+
+## Full happy-path run
+
+```bash
+# 1. Build, install, tunnel, clean state
+flutter build apk --debug
+adb install -r build/app/outputs/flutter-apk/app-debug.apk
+adb reverse tcp:8000 tcp:8000
+adb shell pm clear com.robocup.rcj_soccer     # cold start, wipes prior token/outbox
+
+# 2. Start the mock (background, -u) — see above
+
+# 3. Fire the referee deep link (token value is arbitrary for the mock)
+adb shell am start -a android.intent.action.VIEW \
+  -d 'rcjrefmate://r/testsel.testsecret?base_url=http://127.0.0.1:8000'
+```
+
+Then drive the UI (see coordinates + gotchas below): dismiss the OS notification
+prompt → set a score → play first half → half-time dialog "No" → SKIP the break
+→ play second half → full-time fires the `POST`.
+
+Verify in `/tmp/mock.log`:
+```
+GET  /api/v1/soccer/match/ ... 200
+POST /api/v1/soccer/match/result/ body={'home_goals': 2, 'away_goals': 1, ...} ... 200
+RECORDED -> version=2  2-1
+```
+And on screen at full-time: **"Game Over", score preserved (NOT reset to 0-0)** —
+that's the headline `gameInit()`-only-`if(!inGame)` fix.
+
+---
+
+## UI driving — coordinates & gotchas
+
+> **Coordinates below are for a Pixel 10 in portrait (screenshot 1080×2400).**
+> For another device/resolution, re-derive: `adb exec-out screencap -p > s.png`
+> and read pixel positions, or `adb shell uiautomator dump` for a coordinate XML.
+
+**Double-tap is the critical-action gesture** (start/stop, score, timer). Two
+separate `adb shell input tap` calls are >300 ms apart (process overhead) and
+register as two *single* taps — which do nothing. Put **both taps in one shell
+call**:
+```bash
+adb shell "input tap 538 635; input tap 538 635"   # = one double-tap
+```
+
+| Target | Coord (Pixel 10 portrait) | Notes |
+|---|---|---|
+| Center timer button (START / STOP / SKIP / REPEAT) | `538 635` | double-tap |
+| Red (left) score | `193 635` | double-tap = +1 goal |
+| Blue (right) score | `885 635` | double-tap = +1 goal |
+| Settings gear | `1017 245` | single tap |
+| Notification permission "Allow / Povoliť" | `540 1381` | OS dialog after `pm clear`; language follows phone locale |
+| Half-time "Switch Team Order" → **No** | `343 1382` | keeps order (clean home/away mapping) |
+| Half-time "Switch Team Order" → **Yes** | `737 1382` | swaps sides — use to test mapping under a swap |
+| Module tiles A1/B1/A2/B2 | ~`280 1000` / `800 1000` / `280 1670` / `800 1670` | **long-press** opens per-module BLE settings |
+
+**Match stage flow:** firstHalf → (timer hits 0) → **half-time** (shows the
+Switch-Team-Order dialog + a break countdown + SKIP) → secondHalf → (timer hits
+0) → **fullTime** (the result `POST` fires here; button becomes REPEAT).
+`REPEAT` (double-tap) resets to a fresh first half (re-applies the loaded config).
+
+**Waiting for the timer.** A long foreground `sleep` is blocked by the harness.
+Use a background bash deadline loop (one completion notification), then screenshot:
+```bash
+end=$(($(date +%s)+33)); while [ $(date +%s) -lt $end ]; do sleep 2; done; echo DONE
+# run_in_background: true ; ~33s covers a 30s half + transition
+```
+
+**Screenshots:** `adb exec-out screencap -p > shot.png` then read the PNG.
+
+---
+
+## Error-injection scenarios
+
+- **409 conflict:** start the mock with `RESULT_STATUS=409`. At full-time the app
+  shows orange **"Final result requires manual review"**, keeps the link/outbox,
+  and does **not** auto-clear. (To re-submit after a real 200, you must restart
+  the mock — token is single-use.)
+- **Client timeout:** `HANG=20` (> the 15 s request timeout). The `POST` is
+  marked a retriable failure and re-attempted on the 20 s retry tick.
+- **Auth reject:** `MATCH_STATUS=401` (GET) or `RESULT_STATUS=401`/`422` (POST) →
+  terminal "rejected", not retried.
+
+---
+
+## Cleanup
+
+```bash
+pkill -f mock_scoreboard.py
+adb reverse --remove tcp:8000
+adb shell pm clear com.robocup.rcj_soccer   # optional: drop the test match/outbox
+```
+
+---
+
+## Known limitations of this test path
+
+- The scoreboard match payload carries **no module MAC addresses** (or side), so
+  the deep link **cannot auto-connect robot modules** — that's a server-side gap,
+  not testable here. Module BLE auto-connect is a separate manual flow
+  (per-module MAC entry / QR / catigoal comment).
+- Auto-clear-after-submit wipes the on-screen "submitted" confirmation + outbox
+  audit trail; left as-is pending the end-of-match review/confirmation screen
+  (issue #51). Don't flag it as new.

--- a/docs/ai/tools/mock_scoreboard.py
+++ b/docs/ai/tools/mock_scoreboard.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Stdlib mock of the rcj-scoreboard referee API for on-device PR #15 testing.
+
+Endpoints (exact path match, trailing slash required):
+  GET  /api/v1/soccer/match/         -> match config (needs Bearer auth)
+  POST /api/v1/soccer/match/result/  -> record result (single-use token)
+
+Env-var error injection:
+  PORT          listen port (default 8000)
+  RESULT_STATUS force POST status (e.g. 409, 401, 422, 500)
+  MATCH_STATUS  force GET status (e.g. 401, 500)
+  HANG          seconds to sleep before responding (test 15s timeout)
+  TOKEN         expected bearer token (default: accept any non-empty)
+
+Run:  python3 -u mock_scoreboard.py
+"""
+import json, os, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("PORT", "8000"))
+RESULT_STATUS = int(os.environ.get("RESULT_STATUS", "200"))
+MATCH_STATUS = int(os.environ.get("MATCH_STATUS", "200"))
+HANG = float(os.environ.get("HANG", "0"))
+EXPECTED_TOKEN = os.environ.get("TOKEN", "")
+
+# In-memory match. version bumps on successful result record.
+MATCH = {
+    "match_code": "RR-vs-BB-01",
+    "home_team": {"name": "Red Robots"},
+    "away_team": {"name": "Blue Bots"},
+    "home_is_left": True,
+    "venue": "Field 1",
+    "scheduled_start": "2026-06-26T10:00:00Z",
+    "duration_seconds": 30,
+    "timezone": "UTC",
+    "version": 1,
+    "status": "SCHEDULED",
+    # Per-robot inspection (rcj-scoreboard #116 / app #78). Mix of every badge
+    # case: ok, failed+note, missing, ok+note. Team-level keys kept for compat.
+    "home_inspection_status": "ok",
+    "away_inspection_status": "failed",
+    "home_inspection_robots": [
+        {"robot": 1, "status": "ok",
+         "note": "Front-left dribbler motor connector was reseated during "
+                 "inspection because an intermittent dropout was observed under "
+                 "load on the test bench. The team resoldered the joint and it "
+                 "held for the remainder of the check, but the inspector asked "
+                 "the referee to keep an eye on the left wheel behaviour during "
+                 "play and to re-check the connector at halftime if the robot "
+                 "starts drifting. Otherwise the robot passed all size, weight "
+                 "and light-emission tests without further issue."},
+        {"robot": 2, "status": "failed",
+         "note": "Battery pack measured below the 10.5V minimum under load and "
+                 "the kicker capacitor exceeded the allowed maximum voltage on "
+                 "two separate measurements. In addition the top light-shield "
+                 "was 3mm over the legal height and one exposed wire on the "
+                 "underside was not properly insulated. All three issues must "
+                 "be corrected and the robot must be brought back for a full "
+                 "re-inspection before it is allowed to play its next match."},
+    ],
+    "away_inspection_robots": [
+        {"robot": 1, "status": "missing",
+         "note": "Robot was not presented for inspection today. A team member "
+                 "told the inspection desk that it is still being repaired in "
+                 "the pit area after a collision in the previous round bent the "
+                 "chassis, and that they hope to bring it for inspection before "
+                 "their next scheduled match. Until it is inspected it may not "
+                 "be fielded, so the referee should confirm its status at the "
+                 "table before kickoff."},
+        {"robot": 2, "status": "ok",
+         "note": "Wheels were re-seated and the light shield was trimmed to the "
+                 "legal height after it failed on the first attempt. On the "
+                 "second attempt the robot passed every check: dimensions, "
+                 "weight, battery voltage under load, kicker energy and the "
+                 "infrared light-emission limits were all within spec, so it is "
+                 "cleared to play with no further conditions attached."},
+    ],
+}
+SEEN_IDEMPOTENCY = {}  # idempotency_key -> stored response (single-use replay)
+TOKEN_CONSUMED = {"done": False}
+
+
+def _auth_ok(handler):
+    h = handler.headers.get("Authorization", "")
+    if not h.startswith("Bearer "):
+        return False
+    tok = h[len("Bearer "):].strip()
+    if not tok:
+        return False
+    if EXPECTED_TOKEN and tok != EXPECTED_TOKEN:
+        return False
+    return True
+
+
+class H(BaseHTTPRequestHandler):
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        print("[mock] %s - %s" % (self.address_string(), fmt % args), flush=True)
+
+    def do_GET(self):
+        if HANG:
+            time.sleep(HANG)
+        if self.path != "/api/v1/soccer/match/":
+            return self._send(404, {"reason": "not_found", "path": self.path})
+        if not _auth_ok(self):
+            return self._send(401, {"reason": "invalid_token"})
+        if MATCH_STATUS != 200:
+            return self._send(MATCH_STATUS, {"reason": "forced_%d" % MATCH_STATUS})
+        print("[mock] GET match -> version=%d" % MATCH["version"], flush=True)
+        return self._send(200, MATCH)
+
+    def do_POST(self):
+        if HANG:
+            time.sleep(HANG)
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(raw or b"{}")
+        except Exception:
+            payload = {}
+        print("[mock] POST %s body=%s" % (self.path, payload), flush=True)
+        if self.path != "/api/v1/soccer/match/result/":
+            return self._send(404, {"reason": "not_found", "path": self.path})
+        if not _auth_ok(self):
+            return self._send(401, {"reason": "invalid_token"})
+
+        idem = payload.get("idempotency_key")
+        if idem and idem in SEEN_IDEMPOTENCY:
+            print("[mock] idempotent replay for %s" % idem, flush=True)
+            return self._send(200, SEEN_IDEMPOTENCY[idem])
+
+        if RESULT_STATUS != 200:
+            return self._send(RESULT_STATUS, {"reason": "forced_%d" % RESULT_STATUS})
+
+        if TOKEN_CONSUMED["done"]:
+            return self._send(409, {"reason": "already_recorded"})
+
+        MATCH["version"] += 1
+        MATCH["status"] = "COMPLETED"
+        TOKEN_CONSUMED["done"] = True
+        resp = {
+            "ok": True,
+            "version": MATCH["version"],
+            "home_goals": payload.get("home_goals"),
+            "away_goals": payload.get("away_goals"),
+            "comment": payload.get("comment"),
+        }
+        if idem:
+            SEEN_IDEMPOTENCY[idem] = resp
+        print("[mock] RECORDED -> version=%d  %s-%s" % (
+            MATCH["version"], resp["home_goals"], resp["away_goals"]), flush=True)
+        return self._send(200, resp)
+
+
+if __name__ == "__main__":
+    print("[mock] listening on 0.0.0.0:%d  RESULT_STATUS=%d MATCH_STATUS=%d HANG=%s"
+          % (PORT, RESULT_STATUS, MATCH_STATUS, HANG), flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), H).serve_forever()

--- a/docs/ai/tools/mock_scoreboard.py
+++ b/docs/ai/tools/mock_scoreboard.py
@@ -30,7 +30,7 @@ MATCH = {
     "away_team": {"name": "Blue Bots"},
     "home_is_left": True,
     "venue": "Field 1",
-    "scheduled_start": "2026-06-26T10:00:00Z",
+    "scheduled_start": "2026-07-01T13:30:00Z",
     "duration_seconds": 30,
     "timezone": "UTC",
     "version": 1,

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1607,6 +1607,20 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _scoreboardAwayTeamId = config.homeIsLeft ? 'B' : 'A';
   }
 
+  /// The scoreboard's per-robot inspection rows for [team]'s side of the linked
+  /// fixture, so the loaded-match team-settings view can surface inspection
+  /// status during a match (not only in the "Load match?" dialog). Returns an
+  /// empty list when no fixture is linked or the side mapping is unresolved.
+  /// Routes through the home/away->team-id mapping ([_deriveScoreboardSideMapping])
+  /// so callers never re-derive that rule and can't cross the sides.
+  List<InspectionRobot> inspectionRobotsForTeam(Team team) {
+    final config = scoreboardResultService.matchConfig;
+    if (config == null) return const [];
+    if (team.id == _scoreboardHomeTeamId) return config.homeInspectionRobots;
+    if (team.id == _scoreboardAwayTeamId) return config.awayInspectionRobots;
+    return const [];
+  }
+
   void _enterFullTimeResultReview() {
     final config = scoreboardResultService.matchConfig;
     if (config != null &&

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -2,11 +2,12 @@ import 'dart:convert';
 
 enum ResultSubmissionState { pending, submitted, conflict, failed }
 
-/// Soft per-team inspection status the scoreboard reports for the current
-/// competition day (rcj-scoreboard #112). [unknown] is the client-side fallback
-/// for an absent/unrecognised value — treat both [unknown] and [missing] as
-/// "not applicable / not yet cleared", never as a hard "blocked": the server's
-/// "missing" conflates a non-inspecting league with an uninspected team.
+/// Soft inspection status the scoreboard reports per fielded robot for the
+/// current competition day (rcj-scoreboard #112). [unknown] is the client-side
+/// fallback for an absent/unrecognised value — treat both [unknown] and
+/// [missing] as "not applicable / not yet cleared", never as a hard "blocked":
+/// the server's "missing" conflates a non-inspecting league with an uninspected
+/// robot.
 enum InspectionStatus { ok, failed, missing, unknown }
 
 InspectionStatus _inspectionStatusFromJson(dynamic value) {
@@ -15,41 +16,6 @@ InspectionStatus _inspectionStatusFromJson(dynamic value) {
     (s) => s.name == name,
     orElse: () => InspectionStatus.unknown,
   );
-}
-
-/// One inspection note the scoreboard reports for a fielded robot on the current
-/// competition day (rcj-scoreboard #112): the free text explaining why a side is
-/// flagged. [robot] is the robot number the note was recorded against.
-class InspectionNote {
-  final int robot;
-  final String note;
-
-  const InspectionNote({required this.robot, required this.note});
-
-  factory InspectionNote.fromJson(Map<String, dynamic> json) => InspectionNote(
-        robot: (json['robot'] as num?)?.toInt() ?? 0,
-        note: (json['note']?.toString() ?? '').trim(),
-      );
-
-  Map<String, dynamic> toJson() => {'robot': robot, 'note': note};
-
-  @override
-  bool operator ==(Object other) =>
-      other is InspectionNote && other.robot == robot && other.note == note;
-
-  @override
-  int get hashCode => Object.hash(robot, note);
-}
-
-/// Parses the `*_inspection_notes` array, dropping malformed entries and any
-/// note that arrives with empty text so the UI never renders a blank line.
-List<InspectionNote> _inspectionNotesFromJson(dynamic value) {
-  if (value is! List) return const [];
-  return value
-      .whereType<Map>()
-      .map((m) => InspectionNote.fromJson(Map<String, dynamic>.from(m)))
-      .where((n) => n.note.isNotEmpty)
-      .toList(growable: false);
 }
 
 /// One fielded robot's soft inspection result for the current competition day
@@ -67,7 +33,9 @@ class InspectionRobot {
   });
 
   factory InspectionRobot.fromJson(Map<String, dynamic> json) => InspectionRobot(
-        robot: int.tryParse(json['robot']?.toString() ?? '') ?? 0,
+        // num.tryParse handles an int (3), a float (3.0), and a string ("3")
+        // without ever throwing or silently dropping a valid robot.
+        robot: num.tryParse(json['robot']?.toString() ?? '')?.toInt() ?? 0,
         status: _inspectionStatusFromJson(json['status']),
         note: (json['note']?.toString() ?? '').trim(),
       );
@@ -109,10 +77,6 @@ class ScoreboardMatchConfig {
   final String timezone;
   final int version;
   final String status;
-  final InspectionStatus homeInspectionStatus;
-  final InspectionStatus awayInspectionStatus;
-  final List<InspectionNote> homeInspectionNotes;
-  final List<InspectionNote> awayInspectionNotes;
   final List<InspectionRobot> homeInspectionRobots;
   final List<InspectionRobot> awayInspectionRobots;
 
@@ -136,10 +100,6 @@ class ScoreboardMatchConfig {
     required this.status,
     this.homeModuleMacs = const [],
     this.awayModuleMacs = const [],
-    this.homeInspectionStatus = InspectionStatus.unknown,
-    this.awayInspectionStatus = InspectionStatus.unknown,
-    this.homeInspectionNotes = const [],
-    this.awayInspectionNotes = const [],
     this.homeInspectionRobots = const [],
     this.awayInspectionRobots = const [],
   });
@@ -157,10 +117,6 @@ class ScoreboardMatchConfig {
     String? status,
     List<String>? homeModuleMacs,
     List<String>? awayModuleMacs,
-    InspectionStatus? homeInspectionStatus,
-    InspectionStatus? awayInspectionStatus,
-    List<InspectionNote>? homeInspectionNotes,
-    List<InspectionNote>? awayInspectionNotes,
     List<InspectionRobot>? homeInspectionRobots,
     List<InspectionRobot>? awayInspectionRobots,
   }) {
@@ -177,10 +133,6 @@ class ScoreboardMatchConfig {
       status: status ?? this.status,
       homeModuleMacs: homeModuleMacs ?? this.homeModuleMacs,
       awayModuleMacs: awayModuleMacs ?? this.awayModuleMacs,
-      homeInspectionStatus: homeInspectionStatus ?? this.homeInspectionStatus,
-      awayInspectionStatus: awayInspectionStatus ?? this.awayInspectionStatus,
-      homeInspectionNotes: homeInspectionNotes ?? this.homeInspectionNotes,
-      awayInspectionNotes: awayInspectionNotes ?? this.awayInspectionNotes,
       homeInspectionRobots: homeInspectionRobots ?? this.homeInspectionRobots,
       awayInspectionRobots: awayInspectionRobots ?? this.awayInspectionRobots,
     );
@@ -239,12 +191,6 @@ class ScoreboardMatchConfig {
       status: (json['status']?.toString() ?? '').toUpperCase(),
       homeModuleMacs: moduleMacs(json['home_module_macs']),
       awayModuleMacs: moduleMacs(json['away_module_macs']),
-      homeInspectionStatus:
-          _inspectionStatusFromJson(json['home_inspection_status']),
-      awayInspectionStatus:
-          _inspectionStatusFromJson(json['away_inspection_status']),
-      homeInspectionNotes: _inspectionNotesFromJson(json['home_inspection_notes']),
-      awayInspectionNotes: _inspectionNotesFromJson(json['away_inspection_notes']),
       homeInspectionRobots: _inspectionRobotsFromJson(json['home_inspection_robots']),
       awayInspectionRobots: _inspectionRobotsFromJson(json['away_inspection_robots']),
     );
@@ -291,12 +237,6 @@ class ScoreboardMatchConfig {
         'status': status,
         'home_module_macs': homeModuleMacs,
         'away_module_macs': awayModuleMacs,
-        'home_inspection_status': homeInspectionStatus.name,
-        'away_inspection_status': awayInspectionStatus.name,
-        'home_inspection_notes':
-            homeInspectionNotes.map((n) => n.toJson()).toList(),
-        'away_inspection_notes':
-            awayInspectionNotes.map((n) => n.toJson()).toList(),
         'home_inspection_robots':
             homeInspectionRobots.map((r) => r.toJson()).toList(),
         'away_inspection_robots':

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -52,6 +52,52 @@ List<InspectionNote> _inspectionNotesFromJson(dynamic value) {
       .toList(growable: false);
 }
 
+/// One fielded robot's soft inspection result for the current competition day
+/// (rcj-scoreboard #112): its [status] and free-text [note]. [robot] is the
+/// robot number.
+class InspectionRobot {
+  final int robot;
+  final InspectionStatus status;
+  final String note;
+
+  const InspectionRobot({
+    required this.robot,
+    required this.status,
+    required this.note,
+  });
+
+  factory InspectionRobot.fromJson(Map<String, dynamic> json) => InspectionRobot(
+        robot: int.tryParse(json['robot']?.toString() ?? '') ?? 0,
+        status: _inspectionStatusFromJson(json['status']),
+        note: (json['note']?.toString() ?? '').trim(),
+      );
+
+  Map<String, dynamic> toJson() =>
+      {'robot': robot, 'status': status.name, 'note': note};
+
+  @override
+  bool operator ==(Object other) =>
+      other is InspectionRobot &&
+      other.robot == robot &&
+      other.status == status &&
+      other.note == note;
+
+  @override
+  int get hashCode => Object.hash(robot, status, note);
+}
+
+/// Parses the `*_inspection_robots` array, dropping non-map entries and any
+/// entry with an invalid/non-positive robot number so the UI is never fed a
+/// malformed row (this keeps a bad note from breaking the whole match load).
+List<InspectionRobot> _inspectionRobotsFromJson(dynamic value) {
+  if (value is! List) return const [];
+  return value
+      .whereType<Map>()
+      .map((m) => InspectionRobot.fromJson(Map<String, dynamic>.from(m)))
+      .where((r) => r.robot > 0)
+      .toList(growable: false);
+}
+
 class ScoreboardMatchConfig {
   final String matchCode;
   final String homeTeamName;
@@ -67,6 +113,8 @@ class ScoreboardMatchConfig {
   final InspectionStatus awayInspectionStatus;
   final List<InspectionNote> homeInspectionNotes;
   final List<InspectionNote> awayInspectionNotes;
+  final List<InspectionRobot> homeInspectionRobots;
+  final List<InspectionRobot> awayInspectionRobots;
 
   /// MAC addresses of the home/away robots' comm modules, ordered by robot
   /// number (server payload keys `home_module_macs`/`away_module_macs`, #70).
@@ -92,6 +140,8 @@ class ScoreboardMatchConfig {
     this.awayInspectionStatus = InspectionStatus.unknown,
     this.homeInspectionNotes = const [],
     this.awayInspectionNotes = const [],
+    this.homeInspectionRobots = const [],
+    this.awayInspectionRobots = const [],
   });
 
   ScoreboardMatchConfig copyWith({
@@ -111,6 +161,8 @@ class ScoreboardMatchConfig {
     InspectionStatus? awayInspectionStatus,
     List<InspectionNote>? homeInspectionNotes,
     List<InspectionNote>? awayInspectionNotes,
+    List<InspectionRobot>? homeInspectionRobots,
+    List<InspectionRobot>? awayInspectionRobots,
   }) {
     return ScoreboardMatchConfig(
       matchCode: matchCode ?? this.matchCode,
@@ -129,6 +181,8 @@ class ScoreboardMatchConfig {
       awayInspectionStatus: awayInspectionStatus ?? this.awayInspectionStatus,
       homeInspectionNotes: homeInspectionNotes ?? this.homeInspectionNotes,
       awayInspectionNotes: awayInspectionNotes ?? this.awayInspectionNotes,
+      homeInspectionRobots: homeInspectionRobots ?? this.homeInspectionRobots,
+      awayInspectionRobots: awayInspectionRobots ?? this.awayInspectionRobots,
     );
   }
 
@@ -191,6 +245,8 @@ class ScoreboardMatchConfig {
           _inspectionStatusFromJson(json['away_inspection_status']),
       homeInspectionNotes: _inspectionNotesFromJson(json['home_inspection_notes']),
       awayInspectionNotes: _inspectionNotesFromJson(json['away_inspection_notes']),
+      homeInspectionRobots: _inspectionRobotsFromJson(json['home_inspection_robots']),
+      awayInspectionRobots: _inspectionRobotsFromJson(json['away_inspection_robots']),
     );
   }
 
@@ -241,6 +297,10 @@ class ScoreboardMatchConfig {
             homeInspectionNotes.map((n) => n.toJson()).toList(),
         'away_inspection_notes':
             awayInspectionNotes.map((n) => n.toJson()).toList(),
+        'home_inspection_robots':
+            homeInspectionRobots.map((r) => r.toJson()).toList(),
+        'away_inspection_robots':
+            awayInspectionRobots.map((r) => r.toJson()).toList(),
       };
 }
 

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -2,6 +2,56 @@ import 'dart:convert';
 
 enum ResultSubmissionState { pending, submitted, conflict, failed }
 
+/// Soft per-team inspection status the scoreboard reports for the current
+/// competition day (rcj-scoreboard #112). [unknown] is the client-side fallback
+/// for an absent/unrecognised value — treat both [unknown] and [missing] as
+/// "not applicable / not yet cleared", never as a hard "blocked": the server's
+/// "missing" conflates a non-inspecting league with an uninspected team.
+enum InspectionStatus { ok, failed, missing, unknown }
+
+InspectionStatus _inspectionStatusFromJson(dynamic value) {
+  final name = value?.toString().toLowerCase().trim();
+  return InspectionStatus.values.firstWhere(
+    (s) => s.name == name,
+    orElse: () => InspectionStatus.unknown,
+  );
+}
+
+/// One inspection note the scoreboard reports for a fielded robot on the current
+/// competition day (rcj-scoreboard #112): the free text explaining why a side is
+/// flagged. [robot] is the robot number the note was recorded against.
+class InspectionNote {
+  final int robot;
+  final String note;
+
+  const InspectionNote({required this.robot, required this.note});
+
+  factory InspectionNote.fromJson(Map<String, dynamic> json) => InspectionNote(
+        robot: (json['robot'] as num?)?.toInt() ?? 0,
+        note: (json['note']?.toString() ?? '').trim(),
+      );
+
+  Map<String, dynamic> toJson() => {'robot': robot, 'note': note};
+
+  @override
+  bool operator ==(Object other) =>
+      other is InspectionNote && other.robot == robot && other.note == note;
+
+  @override
+  int get hashCode => Object.hash(robot, note);
+}
+
+/// Parses the `*_inspection_notes` array, dropping malformed entries and any
+/// note that arrives with empty text so the UI never renders a blank line.
+List<InspectionNote> _inspectionNotesFromJson(dynamic value) {
+  if (value is! List) return const [];
+  return value
+      .whereType<Map>()
+      .map((m) => InspectionNote.fromJson(Map<String, dynamic>.from(m)))
+      .where((n) => n.note.isNotEmpty)
+      .toList(growable: false);
+}
+
 class ScoreboardMatchConfig {
   final String matchCode;
   final String homeTeamName;
@@ -13,6 +63,10 @@ class ScoreboardMatchConfig {
   final String timezone;
   final int version;
   final String status;
+  final InspectionStatus homeInspectionStatus;
+  final InspectionStatus awayInspectionStatus;
+  final List<InspectionNote> homeInspectionNotes;
+  final List<InspectionNote> awayInspectionNotes;
 
   /// MAC addresses of the home/away robots' comm modules, ordered by robot
   /// number (server payload keys `home_module_macs`/`away_module_macs`, #70).
@@ -34,6 +88,10 @@ class ScoreboardMatchConfig {
     required this.status,
     this.homeModuleMacs = const [],
     this.awayModuleMacs = const [],
+    this.homeInspectionStatus = InspectionStatus.unknown,
+    this.awayInspectionStatus = InspectionStatus.unknown,
+    this.homeInspectionNotes = const [],
+    this.awayInspectionNotes = const [],
   });
 
   ScoreboardMatchConfig copyWith({
@@ -49,6 +107,10 @@ class ScoreboardMatchConfig {
     String? status,
     List<String>? homeModuleMacs,
     List<String>? awayModuleMacs,
+    InspectionStatus? homeInspectionStatus,
+    InspectionStatus? awayInspectionStatus,
+    List<InspectionNote>? homeInspectionNotes,
+    List<InspectionNote>? awayInspectionNotes,
   }) {
     return ScoreboardMatchConfig(
       matchCode: matchCode ?? this.matchCode,
@@ -63,6 +125,10 @@ class ScoreboardMatchConfig {
       status: status ?? this.status,
       homeModuleMacs: homeModuleMacs ?? this.homeModuleMacs,
       awayModuleMacs: awayModuleMacs ?? this.awayModuleMacs,
+      homeInspectionStatus: homeInspectionStatus ?? this.homeInspectionStatus,
+      awayInspectionStatus: awayInspectionStatus ?? this.awayInspectionStatus,
+      homeInspectionNotes: homeInspectionNotes ?? this.homeInspectionNotes,
+      awayInspectionNotes: awayInspectionNotes ?? this.awayInspectionNotes,
     );
   }
 
@@ -119,6 +185,12 @@ class ScoreboardMatchConfig {
       status: (json['status']?.toString() ?? '').toUpperCase(),
       homeModuleMacs: moduleMacs(json['home_module_macs']),
       awayModuleMacs: moduleMacs(json['away_module_macs']),
+      homeInspectionStatus:
+          _inspectionStatusFromJson(json['home_inspection_status']),
+      awayInspectionStatus:
+          _inspectionStatusFromJson(json['away_inspection_status']),
+      homeInspectionNotes: _inspectionNotesFromJson(json['home_inspection_notes']),
+      awayInspectionNotes: _inspectionNotesFromJson(json['away_inspection_notes']),
     );
   }
 
@@ -163,6 +235,12 @@ class ScoreboardMatchConfig {
         'status': status,
         'home_module_macs': homeModuleMacs,
         'away_module_macs': awayModuleMacs,
+        'home_inspection_status': homeInspectionStatus.name,
+        'away_inspection_status': awayInspectionStatus.name,
+        'home_inspection_notes':
+            homeInspectionNotes.map((n) => n.toJson()).toList(),
+        'away_inspection_notes':
+            awayInspectionNotes.map((n) => n.toJson()).toList(),
       };
 }
 

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -442,11 +442,13 @@ Widget buildTeamContainer(Team team, Game game) {
                 isScrollControlled: true,
                 builder: (context) {
                   return FractionallySizedBox(
-                    heightFactor: 0.7,
+                    heightFactor: 0.85,
                     child: Container(
                       color: Colors.grey[800],
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 20.0, horizontal: 20.0),
+                      // Bottom pad by the system nav inset so the last scrolled
+                      // inspection line clears the gesture bar.
+                      padding: EdgeInsets.fromLTRB(20.0, 20.0, 20.0,
+                          20.0 + MediaQuery.viewPaddingOf(context).bottom),
                       child: TeamSettingsWidget(team: team, game: game),
                     ),
                   );
@@ -592,6 +594,7 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
   Widget build(BuildContext context) {
     final team = widget.team;
     final game = widget.game;
+    final robots = game.inspectionRobotsForTeam(team);
     return Column(
       children: [
         Text(
@@ -646,6 +649,19 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
               icon: const Icon(Icons.remove, color: Colors.white),
               label: const Text('Sub', style: TextStyle(color: Colors.white)),
             ),
+            // Live score of the team being edited, between the -/+ buttons, so
+            // Sub/Add visibly change it (team is a ChangeNotifier).
+            ListenableBuilder(
+              listenable: team,
+              builder: (context, _) => Text(
+                team.score.toString(),
+                style: const TextStyle(
+                  fontSize: 28.0,
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
             ElevatedButton.icon(
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.blue,
@@ -659,6 +675,36 @@ class _TeamSettingsWidgetState extends State<TeamSettingsWidget> {
             ),
           ],
         ),
+        // Per-robot inspection status for this team's side of the linked fixture
+        // (rcj-scoreboard #112), so a referee can check it DURING a loaded
+        // match. Kept in its OWN scroll area (Expanded) below the pinned name +
+        // score controls, so a long note scrolls here instead of pushing the
+        // Score buttons out of reach. Only shown when this side has rows.
+        if (robots.isNotEmpty)
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 20.0),
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Inspection',
+                      style: TextStyle(
+                        fontSize: 16.0,
+                        color: Colors.white70,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 4.0),
+                  InspectionRobotList(robots: robots),
+                ],
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -982,23 +1028,15 @@ Future<void> _openScoreboardResultReview(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Per-team, per-robot inspection (rcj-scoreboard #112): each
-                    // fielded robot's own status + note. Row count follows the
-                    // list (1v1 -> 1 row, 2v2 -> 2). Informational only.
+                    // Matchup + fixture details first...
                     Text(
-                      config.homeTeamName,
+                      '${config.homeTeamName} vs ${config.awayTeamName}',
                       style: const TextStyle(
-                          color: Colors.white, fontWeight: FontWeight.w600),
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
                     ),
-                    InspectionRobotList(robots: config.homeInspectionRobots),
-                    const SizedBox(height: 6),
-                    Text(
-                      config.awayTeamName,
-                      style: const TextStyle(
-                          color: Colors.white, fontWeight: FontWeight.w600),
-                    ),
-                    InspectionRobotList(robots: config.awayInspectionRobots),
-                    const SizedBox(height: 8),
                     for (final line in details)
                       Padding(
                         padding: const EdgeInsets.only(top: 4),
@@ -1014,6 +1052,33 @@ Future<void> _openScoreboardResultReview(
                           ),
                         ),
                       ),
+                    // ...then the per-team, per-robot inspection section
+                    // (rcj-scoreboard #112): each fielded robot's own status +
+                    // note, grouped under an underlined team name. Row count
+                    // follows the list (1v1 -> 1 row, 2v2 -> 2). Informational
+                    // only.
+                    const SizedBox(height: 12),
+                    Text(
+                      config.homeTeamName,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                    InspectionRobotList(robots: config.homeInspectionRobots),
+                    const SizedBox(height: 10),
+                    Text(
+                      config.awayTeamName,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                    InspectionRobotList(robots: config.awayInspectionRobots),
                   ],
                 ),
               ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -14,7 +14,7 @@ import 'package:rcj_scoreboard/screens/settings.dart';
 import 'package:rcj_scoreboard/screens/scoreboard_result_review.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
 import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
-import 'package:rcj_scoreboard/widgets/inspection_status_badge.dart';
+import 'package:rcj_scoreboard/widgets/inspection_robot_list.dart';
 import 'package:rcj_scoreboard/widgets/scrolling_status_text.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:rcj_scoreboard/services/ble_adapter_monitor.dart';
@@ -982,26 +982,22 @@ Future<void> _openScoreboardResultReview(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Team names with their soft inspection-status badges
-                    // (rcj-scoreboard #112). A Wrap keeps long names + badges
-                    // from overflowing the dialog width.
-                    Wrap(
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      spacing: 6,
-                      runSpacing: 4,
-                      children: [
-                        Text(config.homeTeamName,
-                            style: const TextStyle(color: Colors.white)),
-                        InspectionStatusBadge(
-                            status: config.homeInspectionStatus),
-                        const Text('vs',
-                            style: TextStyle(color: Colors.white70)),
-                        Text(config.awayTeamName,
-                            style: const TextStyle(color: Colors.white)),
-                        InspectionStatusBadge(
-                            status: config.awayInspectionStatus),
-                      ],
+                    // Per-team, per-robot inspection (rcj-scoreboard #112): each
+                    // fielded robot's own status + note. Row count follows the
+                    // list (1v1 -> 1 row, 2v2 -> 2). Informational only.
+                    Text(
+                      config.homeTeamName,
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w600),
                     ),
+                    InspectionRobotList(robots: config.homeInspectionRobots),
+                    const SizedBox(height: 6),
+                    Text(
+                      config.awayTeamName,
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w600),
+                    ),
+                    InspectionRobotList(robots: config.awayInspectionRobots),
                     const SizedBox(height: 8),
                     for (final line in details)
                       Padding(
@@ -1018,35 +1014,6 @@ Future<void> _openScoreboardResultReview(
                           ),
                         ),
                       ),
-                    // Inspection notes under the fixture details, so a referee
-                    // can see WHY a side is flagged before loading. Rendered per
-                    // side only when that side actually has notes.
-                    for (final side in [
-                      (config.homeTeamName, config.homeInspectionNotes),
-                      (config.awayTeamName, config.awayInspectionNotes),
-                    ])
-                      if (side.$2.isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        Text(
-                          '${side.$1} inspection notes:',
-                          style: const TextStyle(
-                            color: Colors.white70,
-                            fontWeight: FontWeight.w600,
-                            fontSize: 13,
-                          ),
-                        ),
-                        for (final note in side.$2)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 2, left: 8),
-                            child: Text(
-                              'Robot ${note.robot}: ${note.note}',
-                              style: const TextStyle(
-                                color: Colors.white70,
-                                fontSize: 13,
-                              ),
-                            ),
-                          ),
-                      ],
                   ],
                 ),
               ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -14,6 +14,7 @@ import 'package:rcj_scoreboard/screens/settings.dart';
 import 'package:rcj_scoreboard/screens/scoreboard_result_review.dart';
 import 'package:rcj_scoreboard/utils/colors.dart';
 import 'package:rcj_scoreboard/widgets/critical_gesture_detector.dart';
+import 'package:rcj_scoreboard/widgets/inspection_status_badge.dart';
 import 'package:rcj_scoreboard/widgets/scrolling_status_text.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:rcj_scoreboard/services/ble_adapter_monitor.dart';
@@ -976,31 +977,78 @@ Future<void> _openScoreboardResultReview(
               backgroundColor: Colors.grey[800],
               title: const Text('Load match?',
                   style: TextStyle(color: Colors.white)),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '${config.homeTeamName} vs ${config.awayTeamName}',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                  const SizedBox(height: 8),
-                  for (final line in details)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        line,
-                        style: TextStyle(
-                          color: line.startsWith('⚠')
-                              ? Colors.orangeAccent
-                              : Colors.white70,
-                          fontWeight: line.startsWith('⚠')
-                              ? FontWeight.w600
-                              : FontWeight.normal,
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Team names with their soft inspection-status badges
+                    // (rcj-scoreboard #112). A Wrap keeps long names + badges
+                    // from overflowing the dialog width.
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: 6,
+                      runSpacing: 4,
+                      children: [
+                        Text(config.homeTeamName,
+                            style: const TextStyle(color: Colors.white)),
+                        InspectionStatusBadge(
+                            status: config.homeInspectionStatus),
+                        const Text('vs',
+                            style: TextStyle(color: Colors.white70)),
+                        Text(config.awayTeamName,
+                            style: const TextStyle(color: Colors.white)),
+                        InspectionStatusBadge(
+                            status: config.awayInspectionStatus),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    for (final line in details)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          line,
+                          style: TextStyle(
+                            color: line.startsWith('⚠')
+                                ? Colors.orangeAccent
+                                : Colors.white70,
+                            fontWeight: line.startsWith('⚠')
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
                         ),
                       ),
-                    ),
-                ],
+                    // Inspection notes under the fixture details, so a referee
+                    // can see WHY a side is flagged before loading. Rendered per
+                    // side only when that side actually has notes.
+                    for (final side in [
+                      (config.homeTeamName, config.homeInspectionNotes),
+                      (config.awayTeamName, config.awayInspectionNotes),
+                    ])
+                      if (side.$2.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          '${side.$1} inspection notes:',
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontWeight: FontWeight.w600,
+                            fontSize: 13,
+                          ),
+                        ),
+                        for (final note in side.$2)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 2, left: 8),
+                            child: Text(
+                              'Robot ${note.robot}: ${note.note}',
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                      ],
+                  ],
+                ),
               ),
               actions: [
                 Row(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1006,7 +1006,7 @@ Future<void> _openScoreboardResultReview(
       // newer pending link that replaced it after this dialog was built.
       final expectedSignature = config.signature;
       final duration = _formatMatchDuration(config.durationSeconds);
-      final kickoff = _formatLocalKickoff(config.scheduledStart);
+      final kickoff = formatLocalKickoff(config.scheduledStart);
       final details = <String>[
         if (config.venueShortName.isNotEmpty)
           'Field ${config.venueShortName} · $duration'
@@ -1182,7 +1182,8 @@ String _formatMatchDuration(int seconds) {
 // from the payload's ISO-8601 (UTC/offset) value; toLocal() converts it to the
 // device zone. Formatted by hand (no intl dependency). Returns null when the
 // payload carries no scheduled_start.
-String? _formatLocalKickoff(DateTime? scheduledStart) {
+@visibleForTesting
+String? formatLocalKickoff(DateTime? scheduledStart) {
   if (scheduledStart == null) return null;
   final dt = scheduledStart.toLocal();
   const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1006,11 +1006,13 @@ Future<void> _openScoreboardResultReview(
       // newer pending link that replaced it after this dialog was built.
       final expectedSignature = config.signature;
       final duration = _formatMatchDuration(config.durationSeconds);
+      final kickoff = _formatLocalKickoff(config.scheduledStart);
       final details = <String>[
         if (config.venueShortName.isNotEmpty)
           'Field ${config.venueShortName} · $duration'
         else
           duration,
+        if (kickoff != null) 'Kickoff $kickoff (local time)',
         if (game.inGame) '⚠ This replaces the match in progress.',
       ];
       try {
@@ -1173,6 +1175,24 @@ String _formatMatchDuration(int seconds) {
   if (minutes == 0) return '$secs s';
   if (secs == 0) return '$minutes min';
   return '$minutes min $secs s';
+}
+
+// The fixture's scheduled kickoff in the phone's LOCAL time, so a referee can
+// confirm they loaded the match for the right slot. `scheduledStart` is parsed
+// from the payload's ISO-8601 (UTC/offset) value; toLocal() converts it to the
+// device zone. Formatted by hand (no intl dependency). Returns null when the
+// payload carries no scheduled_start.
+String? _formatLocalKickoff(DateTime? scheduledStart) {
+  if (scheduledStart == null) return null;
+  final dt = scheduledStart.toLocal();
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', //
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+  ];
+  final hh = dt.hour.toString().padLeft(2, '0');
+  final mm = dt.minute.toString().padLeft(2, '0');
+  return '${days[dt.weekday - 1]} ${dt.day} ${months[dt.month - 1]} · $hh:$mm';
 }
 
 String _resumeMatchBody(MatchSnapshot snapshot) {

--- a/lib/widgets/inspection_robot_list.dart
+++ b/lib/widgets/inspection_robot_list.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/widgets/inspection_status_badge.dart';
 
-/// A compact per-robot inspection list: one row per [InspectionRobot] showing
-/// "Robot N", its status badge (green cleared / red failed / neutral grey dash
-/// for missing/unknown), and its note when present. Informational only.
+/// A per-robot inspection list: for each [InspectionRobot], "Robot N" + its
+/// status badge (green cleared / red failed / neutral grey dash for
+/// missing/unknown) on one line, and its note — when present — on its own line
+/// below so a long comment wraps full-width instead of crowding the status.
+/// Informational only.
 ///
 /// Renders nothing for an empty list (an unresolved side or a non-inspecting
 /// league), so callers can drop it in unconditionally.
@@ -23,25 +25,35 @@ class InspectionRobotList extends StatelessWidget {
       children: [
         for (final r in robots)
           Padding(
-            padding: const EdgeInsets.only(top: 2, left: 8),
-            child: Row(
+            padding: const EdgeInsets.only(top: 8, left: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  'Robot ${r.robot}',
-                  style: const TextStyle(color: Colors.white70, fontSize: 13),
+                // "Robot N" + status badge on one line.
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Robot ${r.robot}',
+                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                    const SizedBox(width: 8),
+                    InspectionStatusBadge(status: r.status),
+                  ],
                 ),
-                const SizedBox(width: 6),
-                InspectionStatusBadge(status: r.status),
-                if (r.note.isNotEmpty) ...[
-                  const SizedBox(width: 6),
-                  Flexible(
+                // The note on its own new line below, full width so a long
+                // comment wraps naturally instead of being squeezed after the
+                // badge.
+                if (r.note.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 3, left: 4),
                     child: Text(
-                      '· ${r.note}',
-                      style: const TextStyle(color: Colors.white70, fontSize: 13),
+                      r.note,
+                      style:
+                          const TextStyle(color: Colors.white70, fontSize: 15),
                     ),
                   ),
-                ],
               ],
             ),
           ),

--- a/lib/widgets/inspection_robot_list.dart
+++ b/lib/widgets/inspection_robot_list.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/widgets/inspection_status_badge.dart';
+
+/// A compact per-robot inspection list: one row per [InspectionRobot] showing
+/// "Robot N", its status badge (green cleared / red failed / neutral grey dash
+/// for missing/unknown), and its note when present. Informational only.
+///
+/// Renders nothing for an empty list (an unresolved side or a non-inspecting
+/// league), so callers can drop it in unconditionally.
+class InspectionRobotList extends StatelessWidget {
+  final List<InspectionRobot> robots;
+
+  const InspectionRobotList({super.key, required this.robots});
+
+  @override
+  Widget build(BuildContext context) {
+    if (robots.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final r in robots)
+          Padding(
+            padding: const EdgeInsets.only(top: 2, left: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Robot ${r.robot}',
+                  style: const TextStyle(color: Colors.white70, fontSize: 13),
+                ),
+                const SizedBox(width: 6),
+                InspectionStatusBadge(status: r.status),
+                if (r.note.isNotEmpty) ...[
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      '· ${r.note}',
+                      style: const TextStyle(color: Colors.white70, fontSize: 13),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/inspection_status_badge.dart
+++ b/lib/widgets/inspection_status_badge.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/utils/colors.dart';
+
+/// Small inline badge for a team's soft inspection status, shown beside the
+/// team name in the "Load match?" dialog. Informational only — it never blocks
+/// loading a match.
+///
+/// [InspectionStatus.missing] and [InspectionStatus.unknown] render as a neutral
+/// grey dash, deliberately NOT as a warning: the scoreboard's "missing"
+/// conflates "this league runs no inspections" with "team not yet cleared
+/// today", so the app must not imply the team is blocked.
+class InspectionStatusBadge extends StatelessWidget {
+  final InspectionStatus status;
+
+  const InspectionStatusBadge({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    switch (status) {
+      case InspectionStatus.ok:
+        return _chip(AppColors.green, Icons.check_circle, 'cleared');
+      case InspectionStatus.failed:
+        return _chip(AppColors.red, Icons.cancel, 'failed');
+      case InspectionStatus.missing:
+      case InspectionStatus.unknown:
+        return const Text(
+          '—',
+          style: TextStyle(color: Colors.white38, fontWeight: FontWeight.w600),
+        );
+    }
+  }
+
+  Widget _chip(Color color, IconData icon, String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 12, color: color),
+          const SizedBox(width: 3),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/inspection_status_badge.dart
+++ b/lib/widgets/inspection_status_badge.dart
@@ -27,7 +27,8 @@ class InspectionStatusBadge extends StatelessWidget {
       case InspectionStatus.unknown:
         return const Text(
           '—',
-          style: TextStyle(color: Colors.white38, fontWeight: FontWeight.w600),
+          style: TextStyle(
+              color: Colors.white38, fontWeight: FontWeight.w600, fontSize: 16),
         );
     }
   }
@@ -42,13 +43,13 @@ class InspectionStatusBadge extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 12, color: color),
-          const SizedBox(width: 3),
+          Icon(icon, size: 15, color: color),
+          const SizedBox(width: 4),
           Text(
             label,
             style: TextStyle(
               color: color,
-              fontSize: 11,
+              fontSize: 13,
               fontWeight: FontWeight.w600,
             ),
           ),

--- a/test/format_local_kickoff_test.dart
+++ b/test/format_local_kickoff_test.dart
@@ -1,0 +1,24 @@
+// test/format_local_kickoff_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/screens/home.dart';
+
+void main() {
+  test('null scheduledStart -> null (line omitted)', () {
+    expect(formatLocalKickoff(null), isNull);
+  });
+
+  test('formats weekday/day/month with zero-padded hh:mm', () {
+    // A *local* DateTime, so toLocal() is a no-op and the result is
+    // deterministic regardless of the test machine's timezone. 2026-07-01 is a
+    // Wednesday; single-digit hour/minute must zero-pad.
+    expect(formatLocalKickoff(DateTime(2026, 7, 1, 9, 5)), 'Wed 1 Jul · 09:05');
+  });
+
+  test('indexes the month and weekday tables correctly across the year', () {
+    // First and last months exercise the table bounds (weekday-1 / month-1).
+    expect(formatLocalKickoff(DateTime(2026, 1, 5, 0, 0)), contains('5 Jan'));
+    final dec = formatLocalKickoff(DateTime(2026, 12, 25, 23, 59));
+    expect(dec, contains('25 Dec'));
+    expect(dec, endsWith('23:59'));
+  });
+}

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -284,6 +284,74 @@ void main() {
     });
   });
 
+  group('inspectionRobotsForTeam side mapping (#77)', () {
+    Map<String, dynamic> configWithInspection({required bool homeIsLeft}) => {
+          ..._scoreboardConfig(
+              matchCode: 'M-INSP', version: 1, homeIsLeft: homeIsLeft),
+          'home_inspection_robots': const [
+            {'robot': 1, 'status': 'ok', 'note': ''},
+            {'robot': 2, 'status': 'failed', 'note': 'battery low'},
+          ],
+          'away_inspection_robots': const [
+            {'robot': 1, 'status': 'missing', 'note': ''},
+          ],
+        };
+
+    testWidgets('maps home rows to the home-side team, away to the other',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(configWithInspection(homeIsLeft: true)),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+      final teamB = game.teams.firstWhere((t) => t.id == 'B');
+      // homeIsLeft -> team A is home.
+      expect(game.inspectionRobotsForTeam(teamA), const [
+        InspectionRobot(robot: 1, status: InspectionStatus.ok, note: ''),
+        InspectionRobot(
+            robot: 2, status: InspectionStatus.failed, note: 'battery low'),
+      ]);
+      expect(game.inspectionRobotsForTeam(teamB), const [
+        InspectionRobot(robot: 1, status: InspectionStatus.missing, note: ''),
+      ]);
+      game.dispose();
+    });
+
+    testWidgets('a home/away swap (homeIsLeft:false) crosses the sides by id',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(configWithInspection(homeIsLeft: false)),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+      final teamB = game.teams.firstWhere((t) => t.id == 'B');
+      // homeIsLeft:false -> team B is home, so team A gets the AWAY rows.
+      expect(game.inspectionRobotsForTeam(teamB).map((r) => r.robot), [1, 2]);
+      expect(game.inspectionRobotsForTeam(teamA), const [
+        InspectionRobot(robot: 1, status: InspectionStatus.missing, note: ''),
+      ]);
+      game.dispose();
+    });
+
+    testWidgets('no linked fixture -> empty for both teams', (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      await tester.pump();
+      for (final team in game.teams) {
+        expect(game.inspectionRobotsForTeam(team), isEmpty);
+      }
+      game.dispose();
+    });
+  });
+
   group('cold-launch detection', () {
     testWidgets('an in-progress snapshot is offered for resume',
         (tester) async {

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -10,6 +10,7 @@
 
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -17,6 +18,7 @@ import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/models/team.dart';
+import 'package:rcj_scoreboard/screens/home.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
 
 ModuleSnapshot _moduleSnap({
@@ -348,6 +350,32 @@ void main() {
       for (final team in game.teams) {
         expect(game.inspectionRobotsForTeam(team), isEmpty);
       }
+      game.dispose();
+    });
+
+    testWidgets('team-settings sheet renders the per-robot inspection section',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(configWithInspection(homeIsLeft: true)),
+        token: 'test-token',
+      );
+      await tester.pump();
+      final teamA = game.teams.firstWhere((t) => t.id == 'A');
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: TeamSettingsWidget(team: teamA, game: game)),
+      ));
+      await tester.pump();
+
+      // Home side (team A) shows both robots with their status + note.
+      expect(find.text('Inspection'), findsOneWidget);
+      expect(find.text('Robot 1'), findsOneWidget);
+      expect(find.text('Robot 2'), findsOneWidget);
+      expect(find.text('cleared'), findsOneWidget); // robot 1 ok
+      expect(find.text('failed'), findsOneWidget); // robot 2 failed
+      expect(find.textContaining('battery low'), findsOneWidget);
       game.dispose();
     });
   });

--- a/test/inspection_robot_list_test.dart
+++ b/test/inspection_robot_list_test.dart
@@ -1,0 +1,37 @@
+// test/inspection_robot_list_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/widgets/inspection_robot_list.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('renders one row per robot with status and note', (tester) async {
+    await tester.pumpWidget(wrap(const InspectionRobotList(robots: [
+      InspectionRobot(robot: 1, status: InspectionStatus.ok, note: ''),
+      InspectionRobot(
+          robot: 2, status: InspectionStatus.failed, note: 'battery below spec'),
+    ])));
+    expect(find.text('Robot 1'), findsOneWidget);
+    expect(find.text('Robot 2'), findsOneWidget);
+    expect(find.text('cleared'), findsOneWidget); // ok badge
+    expect(find.text('failed'), findsOneWidget); // failed badge
+    expect(find.textContaining('battery below spec'), findsOneWidget);
+  });
+
+  testWidgets('missing robot renders a neutral dash, no note text', (tester) async {
+    await tester.pumpWidget(wrap(const InspectionRobotList(robots: [
+      InspectionRobot(robot: 1, status: InspectionStatus.missing, note: ''),
+    ])));
+    expect(find.text('Robot 1'), findsOneWidget);
+    expect(find.text('—'), findsOneWidget);
+    expect(find.text('cleared'), findsNothing);
+    expect(find.text('failed'), findsNothing);
+  });
+
+  testWidgets('empty list renders nothing', (tester) async {
+    await tester.pumpWidget(wrap(const InspectionRobotList(robots: [])));
+    expect(find.byType(Row), findsNothing);
+  });
+}

--- a/test/inspection_status_badge_test.dart
+++ b/test/inspection_status_badge_test.dart
@@ -1,0 +1,36 @@
+// test/inspection_status_badge_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/models/scoreboard_result.dart';
+import 'package:rcj_scoreboard/widgets/inspection_status_badge.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('ok renders a green "cleared" badge', (tester) async {
+    await tester.pumpWidget(
+        wrap(const InspectionStatusBadge(status: InspectionStatus.ok)));
+    expect(find.text('cleared'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('failed renders a red "failed" badge', (tester) async {
+    await tester.pumpWidget(
+        wrap(const InspectionStatusBadge(status: InspectionStatus.failed)));
+    expect(find.text('failed'), findsOneWidget);
+    expect(find.byIcon(Icons.cancel), findsOneWidget);
+  });
+
+  testWidgets('missing and unknown render a neutral dash, never a warning',
+      (tester) async {
+    for (final s in [InspectionStatus.missing, InspectionStatus.unknown]) {
+      await tester.pumpWidget(wrap(InspectionStatusBadge(status: s)));
+      // Neutral: a dash, no status word, no colored status icon.
+      expect(find.text('—'), findsOneWidget);
+      expect(find.text('cleared'), findsNothing);
+      expect(find.text('failed'), findsNothing);
+      expect(find.byIcon(Icons.check_circle), findsNothing);
+      expect(find.byIcon(Icons.cancel), findsNothing);
+    }
+  });
+}

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -40,6 +40,10 @@ Map<String, dynamic> _matchJson({
       'timezone': 'Europe/Prague',
       'version': version,
       'status': 'SCHEDULED',
+      'home_inspection_status': 'ok',
+      'away_inspection_status': 'missing',
+      'home_inspection_notes': const [],
+      'away_inspection_notes': const [],
     };
 
 Future<void> _waitFor(
@@ -76,6 +80,95 @@ void main() {
       expect(config.durationSeconds, 480);
       expect(config.version, 7);
       expect(config.status, 'SCHEDULED');
+    });
+
+    test('parses inspection status and notes', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_status': 'ok',
+        'away_inspection_status': 'failed',
+        'home_inspection_notes': const [],
+        'away_inspection_notes': const [
+          {'robot': 1, 'note': 'battery low'},
+          {'robot': 2, 'note': 'wheels re-seated'},
+        ],
+      });
+
+      expect(config.homeInspectionStatus, InspectionStatus.ok);
+      expect(config.awayInspectionStatus, InspectionStatus.failed);
+      expect(config.homeInspectionNotes, isEmpty);
+      expect(config.awayInspectionNotes, const [
+        InspectionNote(robot: 1, note: 'battery low'),
+        InspectionNote(robot: 2, note: 'wheels re-seated'),
+      ]);
+    });
+
+    test('unknown/absent inspection status falls back to unknown', () {
+      final absent = ScoreboardMatchConfig.fromJson(_matchJson()
+        ..remove('home_inspection_status')
+        ..remove('away_inspection_status')
+        ..remove('home_inspection_notes')
+        ..remove('away_inspection_notes'));
+      expect(absent.homeInspectionStatus, InspectionStatus.unknown);
+      expect(absent.awayInspectionStatus, InspectionStatus.unknown);
+      expect(absent.homeInspectionNotes, isEmpty);
+      expect(absent.awayInspectionNotes, isEmpty);
+
+      final garbage = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_status': 'exploded',
+      });
+      expect(garbage.homeInspectionStatus, InspectionStatus.unknown);
+    });
+
+    test('inspection notes drop blank text and malformed entries', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_notes': const [
+          {'robot': 1, 'note': 'cracked chassis'},
+          {'robot': 2, 'note': '   '},
+          {'robot': 3, 'note': ''},
+          'not-a-map',
+        ],
+        'away_inspection_notes': 'not-a-list',
+      });
+      expect(config.homeInspectionNotes,
+          const [InspectionNote(robot: 1, note: 'cracked chassis')]);
+      expect(config.awayInspectionNotes, isEmpty);
+    });
+
+    test('inspection status and notes survive a toJson/fromJson round-trip', () {
+      final original = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_status': 'failed',
+        'away_inspection_status': 'missing',
+        'home_inspection_notes': const [
+          {'robot': 2, 'note': 'loose wiring'},
+        ],
+        'away_inspection_notes': const [],
+      });
+
+      final restored = ScoreboardMatchConfig.fromJson(
+        jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.homeInspectionStatus, InspectionStatus.failed);
+      expect(restored.awayInspectionStatus, InspectionStatus.missing);
+      expect(restored.homeInspectionNotes,
+          const [InspectionNote(robot: 2, note: 'loose wiring')]);
+      expect(restored.awayInspectionNotes, isEmpty);
+    });
+
+    test('inspection status is not part of the load signature', () {
+      final base = ScoreboardMatchConfig.fromJson(_matchJson());
+      final flipped = base.copyWith(
+        homeInspectionStatus: InspectionStatus.failed,
+        awayInspectionStatus: InspectionStatus.ok,
+        homeInspectionNotes: const [InspectionNote(robot: 1, note: 'x')],
+      );
+      // Inspection state is cosmetic: a status/notes change must not re-fire the
+      // confirm-on-load / apply-dedupe logic keyed on `signature`.
+      expect(flipped.signature, base.signature);
     });
 
     test('falls back to side_order map and defaults', () {

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -44,6 +44,8 @@ Map<String, dynamic> _matchJson({
       'away_inspection_status': 'missing',
       'home_inspection_notes': const [],
       'away_inspection_notes': const [],
+      'home_inspection_robots': const [],
+      'away_inspection_robots': const [],
     };
 
 Future<void> _waitFor(
@@ -232,6 +234,68 @@ void main() {
 
       expect(restored.homeModuleMacs, ['A1:B2:C3:D4:E5:F6']);
       expect(restored.awayModuleMacs, ['AA:BB:CC:DD:EE:FF']);
+    });
+
+    test('parses inspection robots (status + note per robot)', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'ok', 'note': ''},
+          {'robot': 2, 'status': 'failed', 'note': 'battery below spec'},
+        ],
+        'away_inspection_robots': const [
+          {'robot': 1, 'status': 'missing', 'note': ''},
+        ],
+      });
+
+      expect(config.homeInspectionRobots, const [
+        InspectionRobot(robot: 1, status: InspectionStatus.ok, note: ''),
+        InspectionRobot(
+            robot: 2, status: InspectionStatus.failed, note: 'battery below spec'),
+      ]);
+      expect(config.awayInspectionRobots, const [
+        InspectionRobot(robot: 1, status: InspectionStatus.missing, note: ''),
+      ]);
+    });
+
+    test('inspection robots parsing is total (drops malformed/invalid robot)', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'ok', 'note': ''},
+          {'robot': 'x', 'status': 'ok', 'note': 'bad id'},
+          {'robot': 0, 'status': 'ok', 'note': 'zero'},
+          'not-a-map',
+        ],
+        'away_inspection_robots': 'not-a-list',
+      });
+      expect(config.homeInspectionRobots,
+          const [InspectionRobot(robot: 1, status: InspectionStatus.ok, note: '')]);
+      expect(config.awayInspectionRobots, isEmpty);
+    });
+
+    test('inspection robots survive a toJson/fromJson round-trip', () {
+      final original = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_robots': const [
+          {'robot': 2, 'status': 'failed', 'note': 'loose wiring'},
+        ],
+      });
+      final restored = ScoreboardMatchConfig.fromJson(
+        jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+      );
+      expect(restored.homeInspectionRobots, const [
+        InspectionRobot(
+            robot: 2, status: InspectionStatus.failed, note: 'loose wiring'),
+      ]);
+    });
+
+    test('inspection robots are not part of the load signature', () {
+      final base = ScoreboardMatchConfig.fromJson(_matchJson());
+      final flipped = base.copyWith(homeInspectionRobots: const [
+        InspectionRobot(robot: 1, status: InspectionStatus.failed, note: 'x'),
+      ]);
+      expect(flipped.signature, base.signature);
     });
   });
 

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -40,10 +40,6 @@ Map<String, dynamic> _matchJson({
       'timezone': 'Europe/Prague',
       'version': version,
       'status': 'SCHEDULED',
-      'home_inspection_status': 'ok',
-      'away_inspection_status': 'missing',
-      'home_inspection_notes': const [],
-      'away_inspection_notes': const [],
       'home_inspection_robots': const [],
       'away_inspection_robots': const [],
     };
@@ -84,91 +80,105 @@ void main() {
       expect(config.status, 'SCHEDULED');
     });
 
-    test('parses inspection status and notes', () {
+    test('parses per-robot inspection status and notes, in order', () {
       final config = ScoreboardMatchConfig.fromJson({
         ..._matchJson(),
-        'home_inspection_status': 'ok',
-        'away_inspection_status': 'failed',
-        'home_inspection_notes': const [],
-        'away_inspection_notes': const [
-          {'robot': 1, 'note': 'battery low'},
-          {'robot': 2, 'note': 'wheels re-seated'},
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'ok', 'note': ''},
+        ],
+        'away_inspection_robots': const [
+          {'robot': 1, 'status': 'failed', 'note': 'battery low'},
+          {'robot': 2, 'status': 'ok', 'note': 'wheels re-seated'},
         ],
       });
 
-      expect(config.homeInspectionStatus, InspectionStatus.ok);
-      expect(config.awayInspectionStatus, InspectionStatus.failed);
-      expect(config.homeInspectionNotes, isEmpty);
-      expect(config.awayInspectionNotes, const [
-        InspectionNote(robot: 1, note: 'battery low'),
-        InspectionNote(robot: 2, note: 'wheels re-seated'),
+      expect(config.homeInspectionRobots, const [
+        InspectionRobot(robot: 1, status: InspectionStatus.ok, note: ''),
+      ]);
+      expect(config.awayInspectionRobots, const [
+        InspectionRobot(
+            robot: 1, status: InspectionStatus.failed, note: 'battery low'),
+        InspectionRobot(
+            robot: 2, status: InspectionStatus.ok, note: 'wheels re-seated'),
       ]);
     });
 
-    test('unknown/absent inspection status falls back to unknown', () {
+    test('absent robots -> empty; garbage status -> unknown', () {
       final absent = ScoreboardMatchConfig.fromJson(_matchJson()
-        ..remove('home_inspection_status')
-        ..remove('away_inspection_status')
-        ..remove('home_inspection_notes')
-        ..remove('away_inspection_notes'));
-      expect(absent.homeInspectionStatus, InspectionStatus.unknown);
-      expect(absent.awayInspectionStatus, InspectionStatus.unknown);
-      expect(absent.homeInspectionNotes, isEmpty);
-      expect(absent.awayInspectionNotes, isEmpty);
+        ..remove('home_inspection_robots')
+        ..remove('away_inspection_robots'));
+      expect(absent.homeInspectionRobots, isEmpty);
+      expect(absent.awayInspectionRobots, isEmpty);
 
       final garbage = ScoreboardMatchConfig.fromJson({
         ..._matchJson(),
-        'home_inspection_status': 'exploded',
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'exploded', 'note': ''},
+        ],
       });
-      expect(garbage.homeInspectionStatus, InspectionStatus.unknown);
+      expect(
+          garbage.homeInspectionRobots.single.status, InspectionStatus.unknown);
     });
 
-    test('inspection notes drop blank text and malformed entries', () {
+    test('robot id parses from int, float and string; bad rows dropped', () {
       final config = ScoreboardMatchConfig.fromJson({
         ..._matchJson(),
-        'home_inspection_notes': const [
-          {'robot': 1, 'note': 'cracked chassis'},
-          {'robot': 2, 'note': '   '},
-          {'robot': 3, 'note': ''},
-          'not-a-map',
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'ok', 'note': ''}, // int
+          {'robot': 3.0, 'status': 'ok', 'note': ''}, // float -> 3
+          {'robot': '2', 'status': 'failed', 'note': 'x'}, // string -> 2
+          {'robot': 0, 'status': 'ok', 'note': ''}, // non-positive -> dropped
+          {'robot': 'nope', 'status': 'ok', 'note': ''}, // unparseable -> dropped
+          'not-a-map', // dropped
         ],
-        'away_inspection_notes': 'not-a-list',
+        'away_inspection_robots': 'not-a-list',
       });
-      expect(config.homeInspectionNotes,
-          const [InspectionNote(robot: 1, note: 'cracked chassis')]);
-      expect(config.awayInspectionNotes, isEmpty);
+      expect(config.homeInspectionRobots.map((r) => r.robot), [1, 3, 2]);
+      expect(config.awayInspectionRobots, isEmpty);
     });
 
-    test('inspection status and notes survive a toJson/fromJson round-trip', () {
+    test('robot note is trimmed; status normalizes case + whitespace', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'home_inspection_robots': const [
+          {'robot': 1, 'status': 'OK', 'note': '  spaced out  '},
+          {'robot': 2, 'status': ' Failed ', 'note': '   '},
+        ],
+      });
+      expect(config.homeInspectionRobots[0].status, InspectionStatus.ok);
+      expect(config.homeInspectionRobots[0].note, 'spaced out');
+      expect(config.homeInspectionRobots[1].status, InspectionStatus.failed);
+      expect(config.homeInspectionRobots[1].note, '');
+    });
+
+    test('per-robot inspection survives a toJson/fromJson round-trip', () {
       final original = ScoreboardMatchConfig.fromJson({
         ..._matchJson(),
-        'home_inspection_status': 'failed',
-        'away_inspection_status': 'missing',
-        'home_inspection_notes': const [
-          {'robot': 2, 'note': 'loose wiring'},
+        'home_inspection_robots': const [
+          {'robot': 2, 'status': 'failed', 'note': 'loose wiring'},
         ],
-        'away_inspection_notes': const [],
+        'away_inspection_robots': const [],
       });
 
       final restored = ScoreboardMatchConfig.fromJson(
         jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
       );
 
-      expect(restored.homeInspectionStatus, InspectionStatus.failed);
-      expect(restored.awayInspectionStatus, InspectionStatus.missing);
-      expect(restored.homeInspectionNotes,
-          const [InspectionNote(robot: 2, note: 'loose wiring')]);
-      expect(restored.awayInspectionNotes, isEmpty);
+      expect(restored.homeInspectionRobots, const [
+        InspectionRobot(
+            robot: 2, status: InspectionStatus.failed, note: 'loose wiring'),
+      ]);
+      expect(restored.awayInspectionRobots, isEmpty);
     });
 
-    test('inspection status is not part of the load signature', () {
+    test('inspection is not part of the load signature', () {
       final base = ScoreboardMatchConfig.fromJson(_matchJson());
       final flipped = base.copyWith(
-        homeInspectionStatus: InspectionStatus.failed,
-        awayInspectionStatus: InspectionStatus.ok,
-        homeInspectionNotes: const [InspectionNote(robot: 1, note: 'x')],
+        homeInspectionRobots: const [
+          InspectionRobot(robot: 1, status: InspectionStatus.failed, note: 'x'),
+        ],
       );
-      // Inspection state is cosmetic: a status/notes change must not re-fire the
+      // Inspection state is cosmetic: a change must not re-fire the
       // confirm-on-load / apply-dedupe logic keyed on `signature`.
       expect(flipped.signature, base.signature);
     });


### PR DESCRIPTION
## What

The scoreboard now reports each side's soft inspection **status** and per-robot
inspection **notes** for the current competition day (rcj-scoreboard #112, plus
the notes companion robocup-junior/rcj-scoreboard#117). This surfaces both in the
**"Load match?" dialog** so a referee can see whether each team is cleared — and
why — before loading the fixture.

- Green ✓ **cleared** / red ✗ **failed** badges beside each team name.
- `missing` **and** the client-side `unknown` fallback render a **neutral grey
  dash**, never a warning: the server's `"missing"` conflates "this league runs
  no inspections" with "team not yet cleared today", so the app must not imply
  the team is blocked.
- Inspection notes (`Robot N: <text>`) under the fixture details.
- **Informational only — loading is never blocked.**

## How

- New `InspectionStatus` enum (`ok`/`failed`/`missing`) with an `unknown`
  fallback for absent/unrecognised values, via the existing
  `firstWhere(...orElse:)` idiom; `InspectionNote` value class for `{robot, note}`.
- Parsed in `ScoreboardMatchConfig` and threaded through the constructor
  (defaulted, so existing callers are unaffected), `copyWith`, `fromJson`, and
  `toJson` so they survive the SharedPreferences persist/rehydrate round-trip.
- Deliberately kept **out of `signature`** so an inspection change can't re-fire
  the confirm-on-load / apply-dedupe logic.
- New reusable `InspectionStatusBadge` widget; dialog content wrapped in
  `SingleChildScrollView` so long notes never overflow.

## Tests

- Model: status/notes parsing, `unknown` fallback, blank/malformed-note
  skipping, `toJson`/`fromJson` round-trip, `signature` stability.
- Widget: `InspectionStatusBadge` for ok/failed and the neutral missing/unknown
  case.

> Note: authored where the Flutter SDK was unavailable to run locally — relying
> on this repo's CI (`flutter analyze` + `flutter test`) for the gate.
