### PR TITLE
feat(match): "End match now" button — jump straight to result confirmation (deep-link matches) (#84)

### DIFF
--- a/docs/ai/KICKOFF_issue84.md
+++ b/docs/ai/KICKOFF_issue84.md
@@ -3,7 +3,9 @@
 > You are starting fresh. Read this, then **study the sources listed below before writing any code or plan.** Do not assume prior context — everything you need is referenced here.
 
 ## The task (issue #84)
-A referee sometimes needs to end a match without playing it (team no-show → forfeit/contumation win). Add a button in **Settings → "Current Game"** that — **only when a deep-link (scoreboard) match is loaded** — ends the match immediately and jumps straight to the existing result confirmation screen, guarded by a **confirmation pop-up**. The referee then edits the score there (contumation score) and submits as usual.
+A referee sometimes needs to end a match without playing it (team no-show → forfeit/contumation win). Add a button in **Settings → "Scoreboard Result API"** that — **only when a deep-link (scoreboard) match is loaded** — ends the match immediately and jumps straight to the existing result confirmation screen, guarded by a **confirmation pop-up**. The referee then edits the score there (contumation score) and submits as usual.
+
+> **Placement note (device-test tweak, 2026-07-02):** the button was originally specced under "Current Game" (next to the no-show controls). During on-device testing the owner moved it into the **"Scoreboard Result API"** section — it is a deep-link-only action (gated on a linked fixture), so it belongs with the other scoreboard-fixture controls (Link status / Match code / Outbox / Refresh / Retry / Clear) rather than the manual-match controls in Current Game. Other "Current Game" references below reflect the original spec.
 
 Read the issue in full first: `gh issue view 84` — it contains the agreed design. Key points:
 - Gate: linked fixture present + submittable (`scoreboardResultService.matchConfig != null`, non-empty `matchCode`, token held — see `_canSubmitScoreboardResult`). Hidden (or disabled w/ subtitle) for manual matches.

--- a/docs/ai/KICKOFF_issue84.md
+++ b/docs/ai/KICKOFF_issue84.md
@@ -1,0 +1,51 @@
+# Kickoff — Issue #84: "End match now" → straight to result confirmation (deep-link matches only)
+
+> You are starting fresh. Read this, then **study the sources listed below before writing any code or plan.** Do not assume prior context — everything you need is referenced here.
+
+## The task (issue #84)
+A referee sometimes needs to end a match without playing it (team no-show → forfeit/contumation win). Add a button in **Settings → "Current Game"** that — **only when a deep-link (scoreboard) match is loaded** — ends the match immediately and jumps straight to the existing result confirmation screen, guarded by a **confirmation pop-up**. The referee then edits the score there (contumation score) and submits as usual.
+
+Read the issue in full first: `gh issue view 84` — it contains the agreed design. Key points:
+- Gate: linked fixture present + submittable (`scoreboardResultService.matchConfig != null`, non-empty `matchCode`, token held — see `_canSubmitScoreboardResult`). Hidden (or disabled w/ subtitle) for manual matches.
+- Works from **any** stage (before kickoff, firstHalf, halfTime, secondHalf), clock running or not.
+- Confirm pop-up (AlertDialog, same pattern as "Start no-show penalty goals?" in `settings.dart` ~line 137). Cancel = nothing changes.
+- On confirm: **reuse the normal `secondHalf → fullTime` transition side-effects** (`game.dart` ~line 810–825): stop clock, `stopAll(true)` + `gameOverAll()`, `currentStage = fullTime`, `timerButtonText = 'REPEAT'`, `_enterFullTimeResultReview()`, `disconnectInactiveModules()`, `_persistOrClearAtFullTime()`, MQTT/bridge broadcast. Implement as a `Game.endMatchEarly()` that extracts/reuses that block — do NOT build a bespoke shortcut, or you lose the RAVF003 kill-before-submit snapshot, the unresolved-result gate, REPEAT behaviour, and module teardown.
+- Settings must pop back to Home before/as the review is raised (the review route is opened by Home's `onRequestReviewScoreboardResult` callback registered in `home.dart`).
+
+## Required reading (study before acting)
+- `gh issue view 84` — the spec.
+- `CLAUDE.md` (repo root) — **critical invariants you must not violate** (START/STOP latency / no awaits on robot paths; double-tap safety; provider tree; portrait-only; BLE auto-reconnect policy; no new packages) + the **mock-launch pkill gotcha** at the bottom.
+- Memory index: `/home/mato/.claude-rc/projects/-home-mato-StudioProjects-rcj-scoreboard/memory/MEMORY.md` — read `issue51_referee_lifecycle.md`, `scoreboard_integration.md`, `scoreboard_resume_binding_53.md`, `git_housekeeping_caution.md`, `device_test_before_push.md`, `codex_sandbox_flag_usage.md`, `review_anvil_format_gotcha.md`.
+- `docs/ai/00_CONTEXT_INDEX.md` — doc reading order.
+- `docs/ai/07_SCOREBOARD_DEVICE_TESTING.md` + `docs/ai/tools/mock_scoreboard.py` — device-test runbook (adb reverse, deep link, Pixel-10 tap coords, double-tap gotcha, error injection).
+
+## Code you'll touch (study these)
+- `lib/models/game.dart` — the `secondHalf → fullTime` block in `_tickTimer` (~810–825) is the behaviour to extract/reuse; `_enterFullTimeResultReview` (+ its `hasUnresolvedResultFor` gate), `_canSubmitScoreboardResult`, `_persistOrClearAtFullTime`, `stopTimer`, `_resetNoShowPenaltyGoals` (end-early while no-show mode is running must reset it, as the normal transition does).
+- `lib/screens/settings.dart` — "Current Game" `SettingsSection` (~line 335, next to the no-show controls); the no-show confirm dialog (~line 137) is the pop-up pattern to copy.
+- `lib/screens/home.dart` — `onRequestReviewScoreboardResult` registration + `_openScoreboardResultReview`; understand how the review route opens so triggering from Settings works (pop Settings → call `game.endMatchEarly()` → Home's callback fires).
+- `lib/screens/scoreboard_result_review.dart` — the existing review/submit screen (score edit lives here; you change nothing in it).
+- `test/game_recovery_test.dart` — test harness (`debugApplyMatchConfig`, `_scoreboardConfig`, `settleLoad`) to add `endMatchEarly` tests: from each stage; gate (no fixture → no-op/hidden); snapshot persisted at fullTime; REPEAT after early end; unresolved-result gate respected.
+
+## What's already in `dev` (don't rebuild it)
+- #51 review/submit lifecycle, #53 cold-resume fixture binding, #78 per-robot inspection UI, local-kickoff line, 10+5+10 forced timing (v0.10.5 shipped). The review screen and all submission plumbing exist — this issue only adds a new *entry point* into them.
+
+## Workflow (the standard way of working here)
+1. Branch off **`dev`** (e.g. `feat/issue-84-end-match-early`).
+2. Write a **Codex task spec**, then have Codex implement (`codex exec --dangerously-bypass-approvals-and-sandbox` — bwrap sandbox is broken in this env; owner pre-authorized).
+3. **review-anvil** (claude + codex reviewers, multiple rounds) → apply fixes. Never `dart format` the whole tree — only edited files.
+4. Full test suite + `flutter analyze`.
+5. **Device-test on the real phone** (mock + adb reverse; launch mock as a background task with NO self-matching `pkill` in the same command; kill it with `pkill -f '[m]ock_scoreboard\.py'`). `device_test_before_push.md`: desk-green ≠ done; get the owner's go-ahead before commit/push.
+6. Open a well-documented PR (base `dev`); commits end with the Co-Authored-By line; PR body ends with the generated-with line.
+7. **Commit this kickoff doc (`docs/ai/KICKOFF_issue84.md`) as part of your PR** — it is intentionally untracked until then; the owner wants each issue's doc to land with its implementing PR.
+
+## Constraints / gotchas
+- No new packages. App is Android + iOS — the button/dialog must work on both.
+- Owner dislikes git churn — confirm before creating/closing anything beyond the PR branch.
+- The pop-up is the safety mechanism (Settings surface) — no `CriticalGestureDetector` needed for this button, but never weaken invariant #2 elsewhere.
+- Ending early from `halfTime` must also cancel the break countdown cleanly; from `inGame == false` (loaded, never started) it must still work (score 0–0, referee edits in review).
+- Do not fire `gameOverAll()`/BLE work twice if the user somehow confirms twice — make `endMatchEarly()` idempotent (no-op at `fullTime`).
+
+## First moves
+1. `gh issue view 84`; read `CLAUDE.md`, the memory files, `game.dart` (~800–830, 1570–1650), `settings.dart` (~130–150, ~330–400), `home.dart` (review callback).
+2. Decide with the owner if the button label is "End match now" or similar, and hidden-vs-disabled for manual matches.
+3. Draft the Codex task spec for review, then implement per the workflow above.

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -838,7 +838,9 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// Module.stopAll re-dispatches to halfTime() (a fresh break countdown)
   /// instead of STOP — the same reason the halfTime->secondHalf paths use
   /// stopAll(true, force: true). The natural second-half expiry keeps the
-  /// unforced call it always had.
+  /// unforced call it always had. Callers own _broadcastStageAndTime() +
+  /// notifyListeners() afterwards (the natural tick does both once at the end
+  /// of _tickTimer, shared with the other stage transitions).
   void _completeMatchToFullTime({bool forceStop = false}) {
     // Captured before _resetNoShowPenaltyGoals() below clears the flag; when
     // no-show mode owned the robots they were never started, so the stop +
@@ -1635,7 +1637,8 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // with 10:00 left".
     _remainingTime = 0;
     // A match ended administratively "happened" even if the clock never
-    // started (inGame is otherwise only set by startTimer). Required twice
+    // started (during live play inGame is otherwise only set by startTimer;
+    // the cold-resume restore paths set it too). Required twice
     // over: Home's return-from-Settings path calls gameInit() when !inGame,
     // which would wipe the full-time state just set below; and the cold-resume
     // path only restores a snapshot when snapshot.inGame is true, so the

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -236,12 +236,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _periodTime = _prefs!.getInt(_periodTimeKey) ?? _defaultPeriodTimeSeconds;
     _halfTimeDuration =
         _prefs!.getInt(_halfTimeDurationKey) ?? _defaultHalfTimeDurationSeconds;
-    _numberOfPlayers =
-        (_prefs!.getInt(_numberOfPlayersKey) ?? _defaultPlayersPerTeam)
-            .clamp(1, _maxPlayer)
-            .toInt();
-    _penaltyTime =
-        _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
+    _numberOfPlayers = (_prefs!.getInt(_numberOfPlayersKey) ??
+            _defaultPlayersPerTeam)
+        .clamp(1, _maxPlayer)
+        .toInt();
+    _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
 
     // Single-tap pref: flush a pre-load toggle if one happened, otherwise adopt
     // the stored value. Reading unconditionally would clobber an early toggle.
@@ -2150,7 +2149,6 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     return '1 goal/$_noShowPenaltyGoalIntervalSeconds sec';
   }
-
   String get noShowPenaltyScoringTeamName =>
       _noShowPenaltyScoringTeam?.name ?? '';
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -808,20 +808,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           _markDirtyFlush();
           break;
         case MatchStage.secondHalf:
-          currentStage = MatchStage.fullTime;
-          _resetNoShowPenaltyGoals();
-          if (!noShowModeActive) {
-            stopAll(true);
-            gameOverAll();
-          }
-          timerButtonText = 'REPEAT';
-          _enterFullTimeResultReview();
-          // The match is over: stop the OS autoConnect from chasing modules
-          // that are powered down for good (e.g. a unit still off from a
-          // late penalty). In-match these reconnect unbounded on purpose; at
-          // full time we settle the ones still off to "Disconnected".
-          disconnectInactiveModules();
-          _persistOrClearAtFullTime();
+          _completeMatchToFullTime(noShowModeActive: noShowModeActive);
           break;
         default:
           debugPrint('unknown match stage');
@@ -837,6 +824,30 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
 
     notifyListeners();
+  }
+
+  /// The one true secondHalf->fullTime transition. Runs the full set of
+  /// full-time side-effects: stage flip, no-show reset, robot stop + game-over
+  /// (skipped when no-show mode owned the robots), REPEAT affordance, result
+  /// review arming (RAVF003 snapshot + unresolved-result gate), module
+  /// teardown, and snapshot persist-or-clear. Called from the natural
+  /// second-half tick expiry and from endMatchEarly() (#84) — never build a
+  /// bespoke shortcut around it.
+  void _completeMatchToFullTime({required bool noShowModeActive}) {
+    currentStage = MatchStage.fullTime;
+    _resetNoShowPenaltyGoals();
+    if (!noShowModeActive) {
+      stopAll(true);
+      gameOverAll();
+    }
+    timerButtonText = 'REPEAT';
+    _enterFullTimeResultReview();
+    // The match is over: stop the OS autoConnect from chasing modules
+    // that are powered down for good (e.g. a unit still off from a
+    // late penalty). In-match these reconnect unbounded on purpose; at
+    // full time we settle the ones still off to "Disconnected".
+    disconnectInactiveModules();
+    _persistOrClearAtFullTime();
   }
 
   // Upper bound on background catch-up ticks: only the window the timer runs
@@ -1571,6 +1582,43 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       return false;
     }
     return true;
+  }
+
+  /// Whether the "End match now" early-end affordance (#84) applies: a
+  /// deep-link (scoreboard) fixture is loaded and submittable, and the match
+  /// has not already reached full time (also makes endMatchEarly idempotent).
+  /// Manual matches have nothing to confirm/submit, so they never qualify.
+  bool get canEndMatchEarly {
+    if (currentStage == MatchStage.fullTime) return false;
+    final config = scoreboardResultService.matchConfig;
+    if (config == null || config.matchCode.isEmpty) return false;
+    if (!scoreboardResultService.hasToken) return false;
+    return _canSubmitScoreboardResult(config);
+  }
+
+  /// End the match NOW (#84: team no-show -> forfeit/contumation win) and jump
+  /// to the result review. Works from any stage, clock running or not, and
+  /// reuses the exact secondHalf->fullTime side-effects so every full-time
+  /// invariant (RAVF003 kill-before-submit snapshot, unresolved-result gate,
+  /// REPEAT behaviour, module teardown) holds. Gated on [canEndMatchEarly], so
+  /// it is a no-op for manual matches and once already at full time.
+  void endMatchEarly() {
+    if (!canEndMatchEarly) return;
+    final noShowModeActive = _noShowPenaltyGoalsActive;
+    // Cancels a running half clock OR the half-time break countdown, and
+    // clears the background run-clock anchors so a backgrounded app cannot
+    // catch the ended match up later.
+    stopTimer();
+    // A match ended administratively "happened" even if the clock never
+    // started (inGame is otherwise only set by startTimer). Required twice
+    // over: Home's return-from-Settings path calls gameInit() when !inGame,
+    // which would wipe the full-time state just set below; and the cold-resume
+    // path only restores a snapshot when snapshot.inGame is true, so the
+    // RAVF003 kill-before-submit review snapshot must record an in-game match.
+    inGame = true;
+    _completeMatchToFullTime(noShowModeActive: noShowModeActive);
+    _broadcastStageAndTime();
+    notifyListeners();
   }
 
   bool get needsScoreboardResultReview {

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -236,11 +236,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _periodTime = _prefs!.getInt(_periodTimeKey) ?? _defaultPeriodTimeSeconds;
     _halfTimeDuration =
         _prefs!.getInt(_halfTimeDurationKey) ?? _defaultHalfTimeDurationSeconds;
-    _numberOfPlayers = (_prefs!.getInt(_numberOfPlayersKey) ??
-            _defaultPlayersPerTeam)
-        .clamp(1, _maxPlayer)
-        .toInt();
-    _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
+    _numberOfPlayers =
+        (_prefs!.getInt(_numberOfPlayersKey) ?? _defaultPlayersPerTeam)
+            .clamp(1, _maxPlayer)
+            .toInt();
+    _penaltyTime =
+        _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
 
     // Single-tap pref: flush a pre-load toggle if one happened, otherwise adopt
     // the stored value. Reading unconditionally would clobber an early toggle.
@@ -808,7 +809,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
           _markDirtyFlush();
           break;
         case MatchStage.secondHalf:
-          _completeMatchToFullTime(noShowModeActive: noShowModeActive);
+          _completeMatchToFullTime();
           break;
         default:
           debugPrint('unknown match stage');
@@ -826,18 +827,27 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     notifyListeners();
   }
 
