### PR TITLE
feat(scoreboard): consume explicit match timing fields

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -680,7 +680,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         // needsScoreboardResultReview's own unresolved-result clause, so arming
         // here does not surface the review while a result is in flight.
         if (_canSubmitScoreboardResult(config)) {
-          _fullTimeResultSignature = config.signature;
+          _fullTimeResultSignature = config.resultSignature;
         }
         _requestScoreboardResultReview();
       } else {
@@ -1247,9 +1247,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _resumedFixtureMatchCode = null;
     _resumedFixtureVersion = null;
     _suppressScoreboardFinalResult = false;
-    // The deep link had overridden the live periodTime; restore the operator's
-    // configured default (or the app default of 600 s when none is stored).
-    _periodTime = _prefs?.getInt(_periodTimeKey) ?? 600;
+    // The deep link had overridden the live match timing; restore the operator's
+    // configured defaults (or app defaults when none are stored).
+    _periodTime = _prefs?.getInt(_periodTimeKey) ?? _defaultPeriodTimeSeconds;
+    _halfTimeDuration =
+        _prefs?.getInt(_halfTimeDurationKey) ?? _defaultHalfTimeDurationSeconds;
     setTeamToDefaultOrder();
     gameInit();
     unawaited(scoreboardResultService.resetLinkedMatchAfterSubmission());
@@ -1351,6 +1353,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // halfTimeDuration setters) so the link's timing is used for this match only
   // and never persisted as the operator's stored defaults.
   void _applyScoreboardTiming(ScoreboardMatchConfig config) {
+    if (config.hasExplicitTiming) {
+      _periodTime = config.periodDurationSeconds;
+      _halfTimeDuration = config.halfTimeDurationSeconds;
+      return;
+    }
+
     if (config.durationSeconds == _scoreboardSlot25MinSeconds) {
       _periodTime = _scoreboardSlot25HalfSeconds;
       _halfTimeDuration = _scoreboardSlot25HalfTimeSeconds;
@@ -1578,12 +1586,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   bool get needsScoreboardResultReview {
     final config = scoreboardResultService.matchConfig;
     if (currentStage != MatchStage.fullTime) return false;
-    // The committed config must STILL be the exact fixture that just ended.
-    // Loading a different link at full time changes matchConfig, but its
-    // signature won't match the one captured at full time, so we never offer to
-    // submit the just-ended scores against a newly-loaded fixture.
+    // The committed config must STILL be the result identity that just ended.
+    // Loading a different link or organizer side/name/version edit at full time
+    // changes this signature, so we never offer to submit captured scores
+    // against a changed submission target or score mapping. Timing/venue-only
+    // corrections are allowed because they do not affect the final-result POST.
     if (_fullTimeResultSignature == null) return false;
-    if (config == null || config.signature != _fullTimeResultSignature) {
+    if (config == null || config.resultSignature != _fullTimeResultSignature) {
       return false;
     }
     if (!_canSubmitScoreboardResult(config)) return false;
@@ -1634,7 +1643,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         // single-use, so a still-unresolved prior result already owns it and the
         // review stays correctly suppressed (RAVF001, REPEAT same-fixture).
         !scoreboardResultService.hasUnresolvedResultFor(config.matchCode)) {
-      _fullTimeResultSignature = config.signature;
+      _fullTimeResultSignature = config.resultSignature;
     }
     _requestScoreboardResultReview();
   }
@@ -1701,9 +1710,10 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
     return (
       matchCode: config?.matchCode ?? '',
-      // Full fixture+revision identity captured at review time, so a later
-      // same-code change (side swap / version bump) is detected on submit.
-      signature: config?.signature ?? '',
+      // Result identity captured at review time, so a later same-code version,
+      // side, or team-name change is detected on submit without invalidating the
+      // review for timing/venue-only corrections.
+      signature: config?.resultSignature ?? '',
       homeName: _teamNameById(homeTeamId) ?? config?.homeTeamName ?? 'Home',
       awayName: _teamNameById(awayTeamId) ?? config?.awayTeamName ?? 'Away',
       homeGoals: _scoreByTeamId(homeTeamId) ?? 0,
@@ -1722,25 +1732,25 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     if (!_canSubmitScoreboardResult()) return false;
 
     // Identity guard: the review screen captured its scores/team mapping for one
-    // fixture revision. Compare the FULL signature (code + version + side +
-    // names), not just the match code: a same-code config change (e.g. a side
-    // swap or version bump from an organizer edit, or a new link confirmed at
-    // full time) would otherwise post the captured scores against a changed
-    // mapping/version. Refuse so the referee re-opens a fresh review instead.
-    if (scoreboardResultService.matchConfig?.signature != expectedSignature) {
+    // result identity. Compare the result signature (code + version + side +
+    // names), not just the match code: a same-code side/name/version change
+    // would otherwise post captured scores against a changed mapping or match
+    // revision. Timing/venue-only corrections are benign here and remain
+    // load/apply-signature changes only.
+    if (scoreboardResultService.matchConfig?.resultSignature !=
+        expectedSignature) {
       return false;
     }
 
     // Capture the side mapping BEFORE awaiting the enqueue. The signature guard
-    // above proved matchConfig.signature == expectedSignature, so this mapping is
-    // exactly the one the review screen submitted against. An already-in-flight
-    // refreshMatchConfig() can complete during the await below, reassign the
-    // committed config, and (for a same-fixture side swap) flip homeIsLeft —
-    // re-deriving the mapping AFTER the await would then write these goals onto
-    // the WRONG physical teams. Capturing here keeps the write-back correct
-    // regardless of a concurrent refresh, while still letting a benign
-    // version/name refresh through (the team IDs are stable, so the submitted
-    // homeGoals always belong to homeTeamId). Same homeIsLeft fallback as
+    // above proved matchConfig.resultSignature == expectedSignature, so this
+    // mapping is exactly the one the review screen submitted against. An
+    // already-in-flight refreshMatchConfig() can complete during the await below,
+    // reassign the committed config, and (for a same-fixture side swap) flip
+    // homeIsLeft — re-deriving the mapping AFTER the await would then write
+    // these goals onto the WRONG physical teams. Capturing here keeps the
+    // write-back correct regardless of a concurrent refresh, while still letting
+    // benign timing/venue-only refreshes through. Same homeIsLeft fallback as
     // buildScoreboardResultReview.
     final homeIsLeft = scoreboardResultService.matchConfig?.homeIsLeft ?? true;
     final homeTeamId = _scoreboardHomeTeamId ?? (homeIsLeft ? 'A' : 'B');

--- a/lib/models/scoreboard_result.dart
+++ b/lib/models/scoreboard_result.dart
@@ -67,6 +67,10 @@ List<InspectionRobot> _inspectionRobotsFromJson(dynamic value) {
 }
 
 class ScoreboardMatchConfig {
+  static const int _defaultSlotDurationSeconds = 25 * 60;
+  static const int _defaultPeriodDurationSeconds = 10 * 60;
+  static const int _defaultHalfTimeDurationSeconds = 5 * 60;
+
   final String matchCode;
   final String homeTeamName;
   final String awayTeamName;
@@ -74,6 +78,11 @@ class ScoreboardMatchConfig {
   final String venueShortName;
   final DateTime? scheduledStart;
   final int durationSeconds;
+  final int slotDurationSeconds;
+  final int periodDurationSeconds;
+  final int halfTimeDurationSeconds;
+  final int playDurationSeconds;
+  final bool hasExplicitTiming;
   final String timezone;
   final int version;
   final String status;
@@ -95,6 +104,11 @@ class ScoreboardMatchConfig {
     required this.venueShortName,
     required this.scheduledStart,
     required this.durationSeconds,
+    required this.slotDurationSeconds,
+    required this.periodDurationSeconds,
+    required this.halfTimeDurationSeconds,
+    required this.playDurationSeconds,
+    required this.hasExplicitTiming,
     required this.timezone,
     required this.version,
     required this.status,
@@ -112,6 +126,11 @@ class ScoreboardMatchConfig {
     String? venueShortName,
     DateTime? scheduledStart,
     int? durationSeconds,
+    int? slotDurationSeconds,
+    int? periodDurationSeconds,
+    int? halfTimeDurationSeconds,
+    int? playDurationSeconds,
+    bool? hasExplicitTiming,
     String? timezone,
     int? version,
     String? status,
@@ -128,6 +147,12 @@ class ScoreboardMatchConfig {
       venueShortName: venueShortName ?? this.venueShortName,
       scheduledStart: scheduledStart ?? this.scheduledStart,
       durationSeconds: durationSeconds ?? this.durationSeconds,
+      slotDurationSeconds: slotDurationSeconds ?? this.slotDurationSeconds,
+      periodDurationSeconds: periodDurationSeconds ?? this.periodDurationSeconds,
+      halfTimeDurationSeconds:
+          halfTimeDurationSeconds ?? this.halfTimeDurationSeconds,
+      playDurationSeconds: playDurationSeconds ?? this.playDurationSeconds,
+      hasExplicitTiming: hasExplicitTiming ?? this.hasExplicitTiming,
       timezone: timezone ?? this.timezone,
       version: version ?? this.version,
       status: status ?? this.status,
@@ -168,7 +193,32 @@ class ScoreboardMatchConfig {
     final scheduledStartRaw = json['scheduled_start']?.toString();
     final scheduledStart =
         scheduledStartRaw == null ? null : DateTime.tryParse(scheduledStartRaw);
-    final durationSeconds = (json['duration_seconds'] as num?)?.toInt() ?? 600;
+    int positiveSeconds(dynamic value, int fallback) {
+      if (value is num) {
+        final seconds = value.toInt();
+        if (seconds > 0) return seconds;
+      }
+      return fallback;
+    }
+
+    int nonNegativeSeconds(dynamic value, int fallback) {
+      if (value is num) {
+        final seconds = value.toInt();
+        if (seconds >= 0) return seconds;
+      }
+      return fallback;
+    }
+
+    final durationSeconds =
+        positiveSeconds(json['duration_seconds'], _defaultSlotDurationSeconds);
+    final periodDurationSeconds = positiveSeconds(
+        json['period_duration_seconds'], _defaultPeriodDurationSeconds);
+    final halfTimeDurationSeconds = nonNegativeSeconds(
+        json['half_time_duration_seconds'], _defaultHalfTimeDurationSeconds);
+    final hasExplicitTiming = json.containsKey('slot_duration_seconds') ||
+        json.containsKey('period_duration_seconds') ||
+        json.containsKey('half_time_duration_seconds') ||
+        json.containsKey('play_duration_seconds');
 
     List<String> moduleMacs(dynamic value) {
       if (value is! List) return const [];
@@ -185,7 +235,14 @@ class ScoreboardMatchConfig {
       homeIsLeft: homeIsLeft ?? true,
       venueShortName: (json['venue']?.toString() ?? '').trim(),
       scheduledStart: scheduledStart,
-      durationSeconds: durationSeconds <= 0 ? 600 : durationSeconds,
+      durationSeconds: durationSeconds,
+      slotDurationSeconds:
+          positiveSeconds(json['slot_duration_seconds'], durationSeconds),
+      periodDurationSeconds: periodDurationSeconds,
+      halfTimeDurationSeconds: halfTimeDurationSeconds,
+      playDurationSeconds:
+          positiveSeconds(json['play_duration_seconds'], periodDurationSeconds * 2),
+      hasExplicitTiming: hasExplicitTiming,
       timezone: (json['timezone']?.toString() ?? 'UTC').trim(),
       version: (json['version'] as num?)?.toInt() ?? 0,
       status: (json['status']?.toString() ?? '').toUpperCase(),
@@ -197,31 +254,48 @@ class ScoreboardMatchConfig {
   }
 
   /// Stable identity of a fixture+revision as displayed/applied. Used to dedupe
-  /// the confirm-on-load prompt and to guard confirm/cancel/submit against
-  /// acting on a different fixture than the one a stale dialog/review is showing.
+  /// the confirm-on-load prompt and to guard confirm/cancel against acting on a
+  /// different fixture than the one a stale dialog is showing.
   ///
   /// Built via jsonEncode of an ordered field list (not a delimiter-joined
   /// string) so values containing the separator — e.g. a team name with a ':'
   /// — cannot collide with a different fixture.
   ///
-  /// Venue is part of the identity so a corrected schedule payload that changes
-  /// only the venue (same match/version) still re-applies and updates the MQTT
-  /// field number (#50); this keeps the apply-dedupe and the cold-resume re-arm
-  /// in lock-step on a single signature.
+  /// Venue is part of the load/apply identity so a corrected schedule payload
+  /// that changes only the venue (same match/version) still re-applies and
+  /// updates the MQTT field number (#50); timing is part of this identity so an
+  /// organizer correction to period/half-time values re-applies before kickoff.
   ///
   /// The module MACs are deliberately NOT part of the signature: auto-pairing
   /// runs at match (re)load (see Game._applyScoreboardMatchConfig), and folding
   /// MACs into the fixture identity would make an out-of-band module-assignment
-  /// change re-trigger the "Load match?" overwrite and the result-review guards
-  /// mid-match. A MAC-only correction therefore does not force a re-pair.
+  /// change re-trigger the "Load match?" overwrite mid-match. A MAC-only
+  /// correction therefore does not force a re-pair.
   String get signature => jsonEncode(<dynamic>[
         matchCode,
         version,
         durationSeconds,
+        slotDurationSeconds,
+        periodDurationSeconds,
+        halfTimeDurationSeconds,
+        playDurationSeconds,
         homeIsLeft,
         homeTeamName,
         awayTeamName,
         venueShortName,
+      ]);
+
+  /// Stable identity for reviewing/submitting final scores. Excludes
+  /// live-clock/venue-only corrections that do not change the submission target
+  /// or home/away score mapping, but still includes version, side, and team
+  /// names so a result captured for one fixture revision cannot be submitted
+  /// against a later side/name edit for the same match code.
+  String get resultSignature => jsonEncode(<dynamic>[
+        matchCode,
+        version,
+        homeIsLeft,
+        homeTeamName,
+        awayTeamName,
       ]);
 
   Map<String, dynamic> toJson() => {
@@ -232,6 +306,11 @@ class ScoreboardMatchConfig {
         'venue': venueShortName,
         'scheduled_start': scheduledStart?.toIso8601String(),
         'duration_seconds': durationSeconds,
+        if (hasExplicitTiming) 'slot_duration_seconds': slotDurationSeconds,
+        if (hasExplicitTiming) 'period_duration_seconds': periodDurationSeconds,
+        if (hasExplicitTiming)
+          'half_time_duration_seconds': halfTimeDurationSeconds,
+        if (hasExplicitTiming) 'play_duration_seconds': playDurationSeconds,
         'timezone': timezone,
         'version': version,
         'status': status,

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -46,6 +46,10 @@ Map<String, dynamic> _scoreboardConfig({
   required int version,
   bool homeIsLeft = true,
   int durationSeconds = 600,
+  int? slotDurationSeconds,
+  int? periodDurationSeconds,
+  int? halfTimeDurationSeconds,
+  int? playDurationSeconds,
   String homeTeamName = 'Home',
   String awayTeamName = 'Away',
 }) =>
@@ -57,6 +61,14 @@ Map<String, dynamic> _scoreboardConfig({
       'venue': 'Field 1',
       'scheduled_start': null,
       'duration_seconds': durationSeconds,
+      if (slotDurationSeconds != null)
+        'slot_duration_seconds': slotDurationSeconds,
+      if (periodDurationSeconds != null)
+        'period_duration_seconds': periodDurationSeconds,
+      if (halfTimeDurationSeconds != null)
+        'half_time_duration_seconds': halfTimeDurationSeconds,
+      if (playDurationSeconds != null)
+        'play_duration_seconds': playDurationSeconds,
       'timezone': 'Europe/Prague',
       'version': version,
       'status': 'SCHEDULED',
@@ -283,6 +295,174 @@ void main() {
       expect(game.halfTimeDuration, 123,
           reason: 'workaround only remaps half-time for the 25-min slot');
       game.dispose();
+    });
+  });
+
+  group('scoreboard explicit timing fields (#108)', () {
+    testWidgets('explicit period and half-time beat the legacy slot',
+        (tester) async {
+      await prefs.setInt('game_period_time', 777);
+      await prefs.setInt('game_halftime_duration', 123);
+      final game = Game();
+      await settleLoad(tester);
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(
+            matchCode: 'M-EXPLICIT',
+            version: 1,
+            durationSeconds: 1800,
+            slotDurationSeconds: 1800,
+            periodDurationSeconds: 720,
+            halfTimeDurationSeconds: 360,
+            playDurationSeconds: 1440,
+          ),
+        ),
+        token: 'test-token',
+      );
+      await tester.pump();
+
+      expect(game.periodTime, 720,
+          reason: 'period_duration_seconds is the per-half clock');
+      expect(game.halfTimeDuration, 360,
+          reason: 'half_time_duration_seconds is the break clock');
+      expect(game.remainingTime, 720,
+          reason: 'gameInit starts the clock from the explicit period');
+      game.dispose();
+    });
+
+    testWidgets('timing-only corrections reapply with the same legacy slot',
+        (tester) async {
+      final initial = ScoreboardMatchConfig.fromJson(
+        _scoreboardConfig(
+          matchCode: 'M-TIMING',
+          version: 1,
+          durationSeconds: 1800,
+          slotDurationSeconds: 1800,
+          periodDurationSeconds: 600,
+          halfTimeDurationSeconds: 300,
+          playDurationSeconds: 1200,
+        ),
+      );
+      final corrected = ScoreboardMatchConfig.fromJson(
+        _scoreboardConfig(
+          matchCode: 'M-TIMING',
+          version: 1,
+          durationSeconds: 1800,
+          slotDurationSeconds: 1800,
+          periodDurationSeconds: 720,
+          halfTimeDurationSeconds: 360,
+          playDurationSeconds: 1440,
+        ),
+      );
+      expect(corrected.signature, isNot(initial.signature),
+          reason: 'explicit timing belongs to the fixture identity');
+
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(initial,
+          token: 'test-token');
+      await tester.pump();
+      expect(game.periodTime, 600);
+
+      game.scoreboardResultService.debugApplyMatchConfig(corrected,
+          token: 'test-token');
+      await tester.pump();
+
+      expect(game.periodTime, 720,
+          reason: 'a timing correction must not be deduped by duration_seconds');
+      expect(game.halfTimeDuration, 360);
+      expect(game.remainingTime, 720);
+      game.dispose();
+    });
+
+    testWidgets(
+        'timing-only correction after full-time keeps the captured review '
+        'submittable', (tester) async {
+      final initialConfig = _scoreboardConfig(
+        matchCode: 'M-TIMING-REVIEW',
+        version: 1,
+        durationSeconds: 1800,
+        slotDurationSeconds: 1800,
+        periodDurationSeconds: 600,
+        halfTimeDurationSeconds: 300,
+        playDurationSeconds: 1200,
+      );
+      final corrected = ScoreboardMatchConfig.fromJson(
+        _scoreboardConfig(
+          matchCode: 'M-TIMING-REVIEW',
+          version: 1,
+          durationSeconds: 1800,
+          slotDurationSeconds: 1800,
+          periodDurationSeconds: 720,
+          halfTimeDurationSeconds: 360,
+          playDurationSeconds: 1440,
+        ),
+      );
+      final initial = ScoreboardMatchConfig.fromJson(initialConfig);
+      expect(corrected.signature, isNot(initial.signature),
+          reason: 'load/apply dedupe must still see explicit timing changes');
+
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 2,
+        scoreB: 1,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-TIMING-REVIEW',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      addTearDown(game.dispose);
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        initial,
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(game.scoreboardResultService.matchConfig?.signature,
+          initial.signature);
+      game.resumePendingMatch();
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+      final review = game.buildScoreboardResultReview();
+
+      game.scoreboardResultService.debugApplyMatchConfig(
+        corrected,
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(game.scoreboardResultService.matchConfig?.signature,
+          corrected.signature);
+      expect(game.needsScoreboardResultReview, isTrue,
+          reason: 'a timing correction changes load/apply identity, but not the '
+              'fixture identity for reviewing the already-finished result');
+
+      final submitted = await game.submitScoreboardResult(
+        expectedSignature: review.signature,
+        homeGoals: review.homeGoals,
+        awayGoals: review.awayGoals,
+        comment: null,
+        homeConfirmed: false,
+        awayConfirmed: false,
+      );
+      expect(submitted, isTrue,
+          reason: 'the review captured before a timing-only correction must '
+              'still submit for the same fixture');
+      final result =
+          await waitForOutboxItem(tester, game, 'M-TIMING-REVIEW');
+      expect(result.homeGoals, 2);
+      expect(result.awayGoals, 1);
+      expect(result.version, 1);
+
+      await tester.pump(const Duration(milliseconds: 1500));
     });
   });
 
@@ -1526,6 +1706,67 @@ void main() {
 
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();
+    });
+
+    testWidgets(
+        'delivered explicit-timing match restores the saved half-time default',
+        (tester) async {
+      await prefs.setInt('game_period_time', 777);
+      await prefs.setInt('game_halftime_duration', 123);
+      final config = ScoreboardMatchConfig.fromJson(
+        _scoreboardConfig(
+          matchCode: 'M-DLV-TIME',
+          version: 1,
+          durationSeconds: 1800,
+          slotDurationSeconds: 1800,
+          periodDurationSeconds: 720,
+          halfTimeDurationSeconds: 360,
+          playDurationSeconds: 1440,
+        ),
+      );
+      await persist(_snap(
+        stage: 'secondHalf',
+        remainingTime: 1,
+        scoreA: 5,
+        scoreB: 2,
+        isRefereeMatch: true,
+        scoreboardMatchCode: 'M-DLV-TIME',
+        scoreboardVersion: 1,
+        scoreboardHomeTeamId: 'A',
+        scoreboardAwayTeamId: 'B',
+      ));
+      final game = Game();
+      addTearDown(game.dispose);
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        config,
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      expect(game.periodTime, 720);
+      expect(game.halfTimeDuration, 360);
+
+      game.resumePendingMatch();
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+      await submitCurrentReview(tester, game, 'M-DLV-TIME');
+
+      game.scoreboardResultService.onCurrentResultDelivered!();
+      await tester.pump(); // drain the reset microtask
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
+      expect(game.periodTime, 777,
+          reason: 'the reset returns to the operator\'s saved match length');
+      expect(game.halfTimeDuration, 123,
+          reason: 'explicit match half-time is per-fixture and must not leak '
+              'into the next unlinked match');
+      expect(game.remainingTime, 777);
+
+      await tester.pump(const Duration(milliseconds: 1500));
     });
 
     testWidgets(

--- a/test/scoreboard_result_test.dart
+++ b/test/scoreboard_result_test.dart
@@ -80,6 +80,24 @@ void main() {
       expect(config.status, 'SCHEDULED');
     });
 
+    test('parses explicit timing fields while preserving legacy slot alias', () {
+      final config = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(),
+        'duration_seconds': 1800,
+        'slot_duration_seconds': 1800,
+        'period_duration_seconds': 720,
+        'half_time_duration_seconds': 360,
+        'play_duration_seconds': 1440,
+      });
+
+      expect(config.durationSeconds, 1800,
+          reason: 'legacy duration_seconds remains the scheduling-slot alias');
+      expect(config.slotDurationSeconds, 1800);
+      expect(config.periodDurationSeconds, 720);
+      expect(config.halfTimeDurationSeconds, 360);
+      expect(config.playDurationSeconds, 1440);
+    });
+
     test('parses per-robot inspection status and notes, in order', () {
       final config = ScoreboardMatchConfig.fromJson({
         ..._matchJson(),
@@ -183,6 +201,29 @@ void main() {
       expect(flipped.signature, base.signature);
     });
 
+    test('explicit timing changes are part of the load signature', () {
+      final base = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(matchCode: 'M-TIMING'),
+        'duration_seconds': 1800,
+        'slot_duration_seconds': 1800,
+        'period_duration_seconds': 600,
+        'half_time_duration_seconds': 300,
+        'play_duration_seconds': 1200,
+      });
+      final corrected = ScoreboardMatchConfig.fromJson({
+        ..._matchJson(matchCode: 'M-TIMING'),
+        'duration_seconds': 1800,
+        'slot_duration_seconds': 1800,
+        'period_duration_seconds': 720,
+        'half_time_duration_seconds': 360,
+        'play_duration_seconds': 1440,
+      });
+
+      expect(corrected.signature, isNot(base.signature),
+          reason: 'a timing-only correction must reapply even when the legacy '
+              'scheduling slot is unchanged');
+    });
+
     test('falls back to side_order map and defaults', () {
       final config = ScoreboardMatchConfig.fromJson({
         'home_team': {'name': 'Home'},
@@ -191,7 +232,11 @@ void main() {
       });
 
       expect(config.homeIsLeft, isTrue);
-      expect(config.durationSeconds, 600);
+      expect(config.durationSeconds, 1500);
+      expect(config.slotDurationSeconds, 1500);
+      expect(config.periodDurationSeconds, 600);
+      expect(config.halfTimeDurationSeconds, 300);
+      expect(config.playDurationSeconds, 1200);
       expect(config.version, 0);
       expect(config.timezone, 'UTC');
     });


### PR DESCRIPTION
## Summary

Consumes the explicit timing fields added by robocup-junior/rcj-scoreboard#125 for robocup-junior/rcj-scoreboard#108.

The app now:

- parses `slot_duration_seconds`, `period_duration_seconds`, `half_time_duration_seconds`, and `play_duration_seconds`
- prefers explicit period/half-time values over legacy `duration_seconds`
- keeps the existing 25-minute fallback for older scoreboard servers
- keeps load/apply signatures timing-aware so organizer timing corrections reapply
- uses a separate result-review/submission signature so timing-only corrections do not invalidate a captured final-result review
- restores the operator's saved period and half-time defaults after a delivered explicit-timing match

## Companion PR

Requires / pairs with robocup-junior/rcj-scoreboard#125.

## Verification

Local Flutter/Dart tooling is unavailable on this workstation, so the targeted app tests could not be executed locally:

```text
flutter test test/game_recovery_test.dart --name "timing-only correction after full-time|delivered explicit-timing"
error: command not found: flutter
```

```text
dart --version
error: command not found: dart
```

GitHub CI should run the Flutter test suite for this branch.