-  /// The one true secondHalf->fullTime transition. Runs the full set of
-  /// full-time side-effects: stage flip, no-show reset, robot stop + game-over
-  /// (skipped when no-show mode owned the robots), REPEAT affordance, result
-  /// review arming (RAVF003 snapshot + unresolved-result gate), module
-  /// teardown, and snapshot persist-or-clear. Called from the natural
-  /// second-half tick expiry and from endMatchEarly() (#84) — never build a
-  /// bespoke shortcut around it.
-  void _completeMatchToFullTime({required bool noShowModeActive}) {
+  /// The one true *->fullTime transition. Runs the full set of full-time
+  /// side-effects: stage flip, no-show reset, robot stop + game-over (skipped
+  /// when no-show mode owned the robots), REPEAT affordance, result review
+  /// arming (RAVF003 snapshot + unresolved-result gate), module teardown, and
+  /// snapshot persist-or-clear. Called from the natural second-half tick
+  /// expiry and from endMatchEarly() (#84) — never build a bespoke shortcut
+  /// around it. [forceStop] is for ending early out of the half-time break:
+  /// modules parked there have _lastState == halfTime, which an unforced
+  /// Module.stopAll re-dispatches to halfTime() (a fresh break countdown)
+  /// instead of STOP — the same reason the halfTime->secondHalf paths use
+  /// stopAll(true, force: true). The natural second-half expiry keeps the
+  /// unforced call it always had.
+  void _completeMatchToFullTime({bool forceStop = false}) {
+    // Captured before _resetNoShowPenaltyGoals() below clears the flag; when
+    // no-show mode owned the robots they were never started, so the stop +
+    // game-over fan-out is skipped exactly as the pre-#84 tick block did.
+    final noShowModeActive = _noShowPenaltyGoalsActive;
     currentStage = MatchStage.fullTime;
     _resetNoShowPenaltyGoals();
     if (!noShowModeActive) {
-      stopAll(true);
+      stopAll(true, force: forceStop);
       gameOverAll();
     }
     timerButtonText = 'REPEAT';
@@ -1593,6 +1603,14 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     final config = scoreboardResultService.matchConfig;
     if (config == null || config.matchCode.isEmpty) return false;
     if (!scoreboardResultService.hasToken) return false;
+    // A still-unresolved prior result for this fixture (REPEAT while the first
+    // run's POST is in flight) means _enterFullTimeResultReview would refuse
+    // to arm the review — ending early would strand the referee at full time
+    // with no result editor, breaking the dialog's promise. Hide the button
+    // instead, matching the review suppression at a natural full time.
+    if (scoreboardResultService.hasUnresolvedResultFor(config.matchCode)) {
+      return false;
+    }
     return _canSubmitScoreboardResult(config);
   }
 
@@ -1604,11 +1622,18 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   /// it is a no-op for manual matches and once already at full time.
   void endMatchEarly() {
     if (!canEndMatchEarly) return;
-    final noShowModeActive = _noShowPenaltyGoalsActive;
+    // Modules parked in the half-time break need the forced STOP dispatch —
+    // decided here, before the transition below moves the stage off halfTime.
+    final endedFromHalfTime = currentStage == MatchStage.halfTime;
     // Cancels a running half clock OR the half-time break countdown, and
     // clears the background run-clock anchors so a backgrounded app cannot
     // catch the ended match up later.
     stopTimer();
+    // Every natural path reaches fullTime only when the clock hits 0:00, and
+    // Home, the MQTT/bridge sinks, and the persisted RAVF003 snapshot all
+    // surface _remainingTime as-is — an early end must not present "full time
+    // with 10:00 left".
+    _remainingTime = 0;
     // A match ended administratively "happened" even if the clock never
     // started (inGame is otherwise only set by startTimer). Required twice
     // over: Home's return-from-Settings path calls gameInit() when !inGame,
@@ -1616,7 +1641,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // path only restores a snapshot when snapshot.inGame is true, so the
     // RAVF003 kill-before-submit review snapshot must record an in-game match.
     inGame = true;
-    _completeMatchToFullTime(noShowModeActive: noShowModeActive);
+    _completeMatchToFullTime(forceStop: endedFromHalfTime);
     _broadcastStageAndTime();
     notifyListeners();
   }
@@ -2122,6 +2147,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     return '1 goal/$_noShowPenaltyGoalIntervalSeconds sec';
   }
+
   String get noShowPenaltyScoringTeamName =>
       _noShowPenaltyScoringTeam?.name ?? '';
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -324,6 +324,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                   status:
                                       'Pending ${service.pendingCount}, conflict ${service.conflictCount}, submitted ${service.submittedCount}',
                                 ),
+                                // "End match now" is a deep-link-only action
+                                // (it lives here, not in Current Game, because
+                                // it only applies to a linked scoreboard
+                                // fixture). This section's AnimatedBuilder
+                                // listens to the service, so it does not rebuild
+                                // on match-stage changes (e.g. the clock hitting
+                                // full time while Settings is open); wrap the
+                                // gated button in its own builder on widget.game
+                                // — Game forwards service notifications too, so
+                                // this tracks both the fixture and the stage.
+                                AnimatedBuilder(
+                                  animation: widget.game,
+                                  builder: (context, child) {
+                                    if (!widget.game.canEndMatchEarly) {
+                                      return const SizedBox.shrink();
+                                    }
+                                    return SettingButton(
+                                      title: 'End match now',
+                                      buttonText: 'End',
+                                      onPressed: _confirmEndMatchEarly,
+                                    );
+                                  },
+                                ),
                                 SettingButton(
                                   title: 'Refresh linked match',
                                   buttonText: 'Refresh',
@@ -463,12 +486,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                         widget.game.stopNoShowPenaltyGoals();
                                       });
                                     },
-                                  ),
-                                if (widget.game.canEndMatchEarly)
-                                  SettingButton(
-                                    title: 'End match now',
-                                    buttonText: 'End',
-                                    onPressed: _confirmEndMatchEarly,
                                   ),
                                 SettingButton(
                                   title: 'Disconnect all robots',
@@ -870,7 +887,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             ),
                             Padding(
                               padding: EdgeInsets.symmetric(vertical: 4.0),
-                              child: Text('Author: Martin Faltus, Fabian Weller, Marek Šuppa',
+                              child: Text(
+                                  'Author: Martin Faltus, Fabian Weller, Marek Šuppa',
                                   style: TextStyle(fontSize: 14)),
                             ),
                             Padding(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -870,8 +870,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             ),
                             Padding(
                               padding: EdgeInsets.symmetric(vertical: 4.0),
-                              child: Text(
-                                  'Author: Martin Faltus, Fabian Weller, Marek Šuppa',
+                              child: Text('Author: Martin Faltus, Fabian Weller, Marek Šuppa',
                                   style: TextStyle(fontSize: 14)),
                             ),
                             Padding(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -160,14 +160,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _confirmEndMatchEarly() async {
     final game = widget.game;
-    // Pin the fixture the referee is confirming. A new deep link can be
-    // loaded while this dialog sits open (Home's "Load match?" dialog renders
-    // in the same root overlay, above us), swapping matchConfig under a stale
-    // confirm — the same stale-dialog class the load/review paths guard with
-    // expectedSignature. Version bumps of the same fixture change the
-    // signature too; the conservative no-op just makes the referee re-tap.
+    // Pin the fixture AND the match state the referee is confirming. A deep
+    // link can be Loaded while this dialog sits open (Home's "Load match?"
+    // dialog renders in the same root overlay, above us): a different fixture
+    // swaps matchConfig (caught by the signature, the same stale-dialog class
+    // the load/review paths guard with expectedSignature), while a confirmed
+    // re-Load of the SAME fixture keeps the signature but RESETS the live
+    // match via gameInit() (#69) — caught by the stage/inGame/score pin. A
+    // stage flip or score change while the dialog is open (half expiring,
+    // no-show goal landing) is likewise no longer the state this dialog
+    // displayed. The conservative no-op just makes the referee re-tap.
     final expectedSignature =
         game.scoreboardResultService.matchConfig?.signature;
+    final expectedMatchState = (
+      game.currentStage,
+      game.inGame,
+      game.teams[0].score,
+      game.teams[1].score,
+    );
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -190,15 +200,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
     );
     if (!mounted || confirmed != true) return;
-    // The fixture can be cleared/changed while the dialog sits open; re-check
-    // the gate AND that it is still the exact fixture this dialog showed, so
-    // a stale confirm can't end a different (or edited) match.
+    // The fixture or match can change while the dialog sits open; re-check
+    // the gate AND that both still match what this dialog showed, so a stale
+    // confirm can't end a different fixture or a reset/advanced match.
     if (!game.canEndMatchEarly) return;
     if (expectedSignature == null ||
         game.scoreboardResultService.matchConfig?.signature !=
             expectedSignature) {
       return;
     }
+    final currentMatchState = (
+      game.currentStage,
+      game.inGame,
+      game.teams[0].score,
+      game.teams[1].score,
+    );
+    if (currentMatchState != expectedMatchState) return;
     // Pop Settings back to Home FIRST (returning the game so Home's
     // _navigateToSettings continuation runs gameRefresh(), not gameInit() —
     // endMatchEarly sets inGame synchronously below, before that continuation's

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -158,6 +158,43 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
+  Future<void> _confirmEndMatchEarly() async {
+    final game = widget.game;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('End this match now?'),
+        content: Text(
+          'You will be taken to the result confirmation screen. '
+          'Current score: ${game.teams[0].name} ${game.teams[0].score} '
+          '– ${game.teams[1].score} ${game.teams[1].name}.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('End'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    // The fixture can be cleared/changed while the dialog sits open; re-check
+    // the gate so a stale confirm can't end a match that no longer qualifies.
+    if (!game.canEndMatchEarly) return;
+    // Pop Settings back to Home FIRST (returning the game so Home's
+    // _navigateToSettings continuation runs gameRefresh(), not gameInit() —
+    // endMatchEarly sets inGame synchronously below, before that continuation's
+    // microtask runs). Home's onRequestReviewScoreboardResult callback is
+    // deferred to a post-frame callback, so the review route is pushed over
+    // Home, never over the disappearing Settings route.
+    Navigator.of(context).pop(game);
+    game.endMatchEarly();
+  }
+
   @override
   Widget build(BuildContext context) {
     return PopScope(
@@ -395,6 +432,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                         widget.game.stopNoShowPenaltyGoals();
                                       });
                                     },
+                                  ),
+                                if (widget.game.canEndMatchEarly)
+                                  SettingButton(
+                                    title: 'End match now',
+                                    buttonText: 'End',
+                                    onPressed: _confirmEndMatchEarly,
                                   ),
                                 SettingButton(
                                   title: 'Disconnect all robots',

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -160,6 +160,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _confirmEndMatchEarly() async {
     final game = widget.game;
+    // Pin the fixture the referee is confirming. A new deep link can be
+    // loaded while this dialog sits open (Home's "Load match?" dialog renders
+    // in the same root overlay, above us), swapping matchConfig under a stale
+    // confirm — the same stale-dialog class the load/review paths guard with
+    // expectedSignature. Version bumps of the same fixture change the
+    // signature too; the conservative no-op just makes the referee re-tap.
+    final expectedSignature =
+        game.scoreboardResultService.matchConfig?.signature;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -183,8 +191,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
     if (!mounted || confirmed != true) return;
     // The fixture can be cleared/changed while the dialog sits open; re-check
-    // the gate so a stale confirm can't end a match that no longer qualifies.
+    // the gate AND that it is still the exact fixture this dialog showed, so
+    // a stale confirm can't end a different (or edited) match.
     if (!game.canEndMatchEarly) return;
+    if (expectedSignature == null ||
+        game.scoreboardResultService.matchConfig?.signature !=
+            expectedSignature) {
+      return;
+    }
     // Pop Settings back to Home FIRST (returning the game so Home's
     // _navigateToSettings continuation runs gameRefresh(), not gameInit() —
     // endMatchEarly sets inGame synchronously below, before that continuation's
@@ -839,7 +853,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             ),
                             Padding(
                               padding: EdgeInsets.symmetric(vertical: 4.0),
-                              child: Text('Author: Martin Faltus, Fabian Weller, Marek Šuppa',
+                              child: Text(
+                                  'Author: Martin Faltus, Fabian Weller, Marek Šuppa',
                                   style: TextStyle(fontSize: 14)),
                             ),
                             Padding(

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -2104,7 +2104,11 @@ void main() {
 
     testWidgets('half-time break running is cancelled cleanly', (tester) async {
       final game = await loadScoreboardFixture(tester);
+      // Mirror the real firstHalf->halfTime transition state: break countdown
+      // on the clock and the SKIP affordance, not first-half leftovers.
       game.currentStage = MatchStage.halfTime;
+      game.setRemainingTime(game.halfTimeDuration);
+      game.timerButtonText = 'SKIP';
       game.startTimer();
       await tester.pump();
 
@@ -2112,6 +2116,8 @@ void main() {
 
       expect(game.isTimeRunning, isFalse);
       expect(game.currentStage, MatchStage.fullTime);
+      expect(game.remainingTime, 0);
+      expect(game.timerButtonText, 'REPEAT');
       expect(game.needsScoreboardResultReview, isTrue);
 
       await tester.pump(const Duration(milliseconds: 1500));

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -2003,6 +2003,219 @@ void main() {
     });
   });
 
+  group('end match early (#84)', () {
+    Future<Game> loadScoreboardFixture(
+      WidgetTester tester, {
+      String matchCode = 'M-84',
+      int version = 1,
+    }) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: matchCode, version: version),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      return game;
+    }
+
+    testWidgets('gate: manual match is not eligible and no-ops',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+
+      expect(game.canEndMatchEarly, isFalse);
+      game.endMatchEarly();
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
+      game.dispose();
+    });
+
+    testWidgets('gate: empty match code is not eligible and no-ops',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester, matchCode: '');
+
+      expect(game.canEndMatchEarly, isFalse);
+      game.endMatchEarly();
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
+      game.dispose();
+    });
+
+    testWidgets('before kickoff persists a full-time review snapshot',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
+      expect(game.canEndMatchEarly, isTrue);
+      game.endMatchEarly();
+
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.inGame, isTrue);
+      expect(game.timerButtonText, 'REPEAT');
+      expect(game.needsScoreboardResultReview, isTrue);
+      expect(reviewRequests, 1);
+
+      final saved = await waitForSavedSnapshot(
+        tester,
+        (snapshot) => snapshot.stage == 'fullTime' && snapshot.inGame,
+      );
+      expect(saved.isRefereeMatch, isTrue);
+      expect(saved.scoreboardMatchCode, 'M-84');
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('mid first half stops the running clock and arms review',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.teams[0].score = 1;
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 2));
+      expect(game.isTimeRunning, isTrue);
+
+      game.endMatchEarly();
+
+      expect(game.isTimeRunning, isFalse);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+      expect(reviewRequests, 1);
+      expect(game.teams[0].score, 1);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('half-time break running is cancelled cleanly', (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.currentStage = MatchStage.halfTime;
+      game.startTimer();
+      await tester.pump();
+
+      game.endMatchEarly();
+
+      expect(game.isTimeRunning, isFalse);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isTrue);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('idempotent after full time', (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
+      game.endMatchEarly();
+      final stage = game.currentStage;
+      final inGame = game.inGame;
+      final timerButtonText = game.timerButtonText;
+      final scoreA = game.teams[0].score;
+      final scoreB = game.teams[1].score;
+
+      expect(game.canEndMatchEarly, isFalse);
+      game.endMatchEarly();
+
+      expect(game.currentStage, stage);
+      expect(game.inGame, inGame);
+      expect(game.timerButtonText, timerButtonText);
+      expect(game.teams[0].score, scoreA);
+      expect(game.teams[1].score, scoreB);
+      expect(reviewRequests, 1);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('unresolved-result gate suppresses the review callback',
+        (tester) async {
+      await _seedOutbox(prefs, [
+        _outboxItem(
+          matchCode: 'M-84',
+          state: ResultSubmissionState.pending,
+        ),
+      ]);
+      final game = await loadScoreboardFixture(tester);
+      var reviewRequests = 0;
+      game.onRequestReviewScoreboardResult = () {
+        reviewRequests++;
+      };
+
+      expect(game.canEndMatchEarly, isTrue);
+      game.endMatchEarly();
+
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.needsScoreboardResultReview, isFalse);
+      expect(reviewRequests, 0);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('no-show mode is reset when ended early', (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.startNoShowPenaltyGoals(game.teams[0]);
+      expect(game.noShowPenaltyGoalsActive, isTrue);
+
+      game.endMatchEarly();
+
+      expect(game.noShowPenaltyGoalsActive, isFalse);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.isTimeRunning, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('submit after early end queues the normal result',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+
+      game.endMatchEarly();
+      final result = await submitCurrentReview(tester, game, 'M-84');
+
+      expect(result.matchCode, 'M-84');
+      expect(result.homeGoals, 0);
+      expect(result.awayGoals, 0);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('REPEAT after early end starts a fresh match', (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.teams[0].score = 2;
+
+      game.endMatchEarly();
+      game.toggleTimer();
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.teams[0].score, 0);
+      expect(game.teams[1].score, 0);
+      expect(game.inGame, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
   group('new-fixture Load resets the live match (RAVF002)', () {
     // Drive the real confirm path: stage a pending deep link, then
     // game.confirmScoreboardMatch() (what Home's Load button calls). Only that

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -2060,6 +2060,7 @@ void main() {
 
       expect(game.currentStage, MatchStage.fullTime);
       expect(game.inGame, isTrue);
+      expect(game.remainingTime, 0);
       expect(game.timerButtonText, 'REPEAT');
       expect(game.needsScoreboardResultReview, isTrue);
       expect(reviewRequests, 1);
@@ -2092,6 +2093,7 @@ void main() {
 
       expect(game.isTimeRunning, isFalse);
       expect(game.currentStage, MatchStage.fullTime);
+      expect(game.remainingTime, 0);
       expect(game.needsScoreboardResultReview, isTrue);
       expect(reviewRequests, 1);
       expect(game.teams[0].score, 1);
@@ -2144,8 +2146,12 @@ void main() {
       game.dispose();
     });
 
-    testWidgets('unresolved-result gate suppresses the review callback',
+    testWidgets('unresolved same-fixture result hides early end and no-ops',
         (tester) async {
+      // A still-in-flight prior result for this fixture would make
+      // _enterFullTimeResultReview refuse to arm the review, so ending early
+      // would strand the referee at full time with no result editor. The
+      // gate must hide the affordance instead.
       await _seedOutbox(prefs, [
         _outboxItem(
           matchCode: 'M-84',
@@ -2158,12 +2164,75 @@ void main() {
         reviewRequests++;
       };
 
-      expect(game.canEndMatchEarly, isTrue);
+      expect(game.canEndMatchEarly, isFalse);
       game.endMatchEarly();
 
-      expect(game.currentStage, MatchStage.fullTime);
-      expect(game.needsScoreboardResultReview, isFalse);
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
       expect(reviewRequests, 0);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('gate: fixture without a token is not eligible and no-ops',
+        (tester) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-84', version: 1),
+        ),
+      );
+      await tester.pump();
+
+      expect(game.canEndMatchEarly, isFalse);
+      game.endMatchEarly();
+
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(game.inGame, isFalse);
+      game.dispose();
+    });
+
+    testWidgets('second half ends early like the natural transition',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.teams[1].score = 2;
+      game.currentStage = MatchStage.secondHalf;
+      game.startTimer();
+      await tester.pump(const Duration(seconds: 1));
+
+      game.endMatchEarly();
+
+      expect(game.isTimeRunning, isFalse);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(game.remainingTime, 0);
+      expect(game.timerButtonText, 'REPEAT');
+      expect(game.needsScoreboardResultReview, isTrue);
+      expect(game.teams[1].score, 2);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+
+    testWidgets('half-time early end force-stops break-parked modules',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      game.currentStage = MatchStage.halfTime;
+      // Park an enabled module in the break state exactly as halfTimeAll
+      // does at the firstHalf->halfTime transition.
+      final module = game.teams[0].modules[0];
+      module.enable();
+      module.halfTime();
+      expect(module.lastState, ModuleState.halfTime);
+
+      game.endMatchEarly();
+
+      // The forced dispatch must not re-enter halfTime() (an unforced
+      // Module.stopAll switches on _lastState == halfTime and would send a
+      // fresh break countdown); force lands the module on STOP synchronously.
+      expect(module.lastState, ModuleState.stop);
+      expect(game.currentStage, MatchStage.fullTime);
 
       await tester.pump(const Duration(milliseconds: 1500));
       game.dispose();


### PR DESCRIPTION
## What & why

Derived from **issue #84**. A referee sometimes has to end a match without playing it — most commonly a **team no-show → forfeit/contumation win**. Until now the only way to reach the result review/submit screen (#51) was to run/skip through both halves + the break to hit the natural `secondHalf → fullTime` transition.

This adds an **"End match now"** button that ends a deep-link (scoreboard) match immediately, from any stage, and jumps straight to the existing result confirmation screen — guarded by a confirmation pop-up. The referee then edits the score (e.g. contumation score) and submits as usual. No new submission logic; this is only a new *entry point* into the #51 lifecycle.

Closes #84.

## Design

- **Reuses the real full-time path, never a shortcut.** The `secondHalf → fullTime` tick block was extracted verbatim into `Game._completeMatchToFullTime()` and is now called by both the natural tick expiry and the new `Game.endMatchEarly()`. This keeps every full-time invariant intact: RAVF003 kill-before-submit snapshot, the unresolved-result gate, `REPEAT` behaviour, MQTT/bridge broadcast, and module teardown.
- **Gate (`canEndMatchEarly`):** visible only for a linked, submittable scoreboard fixture — `matchConfig` present + non-empty `matchCode` + token held + `_canSubmitScoreboardResult` + **no unresolved outbox result for the fixture** (otherwise the review could never open) + not already at full time (also makes `endMatchEarly()` idempotent). Manual matches: button hidden.
- **`inGame = true` on early end** (deliberate): a match ended administratively "happened" even if the clock never started. Without it, Home's return-from-Settings path calls `gameInit()` (wiping the just-set full-time state) and the cold-resume path won't restore the snapshot (`snapshot.inGame` gate) — so a kill-before-submit would be unrecoverable for a never-started match.
- **Clock zeroed on early end:** every natural path reaches full time at `0:00`; `endMatchEarly` sets `_remainingTime = 0` so the screen, MQTT/bridge, and the persisted snapshot don't show "game over with 10:00 left".
- **Forced stop out of the half-time break:** modules parked in the break have `_lastState == halfTime`, which an unforced `Module.stopAll` re-dispatches to `halfTime()` (a fresh break countdown) instead of STOP. Ending early from `halfTime` threads `forceStop: true` so they get a real STOP + game-over — the same reason the `halfTime → secondHalf` paths already use `stopAll(force: true)`.
- **Stale-confirm guard:** the confirm dialog pins the fixture `signature` **and** `(stage, inGame, scores)` when it opens, and no-ops the confirm on any mismatch — so a deep link loaded (or a same-fixture confirmed re-Load reset, #69) while the dialog sits open can't end a different/reset match.
- **Placement (device-test tweak):** originally specced under Settings → "Current Game"; moved to the **"Scoreboard Result API"** section since it's a deep-link-only action that belongs with the other fixture controls. The gated button is wrapped in its own `AnimatedBuilder(animation: game)` so it still reacts to match-stage changes (that section otherwise only listens to the result service).

## Commits (logical)

1. `feat(match)` — the button, `endMatchEarly`, gate, tests, kickoff doc
2. `fix(match)` — unresolved-result gate, 0:00 clock, forced half-time stop *(review round 1)*
3. `fix(settings)` — pin the fixture signature across the confirm dialog *(review round 1)*
4. `fix(settings)` — pin the match state too (same-fixture re-Load reset, #69) *(review round 2)*
5. `docs(match)` / `test` — comment accuracy + representative half-time break test *(review round 2)*
6. `style` — restore dev formatting on 3 spots untouched by #84
7. `refactor(settings)` — move the button to the Scoreboard Result API section

## Testing

- **Desk:** `flutter analyze --fatal-infos` clean, **221 tests** (10-case `end match early (#84)` group: gates, all stages, idempotency, unresolved-result gate, no-show reset, submit plumbing, forced half-time stop, REPEAT).
- **review-anvil:** 2 rounds (2 codex + 1 claude each) + adaptive round 3 — fixed 2 high + 3 medium findings (all folded into the commits above).
- **Device (Pixel, mock scoreboard + real robot module):**
  - Before kickoff → 0–0 → edit to 3–0 → submit → `POST {home_goals:3, away_goals:0}` → 200, app reset.
  - Mid first half: Cancel keeps the clock running & score; End → review shows live score.
  - **Half-time break with a real module connected → End → robot went to game over** (not a re-sent break countdown — confirms the forced-stop fix).
  - Kill app before submit → cold-resume re-offers the review with the score preserved (RAVF003).
  - Manual match → button hidden.
  - Early end shows `00:00`; 409 conflict handled gracefully; already-submitted fixture correctly hides the button.

The kickoff doc `docs/ai/KICKOFF_issue84.md` lands with this PR (per the repo convention that each issue's doc ships with its implementing PR); it carries a placement note reflecting the move.

/cc @mrshu — could you review when you get a chance? 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
