### PR TITLE
feat: self-managing field transports — bridge Cancel (#86), end-of-match teardown (#87), MQTT working defaults + auto-connect (#88)

### DIFF
--- a/docs/ai/KICKOFF_issue86_87_88.md
+++ b/docs/ai/KICKOFF_issue86_87_88.md
@@ -1,0 +1,73 @@
+# Kickoff — Issues #86 + #87 + #88: bridge "Cancel" parity, end-of-match bridge/MQTT teardown, MQTT working defaults + auto-connect
+
+> You are starting fresh. Read this, then **study the sources listed below before writing any code or plan.** Do not assume prior context — everything you need is referenced here.
+> One session implements ALL THREE — they touch the same surfaces (`ble_bridge_service.dart`, `mqtt.dart`, the Scoreboard/MQTT sections of `settings.dart`, the fullTime block + config-apply in `game.dart`) and together they make the per-field lifecycle self-managing: **auto-connect MQTT at deep-link load (#88) → play → auto-disconnect bridge+MQTT at full time (#87)**, with a cancellable bridge connect (#86). Prefer one branch + one PR covering all three (separate commits per issue).
+
+## The tasks
+Read all three issues in full first: `gh issue view 86`, `gh issue view 87`, `gh issue view 88`.
+
+### #86 — allow cancelling a stuck BLE-bridge "Connecting…"
+The robot-module flow has a tri-state button — `Disconnect / Cancel / Connect` (`module_settings.dart:408`); **Cancel** calls `bleDisconnect()` which clears `_connectIntent` and stops the OS autoConnect retry. The bridge never got this:
+- `settings.dart` (~471–487, "Bridge connection" `SettingButton`): only two-state. While `BridgeConnectionState.connecting` it shows **"Connect"**, whose handler calls `BLEBridgeService.connect()` — which **early-returns when already connecting** (`ble_bridge_service.dart` ~line 71). A stuck bridge connect is uncancellable from the UI.
+- The service side already supports cancel: `disconnect()` clears `_connectIntent` (~92–103) and settles the state.
+
+Fix: tri-state button mirroring the module pattern (`connected → Disconnect`, `connecting → Cancel`, else `Connect`; Cancel → `bleBridgeService.disconnect()`). While there, audit the bridge connect lifecycle against the module/PR #42 learnings: status text covers all four `BridgeConnectionState`s (incl. `error`), no "Disconnected" flash mid-retry, repeated Connect taps can't stack listeners/GATT clients (single `connect(autoConnect:true)` — invariant #5 applies to the bridge link too).
+
+### #87 — disconnect BLE bridge + MQTT at the end of EVERY match
+Referees rotate phones per field. After full time the old phone keeps holding the bridge (single central → next phone can't connect) and the MQTT session. Today only modules are torn down: `disconnectInactiveModules()` in the `secondHalf → fullTime` block (`game.dart` ~line 823). Fix, in that same block, for manual AND deep-link matches:
+- **After the final full-time state has been broadcast**: drain the bridge's dedup queue (`queueDepthNotifier`, drain-or-timeout of a few seconds — mirror `gameOverAll()`'s 1 s delay pattern) → `bleBridgeService.disconnect()`; and `mqttService.disconnect()` after the final publishes.
+- **Unawaited / fire-and-forget** on the transition path (invariant #1 — never delay the robot path).
+- Only disconnect what was connected; no-op otherwise.
+- Placing it in the shared block means the **#84 "End match now"** path (which reuses this block) inherits it for free — coordinate if #84 lands first/concurrently (see `docs/ai/KICKOFF_issue84.md`).
+
+Decisions flagged in the issue (confirm with the owner if in doubt): REPEAT leaves transports disconnected (manual reconnect via Settings); MQTT `auto_connect` pref (applied at app launch, `mqtt.dart:49`) must not undo the teardown mid-session; no auto-reconnect on cold-resume at fullTime (RAVF003 restore).
+
+### #88 — MQTT working defaults + auto-connect on deep-link match load
+Today every referee phone needs manual MQTT setup: **Secure connection** defaults to `false` (`mqtt.dart:48`) and the shipped default password is a **hint** — `S_p-@P2_rL7ZFv9XYZ` (`mqtt.dart:54`, commit 5750ca5); the real password is that minus the literal trailing `XYZ`. Owner decision: ship it working.
+- Defaults: `mqtt_secure_connection` → `true`; default password → the real one, `S_p-@P2_rL7ZFv9` (accepted trade-off — the broker account is restricted to the single scoreboard topic). Optional one-shot migration: a stored password equal to the old hint string verbatim → migrate to the real default.
+- Auto-connect: when a scoreboard config is applied (`Game._applyScoreboardMatchConfig` — where the venue → `field_N` MQTT topic is already derived, #50), if MQTT is **enabled** and **not connected**, connect automatically with the stored settings. **Unawaited** off the config-apply path (broker outage must not delay match load); status label reports the outcome; never auto-connect when MQTT is disabled; never clobber custom referee creds.
+- Interplay with #87 (important): auto-connect fires on match **LOAD** only — it must NOT re-fire after the same match's full-time teardown (loading the NEXT match connects again; that's the desired handover loop).
+
+## Required reading (study before acting)
+- `gh issue view 86`, `gh issue view 87`, `gh issue view 88` (+ referenced PR #42 discussion for the module reconnect learnings).
+- `CLAUDE.md` (repo root) — **critical invariants** (#1 START/STOP latency — no awaits/serialization on robot paths; #5 autoConnect-only reconnect, NO app-level loop — the #42 GATT-client-leak history; portrait-only; no new packages) + the **mock-launch pkill gotcha** at the bottom.
+- Memory index: `/home/mato/.claude-rc/projects/-home-mato-StudioProjects-rcj-scoreboard/memory/MEMORY.md` — read `ble_bridge_design.md`, `ble_reconnect_unbounded_in_match.md`, `ble_pixel_limit.md`, `git_housekeeping_caution.md`, `device_test_before_push.md`, `codex_sandbox_flag_usage.md`, `review_anvil_format_gotcha.md`, `prepared_issues_84_85.md`.
+- `docs/ai/02_RUNTIME_ARCHITECTURE.md` ("Auto-reconnect policy") and `docs/ai/05_BLE_BRIDGE_FEATURE_PLAN.md` — bridge design/protocol.
+- `docs/ai/07_SCOREBOARD_DEVICE_TESTING.md` — device-test runbook basics (adb, coords, double-tap gotcha, mock deep link).
+
+## Code you'll touch (study these)
+- `lib/services/ble_bridge_service.dart` — `BridgeConnectionState` (line 10), `_connectIntent` (31), `connect()` early-return (~71), `disconnect()` (~92–103), disconnect-event state settle (~158), `queueDepthNotifier` + `_processQueue` (dedup queue, pops-before-await).
+- `lib/services/mqtt.dart` — defaults (48–54: `mqtt_secure_connection ?? false`, hint password), `disconnect()` (~281), `connect`, `isEnabled`, `_autoConnect` pref (~28/49/137), `connectionStateNotifier`.
+- `lib/screens/settings.dart` — Scoreboard/bridge `SettingsSection` (~413–490): status label mapping and the "Bridge connection" `SettingButton` (~471); MQTT section right below (~492+; secure-connection toggle + password field).
+- `lib/screens/module_settings.dart` — line ~408: the tri-state button to mirror; its Cancel semantics.
+- `lib/models/game.dart` — the `secondHalf → fullTime` block (~810–825: `stopAll`, `gameOverAll()`, `_enterFullTimeResultReview`, `disconnectInactiveModules()`, `_persistOrClearAtFullTime`); `gameOverAll()` (1 s delayed BLE fan-out — the delay pattern to mirror for queue drain); `_applyScoreboardMatchConfig` (~1360+; field-number derivation ~1457 — where #88's auto-connect hooks in, watch the dedupe/re-apply paths so a refresh doesn't re-trigger connects); the `_broadcast*` helpers that fan out to MQTT + bridge.
+- Tests: `test/bridge_message_test.dart` (bridge queue tests), `test/game_recovery_test.dart` (harness for fullTime-transition + config-apply tests). Add: tri-state mapping unit test; teardown-ordering test (final publish/queue drain before disconnect); no-op when never connected; REPEAT leaves transports down; #88 defaults test (fresh prefs → secure true + real password), auto-connect-on-apply test (enabled+disconnected → connect called once; disabled → never; same-config refresh → not re-fired), hint-password migration test if implemented.
+
+## What's already in `dev` (don't rebuild it)
+- Bridge iteration 1 (MQTT-over-BLE, dedup queue, `_connectIntent` mirroring, iOS UUID handling #65/#67). Module Cancel + "Connecting…" status (0.9.8, PR #42). `disconnectInactiveModules()` at fullTime. Venue → `field_N` topic derivation (#50). #84/#85 are specced (kickoff docs in `docs/ai/`) and may land concurrently — #84 touches the same fullTime block; coordinate/rebase.
+
+## Workflow (the standard way of working here)
+1. Branch off **`dev`** (e.g. `feat/issue-86-87-88-transport-lifecycle`).
+2. Write a **Codex task spec**, then have Codex implement (`codex exec --dangerously-bypass-approvals-and-sandbox` — bwrap sandbox is broken in this env; owner pre-authorized). Separate commits: #86 (button/lifecycle), #87 (teardown), #88 (defaults + auto-connect).
+3. **review-anvil** (claude + codex reviewers, multiple rounds) → apply fixes. Only format edited files.
+4. Full test suite + `flutter analyze`.
+5. **Device-test on the real phone** — `device_test_before_push.md`: desk-green ≠ done; owner go-ahead before commit/push.
+   - **#86**: set the bridge MAC to a powered-off/nonexistent device → Settings shows "Connecting…" → button must read **Cancel** → tap → "Disconnected" immediately, and the device must NOT connect later when powered on. Then a normal connect/disconnect cycle against the real scoreboard bridge.
+   - **#87**: with the real bridge (and MQTT) connected, play a short match (Settings → 10 s halves) to full time → scoreboard shows the FINAL score, then both transports read disconnected within a few seconds; verify a second phone (or re-connecting the same phone) can take the bridge. Repeat via the manual (non-deep-link) path, and via #84's early-end if it has landed.
+   - **#88**: `pm clear` (fresh prefs) → fire a deep-link match (mock or real) → MQTT connects by itself with secure=on and the real default password, publishes land on the fixture's `field_N` topic (verify with a broker-side subscriber or the mock/HiveMQ web client). Then: MQTT disabled → no attempt; full match → #87 disconnects → load the NEXT match → auto-connect fires again.
+6. Open a well-documented PR (base `dev`), closing all three issues; commits end with the Co-Authored-By line; PR body ends with the generated-with line.
+7. **Commit this kickoff doc (`docs/ai/KICKOFF_issue86_87_88.md`) as part of your PR** — it is intentionally untracked until then; the owner wants each issue's doc to land with its implementing PR.
+
+## Constraints / gotchas
+- No new packages. Android + iOS (bridge identifiers are UUIDs on iOS).
+- Owner dislikes git churn — confirm before creating/closing anything beyond the PR branch.
+- The bridge/MQTT are **fully separate from robot control** — nothing here may touch module connect/send paths or add awaits near `bleSendPlayAll`/`bleSendStopAll` (invariant #1). The teardown must not race `gameOverAll()`'s delayed module fan-out; the auto-connect must not delay `_applyScoreboardMatchConfig`.
+- Do NOT add any app-level reconnect loop to the bridge while auditing (invariant #5 — the #42 GATT-client leak was device-proven).
+- The bridge queue drain must be bounded (timeout) — a dead bridge with a non-draining queue must not block the teardown forever.
+- Keep the teardown one-shot/idempotent (e.g. #84's early end reaching fullTime twice → no-op), and keep #88's auto-connect load-only (config **refresh/dedupe** paths in `_applyScoreboardMatchConfig` must not re-trigger it — study `_lastAppliedScoreboardSignature`).
+- The real password lands in the repo/app by explicit owner decision (single-topic broker account) — don't "fix" that in review; do keep it out of logs.
+
+## First moves
+1. `gh issue view 86` + `87` + `88`; read `CLAUDE.md`, the memory files, `ble_bridge_service.dart`, `mqtt.dart`, the settings bridge/MQTT sections, and `game.dart` ~800–830 + `_applyScoreboardMatchConfig`.
+2. Check whether #84 has landed (it reuses the fullTime block) and rebase/coordinate accordingly.
+3. Draft the Codex task spec for review, then implement per the workflow above.

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -145,6 +145,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   // link at full time can't bind the just-ended match's scores to the new
   // fixture. Cleared on a fresh match (gameInit).
   String? _fullTimeResultSignature;
+  bool _fullTimeTransportTeardownDone = false;
 
   // Callback to request showing the dialog
   void Function()? onRequestSwitchTeamOrderDialog;
@@ -317,6 +318,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _resumedFixtureMatchCode = null;
     _resumedFixtureVersion = null;
     _fullTimeResultSignature = null;
+    _fullTimeTransportTeardownDone = false;
     _resetNoShowPenaltyGoals();
 
     stopTimer();
@@ -859,6 +861,36 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // full time we settle the ones still off to "Disconnected".
     disconnectInactiveModules();
     _persistOrClearAtFullTime();
+    unawaited(_teardownFieldTransportsAtFullTime());
+  }
+
+  // Release the field infrastructure at full time (#87): referees rotate
+  // phones per field, and the bridge accepts a single central — while the old
+  // phone holds it (or the MQTT session), the next phone can't take over.
+  // Launched unawaited from _completeMatchToFullTime so both the natural
+  // second-half expiry and endMatchEarly() (#84) inherit it, and nothing on
+  // the robot STOP path waits on it (invariant #1). The 1 s delay + stage
+  // re-check mirror gameOverAll(): the callers' synchronous final
+  // _broadcastStageAndTime() runs before the first await resumes, so the
+  // final "Game Over" publish always precedes the MQTT disconnect, and a
+  // REPEAT during the delay aborts the teardown. One-shot per match
+  // (re-armed by gameInit) so a second entry into the full-time block no-ops.
+  Future<void> _teardownFieldTransportsAtFullTime() async {
+    if (_fullTimeTransportTeardownDone) return;
+    _fullTimeTransportTeardownDone = true;
+    await Future<void>.delayed(const Duration(seconds: 1));
+    if (currentStage != MatchStage.fullTime) return;
+
+    // Tear down a connected OR still-connecting bridge link — the same
+    // stop-chasing-a-powered-down-unit policy disconnectInactiveModules()
+    // applies to robot modules. The bounded drain lets the last queued score
+    // frame reach the scoreboard before the link drops.
+    final bridgeState = bleBridgeService.connectionStateNotifier.value;
+    if (bridgeState == BridgeConnectionState.connected ||
+        bridgeState == BridgeConnectionState.connecting) {
+      await bleBridgeService.disconnectAfterDrain();
+    }
+    mqttService.disconnect();
   }
 
   // Upper bound on background catch-up ticks: only the window the timer runs

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -237,11 +237,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     _periodTime = _prefs!.getInt(_periodTimeKey) ?? _defaultPeriodTimeSeconds;
     _halfTimeDuration =
         _prefs!.getInt(_halfTimeDurationKey) ?? _defaultHalfTimeDurationSeconds;
-    _numberOfPlayers = (_prefs!.getInt(_numberOfPlayersKey) ??
-            _defaultPlayersPerTeam)
-        .clamp(1, _maxPlayer)
-        .toInt();
-    _penaltyTime = _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
+    _numberOfPlayers =
+        (_prefs!.getInt(_numberOfPlayersKey) ?? _defaultPlayersPerTeam)
+            .clamp(1, _maxPlayer)
+            .toInt();
+    _penaltyTime =
+        _prefs!.getInt(_penaltyTimeKey) ?? _defaultPenaltyTimeSeconds;
 
     // Single-tap pref: flush a pre-load toggle if one happened, otherwise adopt
     // the stored value. Reading unconditionally would clobber an early toggle.
@@ -893,6 +894,20 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     mqttService.disconnect();
   }
 
+  // Load-only reconnect: a same-match full-time refresh must not undo #87's
+  // teardown, but a fresh or confirmed match load should claim the field.
+  void _maybeAutoConnectMqttOnMatchLoad() {
+    if (!mqttService.isEnabled) return;
+    if (mqttService.isConnected) return;
+    if (mqttService.connectionStateNotifier.value ==
+        MqttConnectionStateEx.connecting) {
+      return;
+    }
+    // Fire-and-forget: a broker outage must not delay match load, and the
+    // Settings status label reports the outcome.
+    unawaited(mqttService.connect());
+  }
+
   // Upper bound on background catch-up ticks: only the window the timer runs
   // *automatically*. The second-half timer is referee-started (the halfTime ->
   // secondHalf transition does NOT call startTimer()), so catch-up must stop at
@@ -1523,6 +1538,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // #71: a 25-min scheduling slot is mapped to a 10-min half + 5-min break.
       _applyScoreboardTiming(config);
       gameInit();
+      _maybeAutoConnectMqttOnMatchLoad();
     } else if (isConfirmedNewFixtureLoad) {
       // RAVF002: the referee confirmed the "Load match?" overwrite while a match
       // is in progress or finished. The dialog warns it "replaces the match in
@@ -1552,6 +1568,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       // synchronous part (_dirty=false + initiating the tombstone write) runs now;
       // only the disk completion is awaited later, off the robot hot path.
       _confirmedLoadClear = _clearMatchStateAndWait();
+      _maybeAutoConnectMqttOnMatchLoad();
     } else if (reArmedFromSuppression && currentStage == MatchStage.fullTime) {
       // The bound fixture's config only surfaced AFTER this resumed match had
       // already run to full-time while suppressed. Now that the bound fixture's
@@ -2181,6 +2198,7 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     }
     return '1 goal/$_noShowPenaltyGoalIntervalSeconds sec';
   }
+
   String get noShowPenaltyScoringTeamName =>
       _noShowPenaltyScoringTeam?.name ?? '';
   bool get isSomeonePlaying => _numberOfPlaying > 0 ? true : false;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -884,22 +884,26 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
 
     // Tear down a connected OR still-connecting bridge link — the same
     // stop-chasing-a-powered-down-unit policy disconnectInactiveModules()
-    // applies to robot modules. The bounded drain lets the last queued score
-    // frame reach the scoreboard before the link drops.
+    // applies to robot modules. Only a CONNECTED bridge gets the bounded
+    // drain (it lets the last queued score frame reach the scoreboard before
+    // the link drops); a connecting one cannot drain its queue by definition,
+    // so draining it would only pin the teardown at the full timeout.
+    // The drain can take seconds: if a REPEAT or a confirmed Load starts a
+    // new match meanwhile (gameInit re-arms the teardown flag and moves the
+    // stage off fullTime — and a Load may have just auto-connected MQTT via
+    // #88), a stale disconnect would silently strip the new match's
+    // transports, so the epoch is re-checked inside the drain (via
+    // shouldAbort, protecting the bridge) and once more below (protecting
+    // MQTT).
+    bool staleTeardown() =>
+        !_fullTimeTransportTeardownDone || currentStage != MatchStage.fullTime;
     final bridgeState = bleBridgeService.connectionStateNotifier.value;
-    if (bridgeState == BridgeConnectionState.connected ||
-        bridgeState == BridgeConnectionState.connecting) {
-      await bleBridgeService.disconnectAfterDrain();
+    if (bridgeState == BridgeConnectionState.connected) {
+      await bleBridgeService.disconnectAfterDrain(shouldAbort: staleTeardown);
+    } else if (bridgeState == BridgeConnectionState.connecting) {
+      await bleBridgeService.disconnect();
     }
-    // The drain above can take seconds. If a REPEAT or a confirmed Load
-    // started a new match meanwhile (gameInit re-arms the teardown flag and
-    // moves the stage off fullTime — and a Load may have just auto-connected
-    // MQTT via #88), a stale disconnect here would silently freeze the new
-    // match's scoreboard, so re-check the epoch before touching MQTT.
-    if (!_fullTimeTransportTeardownDone ||
-        currentStage != MatchStage.fullTime) {
-      return;
-    }
+    if (staleTeardown()) return;
     mqttService.disconnect();
   }
 
@@ -923,6 +927,11 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       if (connected) {
         _broadcastFullState();
       }
+    }).catchError((Object e) {
+      // The service maps expected failures to its error state; this guard
+      // only keeps a truly unexpected escape from becoming an uncaught async
+      // error on the fire-and-forget load path.
+      debugPrint('MQTT auto-connect failed: $e');
     }));
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -891,6 +891,15 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
         bridgeState == BridgeConnectionState.connecting) {
       await bleBridgeService.disconnectAfterDrain();
     }
+    // The drain above can take seconds. If a REPEAT or a confirmed Load
+    // started a new match meanwhile (gameInit re-arms the teardown flag and
+    // moves the stage off fullTime — and a Load may have just auto-connected
+    // MQTT via #88), a stale disconnect here would silently freeze the new
+    // match's scoreboard, so re-check the epoch before touching MQTT.
+    if (!_fullTimeTransportTeardownDone ||
+        currentStage != MatchStage.fullTime) {
+      return;
+    }
     mqttService.disconnect();
   }
 
@@ -904,8 +913,17 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       return;
     }
     // Fire-and-forget: a broker outage must not delay match load, and the
-    // Settings status label reports the outcome.
-    unawaited(mqttService.connect());
+    // Settings status label reports the outcome. On success, rebroadcast the
+    // CURRENT state: the load path's gameInit() broadcasts ran while MQTT was
+    // still disconnected (publishMessage drops them), so without this the new
+    // match's retained topics would keep the previous match's data until the
+    // first in-match event. Broadcasting whatever is live now is always safe,
+    // even if the fixture changed again while connecting.
+    unawaited(mqttService.connect().then((connected) {
+      if (connected) {
+        _broadcastFullState();
+      }
+    }));
   }
 
   // Upper bound on background catch-up ticks: only the window the timer runs

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -912,6 +912,13 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   void _maybeAutoConnectMqttOnMatchLoad() {
     if (!mqttService.isEnabled) return;
     if (mqttService.isConnected) return;
+    // No field topic, no auto-connect (review #94): a fixture whose venue
+    // carries no number (e.g. "Center Court", #50) leaves the topic empty on
+    // a fresh install, and publishCMMessage would then land the rebroadcast's
+    // RETAINED state on the venue-shared rcj_soccer/* base namespace. A
+    // manually configured field (persisted topic) still auto-connects, and
+    // the Settings Connect button is unaffected.
+    if (mqttService.topic.isEmpty) return;
     // No bail on a `connecting` state: the bounded reconnect loop pins the
     // state there almost continuously during a broker blip, and a load that
     // bailed would never rebroadcast — leaving the previous match's retained

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -912,10 +912,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
   void _maybeAutoConnectMqttOnMatchLoad() {
     if (!mqttService.isEnabled) return;
     if (mqttService.isConnected) return;
-    if (mqttService.connectionStateNotifier.value ==
-        MqttConnectionStateEx.connecting) {
-      return;
-    }
+    // No bail on a `connecting` state: the bounded reconnect loop pins the
+    // state there almost continuously during a broker blip, and a load that
+    // bailed would never rebroadcast — leaving the previous match's retained
+    // topics on the new field. connect() serializes internally, so calling
+    // it while another attempt is in flight just queues this caller.
+    //
     // Fire-and-forget: a broker outage must not delay match load, and the
     // Settings status label reports the outcome. On success, rebroadcast the
     // CURRENT state: the load path's gameInit() broadcasts ran while MQTT was
@@ -929,10 +931,12 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
       }
     }).catchError((Object e) {
       // The service maps expected failures to its error state; this guard
-      // only keeps a truly unexpected escape from becoming an uncaught async
-      // error on the fire-and-forget load path.
+      // only keeps an unexpected Exception escape from becoming an uncaught
+      // async error on the fire-and-forget load path. Errors (programming
+      // bugs) still surface — swallowing them here would hide a broken
+      // load-time MQTT behind a debugPrint.
       debugPrint('MQTT auto-connect failed: $e');
-    }));
+    }, test: (e) => e is Exception));
   }
 
   // Upper bound on background catch-up ticks: only the window the timer runs

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -11,6 +11,17 @@ import '../utils/ble_address.dart';
 import '../utils/colors.dart';
 import 'mac_qr_scanner.dart';
 
+String bridgeConnectionButtonLabel(BridgeConnectionState state) {
+  switch (state) {
+    case BridgeConnectionState.connected:
+      return 'Disconnect';
+    case BridgeConnectionState.connecting:
+      return 'Cancel';
+    default:
+      return 'Connect';
+  }
+}
+
 class SettingsScreen extends StatefulWidget {
   final Game game;
 
@@ -561,13 +572,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                   ),
                                   SettingButton(
                                     title: 'Bridge connection',
-                                    buttonText: bridgeState ==
-                                            BridgeConnectionState.connected
-                                        ? 'Disconnect'
-                                        : 'Connect',
+                                    buttonText: bridgeConnectionButtonLabel(
+                                        bridgeState),
                                     onPressed: () async {
                                       if (bridgeState ==
-                                          BridgeConnectionState.connected) {
+                                              BridgeConnectionState.connected ||
+                                          bridgeState ==
+                                              BridgeConnectionState
+                                                  .connecting) {
                                         await widget.game.bleBridgeService
                                             .disconnect();
                                       } else {

--- a/lib/services/ble_bridge_service.dart
+++ b/lib/services/ble_bridge_service.dart
@@ -79,10 +79,18 @@ class BleBridgeService extends ChangeNotifier {
     try {
       _device = BluetoothDevice.fromId(_bridgeMacAddress.toUpperCase());
       await _connSub?.cancel();
+      // A Cancel can land during the await above; starting the OS autoConnect
+      // anyway would hold/chase the bridge invisibly (it is a single-central
+      // device) while the UI reads "Disconnected". Same re-check
+      // Module.bleConnect does after its pre-connect await.
+      if (!_connectIntent) return;
       _registerBleSubscriber(_device!);
       await _device!.connect(autoConnect: true, mtu: null);
     } catch (e) {
       debugPrint('BleBridge: connect error: $e');
+      // Don't let a failure surfacing after a Cancel overwrite the settled
+      // "Disconnected" with an error.
+      if (!_connectIntent) return;
       await _setErrorAndDisconnect(message: describeError(e).message);
     }
   }
@@ -261,6 +269,14 @@ class BleBridgeService extends ChangeNotifier {
     }
 
     _txChar = null;
+    // The BLE teardown above can take seconds and the state still reads
+    // "Connecting..." meanwhile, so Settings offers Cancel. If the user took
+    // it, disconnect() already settled "Disconnected" (only it can move the
+    // state here — the listener was cancelled first); don't overwrite that
+    // with an error the user no longer cares about.
+    if (connectionStateNotifier.value != BridgeConnectionState.connecting) {
+      return;
+    }
     connectionStateNotifier.value = BridgeConnectionState.error;
     notifyListeners();
   }

--- a/lib/services/ble_bridge_service.dart
+++ b/lib/services/ble_bridge_service.dart
@@ -104,6 +104,31 @@ class BleBridgeService extends ChangeNotifier {
     connectionStateNotifier.value = BridgeConnectionState.disconnected;
   }
 
+  Future<void> disconnectAfterDrain({
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    try {
+      final deadline = DateTime.now().add(timeout);
+      while ((_queue.isNotEmpty || _sendInProgress) &&
+          DateTime.now().isBefore(deadline)) {
+        final remaining = deadline.difference(DateTime.now());
+        final delay = remaining < const Duration(milliseconds: 100)
+            ? remaining
+            : const Duration(milliseconds: 100);
+        if (delay <= Duration.zero) break;
+        await Future<void>.delayed(delay);
+      }
+    } catch (e) {
+      debugPrint('BleBridge: drain before disconnect failed: $e');
+    }
+
+    try {
+      await disconnect();
+    } catch (e) {
+      debugPrint('BleBridge: disconnectAfterDrain failed: $e');
+    }
+  }
+
   void publishTopic(String topic, String value) {
     if (!isEnabled) return;
 

--- a/lib/services/ble_bridge_service.dart
+++ b/lib/services/ble_bridge_service.dart
@@ -90,6 +90,7 @@ class BleBridgeService extends ChangeNotifier {
   Future<void> disconnect() async {
     // Explicit user disconnect — stop intending to be connected.
     _connectIntent = false;
+    _lastErrorMessage = null;
     await _connSub?.cancel();
     _connSub = null;
 

--- a/lib/services/ble_bridge_service.dart
+++ b/lib/services/ble_bridge_service.dart
@@ -88,9 +88,17 @@ class BleBridgeService extends ChangeNotifier {
   }
 
   Future<void> disconnect() async {
-    // Explicit user disconnect — stop intending to be connected.
+    // Explicit user disconnect — stop intending to be connected. Settle the
+    // visible state BEFORE awaiting the (slow) plugin disconnect, mirroring
+    // Module.bleDisconnect: a Cancel on a stuck "Connecting..." must read
+    // "Disconnected" immediately, not after the BLE teardown completes.
     _connectIntent = false;
     _lastErrorMessage = null;
+    _txChar = null;
+    connectionStateNotifier.value = BridgeConnectionState.disconnected;
+
+    // Cancel the connection-state listener before disconnecting so the
+    // teardown disconnect event can't drive any further status work.
     await _connSub?.cancel();
     _connSub = null;
 
@@ -99,9 +107,6 @@ class BleBridgeService extends ChangeNotifier {
     } catch (e) {
       debugPrint('BleBridge: disconnect error: $e');
     }
-
-    _txChar = null;
-    connectionStateNotifier.value = BridgeConnectionState.disconnected;
   }
 
   Future<void> disconnectAfterDrain({

--- a/lib/services/ble_bridge_service.dart
+++ b/lib/services/ble_bridge_service.dart
@@ -109,13 +109,20 @@ class BleBridgeService extends ChangeNotifier {
     }
   }
 
+  /// Drain-then-disconnect for the full-time teardown. [shouldAbort] is
+  /// re-checked while draining and once more before the disconnect: the drain
+  /// can hold this future for seconds, and a caller whose world moved on
+  /// meanwhile (e.g. a REPEAT started a new match) must be able to keep the
+  /// link instead of losing it to a stale teardown.
   Future<void> disconnectAfterDrain({
     Duration timeout = const Duration(seconds: 3),
+    bool Function()? shouldAbort,
   }) async {
     try {
       final deadline = DateTime.now().add(timeout);
       while ((_queue.isNotEmpty || _sendInProgress) &&
-          DateTime.now().isBefore(deadline)) {
+          DateTime.now().isBefore(deadline) &&
+          !(shouldAbort?.call() ?? false)) {
         final remaining = deadline.difference(DateTime.now());
         final delay = remaining < const Duration(milliseconds: 100)
             ? remaining
@@ -126,6 +133,8 @@ class BleBridgeService extends ChangeNotifier {
     } catch (e) {
       debugPrint('BleBridge: drain before disconnect failed: $e');
     }
+
+    if (shouldAbort?.call() ?? false) return;
 
     try {
       await disconnect();
@@ -197,14 +206,29 @@ class BleBridgeService extends ChangeNotifier {
   }
 
   Future<void> _onConnected() async {
+    // Re-check the connect intent after every await: the Cancel button is
+    // offered exactly while this setup phase runs (state `connecting`), and
+    // disconnect() cannot stop an already-running _onConnected — without
+    // these checks a resuming continuation would overwrite the user's settled
+    // "Disconnected" with `connected` (on a link disconnect() is tearing
+    // down) or `error`. Same reason Module.bleConnect re-checks
+    // !_connectIntent after its awaits.
+    if (!_connectIntent) return;
     try {
       try {
         await _device?.requestMtu(247);
       } catch (e) {
         debugPrint('BleBridge: MTU request failed: $e');
       }
+      if (!_connectIntent) return;
 
       final ready = await _discoverBridgeCharacteristic();
+      if (!_connectIntent) {
+        // A Cancel landed during discovery; drop the characteristic the
+        // discovery just installed so the service stays fully torn down.
+        _txChar = null;
+        return;
+      }
       if (!ready) {
         await _setErrorAndDisconnect(
             message: 'Scoreboard service not found on this device');
@@ -217,6 +241,7 @@ class BleBridgeService extends ChangeNotifier {
       await _processQueue();
     } catch (e) {
       debugPrint('BleBridge: initialization error: $e');
+      if (!_connectIntent) return;
       await _setErrorAndDisconnect(message: describeError(e).message);
     }
   }

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -14,6 +14,8 @@ enum MqttConnectionStateEx { disconnected, connecting, connected, error }
 
 const String _defaultMqttPassword = 'S_p-@P2_rL7ZFv9';
 const String _legacyMqttPasswordHint = 'S_p-@P2_rL7ZFv9XYZ';
+const String _defaultMqttServer =
+    'f2ec5c0344964af6a9b036e32a4f726c.s1.eu.hivemq.cloud';
 
 class MqttService {
   MqttServerClient? _client;
@@ -58,8 +60,7 @@ class MqttService {
     _autoConnect = prefs.getBool('mqtt_auto_connect') ?? false;
     _topic = prefs.getString('mqtt_topic') ?? '';
     _port = prefs.getInt('mqtt_port') ?? 8883;
-    _server = prefs.getString('mqtt_server') ??
-        'f2ec5c0344964af6a9b036e32a4f726c.s1.eu.hivemq.cloud';
+    _server = prefs.getString('mqtt_server') ?? _defaultMqttServer;
     _username = prefs.getString('mqtt_username') ?? 'RCj_soccer_2026';
     final storedPassword = prefs.getString('mqtt_password');
     if (storedPassword == _legacyMqttPasswordHint) {
@@ -194,6 +195,20 @@ class MqttService {
   Future<bool> _connect() async {
     if (_server.isEmpty || _port <= 0) {
       debugPrint('MQTT_LOGS::Error: Server or port not set.');
+      return false;
+    }
+
+    // Live-broker backstop (review #94): the shipped defaults are a WORKING
+    // production account, so an unseeded future test driving a match-load
+    // path would otherwise open a real TLS socket from CI and publish
+    // retained reset state onto a real field's topics. Refuse only under
+    // flutter_test AND only for the shipped production server — real devices
+    // never set FLUTTER_TEST, and tests against local/custom brokers (e.g.
+    // 127.0.0.1 in mqtt_service_test) stay fully functional.
+    if (Platform.environment.containsKey('FLUTTER_TEST') &&
+        _server == _defaultMqttServer) {
+      debugPrint(
+          'MQTT_LOGS::Refusing to dial the production broker from a test run');
       return false;
     }
 

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -19,6 +19,8 @@ class MqttService {
   MqttServerClient? _client;
   // The connect attempt currently in flight, if any (see connect()).
   Future<bool>? _pendingConnect;
+  // Bumped by disconnect(); invalidates connect() waiters parked before it.
+  int _connectEpoch = 0;
   final String _mainTopic = 'rcj_soccer'; // To store the configured topic
   String _topic = ''; // To store the configured topic
   bool _isEnabled = false; // To store the enabled state
@@ -162,8 +164,17 @@ class MqttService {
     // the public connecting state — the bounded reconnect loop in
     // _onDisconnected sets connectionStateNotifier to `connecting` before
     // each retry, so a state-based guard would turn every retry into a no-op.
+    // The epoch lets disconnect() veto waiters parked here BEFORE it ran:
+    // without it a queued retry (e.g. a reconnect-loop tick) would wake after
+    // a user/teardown disconnect and reconnect against that explicit intent.
+    // A caller arriving AFTER the disconnect captures the new epoch and
+    // proceeds — exactly the match-load handover case.
+    final epoch = _connectEpoch;
     while (_pendingConnect != null) {
       await _pendingConnect;
+      if (_connectEpoch != epoch) {
+        return false;
+      }
     }
     if (isConnected) {
       return true;
@@ -339,6 +350,9 @@ class MqttService {
   }
 
   void disconnect() {
+    // Veto any connect() waiters parked before this call (see connect()) —
+    // even when there is no client yet, an attempt may be mid-prefix.
+    _connectEpoch++;
     final client = _client;
     if (client == null) {
       return;

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -10,10 +10,10 @@ import 'package:rcj_scoreboard/models/team.dart';
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/services/error_messages.dart';
 
-
-
 enum MqttConnectionStateEx { disconnected, connecting, connected, error }
 
+const String _defaultMqttPassword = 'S_p-@P2_rL7ZFv9';
+const String _legacyMqttPasswordHint = 'S_p-@P2_rL7ZFv9XYZ';
 
 class MqttService {
   MqttServerClient? _client;
@@ -27,13 +27,15 @@ class MqttService {
   late bool _secureConnection; // To store the secure connection state
   late bool _autoConnect; // To store the auto-connect state
 
-  final String _clientIdentifier = 'client_${const Uuid().v4()}'; // Generate unique client ID
-  final ValueNotifier<MqttConnectionStateEx> connectionStateNotifier = ValueNotifier(MqttConnectionStateEx.disconnected);
+  final String _clientIdentifier =
+      'client_${const Uuid().v4()}'; // Generate unique client ID
+  final ValueNotifier<MqttConnectionStateEx> connectionStateNotifier =
+      ValueNotifier(MqttConnectionStateEx.disconnected);
   String _lastErrorMessage = '';
   late SharedPreferences prefs;
 
-  final StreamController<String> _messageStreamController = StreamController<
-      String>.broadcast();
+  final StreamController<String> _messageStreamController =
+      StreamController<String>.broadcast();
 
   Stream<String> get messageStream => _messageStreamController.stream;
 
@@ -45,15 +47,19 @@ class MqttService {
   Future<void> loadPreferences() async {
     prefs = await SharedPreferences.getInstance();
     _isEnabled = prefs.getBool('mqtt_enabled') ?? false;
-    _secureConnection = prefs.getBool('mqtt_secure_connection') ?? false;
+    _secureConnection = prefs.getBool('mqtt_secure_connection') ?? true;
     _autoConnect = prefs.getBool('mqtt_auto_connect') ?? false;
     _topic = prefs.getString('mqtt_topic') ?? '';
     _port = prefs.getInt('mqtt_port') ?? 8883;
-    _server = prefs.getString('mqtt_server') ?? 'f2ec5c0344964af6a9b036e32a4f726c.s1.eu.hivemq.cloud';
+    _server = prefs.getString('mqtt_server') ??
+        'f2ec5c0344964af6a9b036e32a4f726c.s1.eu.hivemq.cloud';
     _username = prefs.getString('mqtt_username') ?? 'RCj_soccer_2026';
-    _password = prefs.getString('mqtt_password') ?? 'S_p-@P2_rL7ZFv9XYZ';
+    final storedPassword = prefs.getString('mqtt_password');
+    if (storedPassword == _legacyMqttPasswordHint) {
+      await prefs.setString('mqtt_password', _defaultMqttPassword);
+    }
+    _password = prefs.getString('mqtt_password') ?? _defaultMqttPassword;
   }
-
 
   // Getters for server, port, username, and password
   String? get server => _server;
@@ -143,8 +149,11 @@ class MqttService {
   bool get isConnected =>
       _client?.connectionStatus?.state == MqttConnectionState.connected;
 
-
   Future<bool> connect() async {
+    if (connectionStateNotifier.value == MqttConnectionStateEx.connecting) {
+      return false;
+    }
+
     if (_server.isEmpty || _port <= 0) {
       debugPrint('MQTT_LOGS::Error: Server or port not set.');
       return false;
@@ -219,18 +228,17 @@ class MqttService {
         _client!.connectionStatus!.state == MqttConnectionState.connected) {
       final topicToPublish = specificTopic ?? _mainTopic;
       if (topicToPublish.isEmpty) {
-          debugPrint('MQTT_LOGS::Error: Topic not set for publishing.');
-          return;
+        debugPrint('MQTT_LOGS::Error: Topic not set for publishing.');
+        return;
       }
       final builder = MqttClientPayloadBuilder();
       builder.addString(message);
       _client!.publishMessage(
-          topicToPublish,
-          MqttQos.atLeastOnce,
-          builder.payload!,
+          topicToPublish, MqttQos.atLeastOnce, builder.payload!,
           retain: true // Set to true if you want the message to be retained
-      );
-      debugPrint('MQTT_LOGS::Published message: $message to topic: $topicToPublish');
+          );
+      debugPrint(
+          'MQTT_LOGS::Published message: $message to topic: $topicToPublish');
     }
   }
 
@@ -246,10 +254,11 @@ class MqttService {
     publishMessage(message, specificTopic: fullTopic);
   }
 
-
   /// Publishes the remaining time in MM:SS format to the 'time' topic.
   void publishTime(int remainingTime) {
-    publishCMMessage('${(remainingTime ~/ 60).toString().padLeft(2, '0')}:${(remainingTime % 60).toString().padLeft(2, '0')}', topic: 'time');
+    publishCMMessage(
+        '${(remainingTime ~/ 60).toString().padLeft(2, '0')}:${(remainingTime % 60).toString().padLeft(2, '0')}',
+        topic: 'time');
   }
 
   /// Publishes the score of both teams to their respective topics.
@@ -260,8 +269,14 @@ class MqttService {
 
   /// Publishes the score of a specific team to its topic.
   void publishTeamNames(List<Team> teams) {
-    publishCMMessage(teams[0].name.substring(0, teams[0].name.length > 20 ? 20 : teams[0].name.length), topic: "team1_name");
-    publishCMMessage(teams[1].name.substring(0, teams[1].name.length > 20 ? 20 : teams[1].name.length), topic: "team2_name");
+    publishCMMessage(
+        teams[0].name.substring(
+            0, teams[0].name.length > 20 ? 20 : teams[0].name.length),
+        topic: "team1_name");
+    publishCMMessage(
+        teams[1].name.substring(
+            0, teams[1].name.length > 20 ? 20 : teams[1].name.length),
+        topic: "team2_name");
   }
 
   void publishTeam(List<Team> teams) {
@@ -286,7 +301,6 @@ class MqttService {
 
     publishCMMessage(gameStageString, topic: 'game_stage');
   }
-
 
   void disconnect() {
     final client = _client;
@@ -325,20 +339,24 @@ class MqttService {
       return;
     }
     if (disconnectedClient.connectionStatus?.disconnectionOrigin ==
-            MqttDisconnectionOrigin.solicited) {
+        MqttDisconnectionOrigin.solicited) {
       _client = null;
-      debugPrint('MQTT_LOGS::Disconnected callback is solicited, not attempting reconnection');
+      debugPrint(
+          'MQTT_LOGS::Disconnected callback is solicited, not attempting reconnection');
       connectionStateNotifier.value = MqttConnectionStateEx.disconnected;
       return;
     }
     // Unintentional disconnect: try to reconnect with bounded retries.
     Future<void> attemptReconnect() async {
       int attempts = 0;
-      while (_isEnabled == true && _client != null && !isConnected &&
-             attempts < _maxReconnectAttempts) {
+      while (_isEnabled == true &&
+          _client != null &&
+          !isConnected &&
+          attempts < _maxReconnectAttempts) {
         attempts++;
         connectionStateNotifier.value = MqttConnectionStateEx.connecting;
-        debugPrint('MQTT_LOGS::Attempting to reconnect ($attempts/$_maxReconnectAttempts)...');
+        debugPrint(
+            'MQTT_LOGS::Attempting to reconnect ($attempts/$_maxReconnectAttempts)...');
         bool success = await connect();
         if (success) break;
         // Don't wait after the final failed attempt: the trailing delay would
@@ -352,11 +370,14 @@ class MqttService {
       // Only report exhaustion if this reconnect session is still active: a
       // user disable (_isEnabled == false) or solicited disconnect
       // (_client == null) during the loop must not be flipped back into error.
-      if (_isEnabled == true && _client != null && !isConnected &&
+      if (_isEnabled == true &&
+          _client != null &&
+          !isConnected &&
           attempts >= _maxReconnectAttempts) {
         // Preserve the specific cause connect() recorded on the last attempt
         // instead of hiding it behind a generic message.
-        final cause = _lastErrorMessage.isNotEmpty ? ' ($_lastErrorMessage)' : '';
+        final cause =
+            _lastErrorMessage.isNotEmpty ? ' ($_lastErrorMessage)' : '';
         _lastErrorMessage =
             'Reconnection failed after $_maxReconnectAttempts attempts$cause';
         connectionStateNotifier.value = MqttConnectionStateEx.error;

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -17,6 +17,8 @@ const String _legacyMqttPasswordHint = 'S_p-@P2_rL7ZFv9XYZ';
 
 class MqttService {
   MqttServerClient? _client;
+  // True while a connect() call is in flight (see the re-entrancy guard).
+  bool _connectInFlight = false;
   final String _mainTopic = 'rcj_soccer'; // To store the configured topic
   String _topic = ''; // To store the configured topic
   bool _isEnabled = false; // To store the enabled state
@@ -150,10 +152,23 @@ class MqttService {
       _client?.connectionStatus?.state == MqttConnectionState.connected;
 
   Future<bool> connect() async {
-    if (connectionStateNotifier.value == MqttConnectionStateEx.connecting) {
+    // Re-entrancy guard (#88): an auto-connect and a manual tap must not stack
+    // clients. Guard on an internal in-flight flag, NOT on the public
+    // connecting state — the bounded reconnect loop in _onDisconnected sets
+    // connectionStateNotifier to `connecting` before each retry, so a
+    // state-based guard would turn every retry into a no-op.
+    if (_connectInFlight) {
       return false;
     }
+    _connectInFlight = true;
+    try {
+      return await _connect();
+    } finally {
+      _connectInFlight = false;
+    }
+  }
 
+  Future<bool> _connect() async {
     if (_server.isEmpty || _port <= 0) {
       debugPrint('MQTT_LOGS::Error: Server or port not set.');
       return false;

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -152,21 +152,25 @@ class MqttService {
 
     connectionStateNotifier.value = MqttConnectionStateEx.connecting;
 
+    final client = MqttServerClient.withPort(_server, _clientIdentifier, _port);
+    _client = client;
+    client.logging(
+        on: false); // Disable logging for production, enable for debugging
 
-    _client = MqttServerClient.withPort(_server, _clientIdentifier, _port);
-    _client!.logging(on: false); // Disable logging for production, enable for debugging
-
-
-    _client!.keepAlivePeriod = 300;
+    client.keepAlivePeriod = 300;
     // Capture the current connection in the callback closures so a stale
     // callback from a previous connect() can never read a newer _client.
-    final capturedClient = _client!;
-    _client!.onDisconnected = () => _onDisconnected(capturedClient);
-    _client!.onConnected = _onConnected;
-    _client!.onSubscribed = _onSubscribed;
-    _client!.pongCallback = _pong; // Optional: for keep alive
+    final capturedClient = client;
+    client.onDisconnected = () => _onDisconnected(capturedClient);
+    client.onConnected = () {
+      if (identical(_client, capturedClient)) {
+        _onConnected();
+      }
+    };
+    client.onSubscribed = _onSubscribed;
+    client.pongCallback = _pong; // Optional: for keep alive
 
-    _client!.secure = _secureConnection;
+    client.secure = _secureConnection;
 
     final connMess = MqttConnectMessage()
         .withClientIdentifier(_clientIdentifier)
@@ -175,29 +179,35 @@ class MqttService {
         .startClean()
         .withWillQos(MqttQos.atLeastOnce);
 
-    _client!.connectionMessage = connMess;
+    client.connectionMessage = connMess;
 
     try {
       debugPrint('MQTT_LOGS::Connecting to $_server:$_port...');
-      await _client!.connect(_username, _password); // Pass username/password again here for some brokers
+      await client.connect(_username,
+          _password); // Pass username/password again here for some brokers
     } on NoConnectionException catch (e) {
+      if (!identical(_client, client)) return false;
       debugPrint('MQTT_LOGS::Client exception - $e');
       _lastErrorMessage = 'Network error: Unable to connect';
       connectionStateNotifier.value = MqttConnectionStateEx.error;
     } on SocketException catch (e) {
+      if (!identical(_client, client)) return false;
       debugPrint('MQTT_LOGS::Socket exception - $e');
       _lastErrorMessage = 'Connection failed: ${e.message}';
       connectionStateNotifier.value = MqttConnectionStateEx.error;
     }
 
-    if (_client!.connectionStatus!.state == MqttConnectionState.connected) {
+    if (!identical(_client, client)) return false;
+
+    if (client.connectionStatus?.state == MqttConnectionState.connected) {
       debugPrint('MQTT_LOGS::Mosquitto client connected');
       return true;
     } else {
-      debugPrint('MQTT_LOGS::ERROR Mosquitto client connection failed - disconnecting, status is ${_client!.connectionStatus}');
-      final status = _client!.connectionStatus!;
+      debugPrint(
+          'MQTT_LOGS::ERROR Mosquitto client connection failed - disconnecting, status is ${client.connectionStatus}');
+      final status = client.connectionStatus;
       _lastErrorMessage = describeMqttReturnCode(
-          status.returnCode ?? MqttConnectReturnCode.noneSpecified);
+          status?.returnCode ?? MqttConnectReturnCode.noneSpecified);
       connectionStateNotifier.value = MqttConnectionStateEx.error;
       return false;
     }
@@ -279,10 +289,18 @@ class MqttService {
 
 
   void disconnect() {
-    if (_client != null) {
-      debugPrint('MQTT_LOGS::Disconnecting client');
-      _client!.disconnect();
+    final client = _client;
+    if (client == null) {
+      return;
     }
+    _client = null;
+    debugPrint('MQTT_LOGS::Disconnecting client');
+    try {
+      client.disconnect();
+    } catch (e) {
+      debugPrint('MQTT_LOGS::Disconnect error - $e');
+    }
+    connectionStateNotifier.value = MqttConnectionStateEx.disconnected;
   }
 
   void _onConnected() {

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -50,7 +50,10 @@ class MqttService {
   /// Loads MQTT settings from SharedPreferences
   Future<void> loadPreferences() async {
     prefs = await SharedPreferences.getInstance();
-    _isEnabled = prefs.getBool('mqtt_enabled') ?? false;
+    // Working defaults (#88): enabled ships ON so a fresh install's deep-link
+    // match load can auto-connect with zero referee taps. An explicit disable
+    // in Settings writes false and is honored (the setter persists it).
+    _isEnabled = prefs.getBool('mqtt_enabled') ?? true;
     _secureConnection = prefs.getBool('mqtt_secure_connection') ?? true;
     _autoConnect = prefs.getBool('mqtt_auto_connect') ?? false;
     _topic = prefs.getString('mqtt_topic') ?? '';

--- a/lib/services/mqtt.dart
+++ b/lib/services/mqtt.dart
@@ -17,8 +17,8 @@ const String _legacyMqttPasswordHint = 'S_p-@P2_rL7ZFv9XYZ';
 
 class MqttService {
   MqttServerClient? _client;
-  // True while a connect() call is in flight (see the re-entrancy guard).
-  bool _connectInFlight = false;
+  // The connect attempt currently in flight, if any (see connect()).
+  Future<bool>? _pendingConnect;
   final String _mainTopic = 'rcj_soccer'; // To store the configured topic
   String _topic = ''; // To store the configured topic
   bool _isEnabled = false; // To store the enabled state
@@ -152,19 +152,28 @@ class MqttService {
       _client?.connectionStatus?.state == MqttConnectionState.connected;
 
   Future<bool> connect() async {
-    // Re-entrancy guard (#88): an auto-connect and a manual tap must not stack
-    // clients. Guard on an internal in-flight flag, NOT on the public
-    // connecting state — the bounded reconnect loop in _onDisconnected sets
-    // connectionStateNotifier to `connecting` before each retry, so a
-    // state-based guard would turn every retry into a no-op.
-    if (_connectInFlight) {
-      return false;
+    // Re-entrancy handling (#88): an auto-connect and a manual tap must not
+    // stack clients, but a caller must not be silently dropped either — a
+    // match-load connect can race a connect attempt that a full-time teardown
+    // (#87) just cancelled, and a plain "return false while in flight" would
+    // leave the new match with MQTT down and no retry. So SERIALIZE: wait for
+    // any in-flight attempt to settle, then run a fresh one unless it already
+    // produced a live connection. Keyed on an internal pending future, NOT on
+    // the public connecting state — the bounded reconnect loop in
+    // _onDisconnected sets connectionStateNotifier to `connecting` before
+    // each retry, so a state-based guard would turn every retry into a no-op.
+    while (_pendingConnect != null) {
+      await _pendingConnect;
     }
-    _connectInFlight = true;
+    if (isConnected) {
+      return true;
+    }
+    final attempt = _connect();
+    _pendingConnect = attempt;
     try {
-      return await _connect();
+      return await attempt;
     } finally {
-      _connectInFlight = false;
+      _pendingConnect = null;
     }
   }
 
@@ -218,6 +227,18 @@ class MqttService {
       if (!identical(_client, client)) return false;
       debugPrint('MQTT_LOGS::Socket exception - $e');
       _lastErrorMessage = 'Connection failed: ${e.message}';
+      connectionStateNotifier.value = MqttConnectionStateEx.error;
+    } on Exception catch (e) {
+      // mqtt_client wraps most secure-connect failures in
+      // NoConnectionException, but its socket onError paths can complete the
+      // awaited future with the raw exception (e.g. a HandshakeException).
+      // connect() is now also called unawaited from the match-load hook, so
+      // an escaped exception would surface as an uncaught async error and pin
+      // the status at "Connecting..." forever. Map anything Exception-shaped
+      // to the error state; real programming errors (Error) still propagate.
+      if (!identical(_client, client)) return false;
+      debugPrint('MQTT_LOGS::Unexpected connect exception - $e');
+      _lastErrorMessage = describeError(e).message;
       connectionStateNotifier.value = MqttConnectionStateEx.error;
     }
 

--- a/test/bridge_message_test.dart
+++ b/test/bridge_message_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rcj_scoreboard/models/bridge_message.dart';
+import 'package:rcj_scoreboard/screens/settings.dart';
 import 'package:rcj_scoreboard/services/ble_bridge_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -54,6 +55,31 @@ void main() {
     });
   });
 
+  group('Bridge connection button label (#86)', () {
+    test('maps all bridge states to the Settings button text', () {
+      expect(
+        bridgeConnectionButtonLabel(BridgeConnectionState.connected),
+        'Disconnect',
+      );
+      expect(
+        bridgeConnectionButtonLabel(BridgeConnectionState.connecting),
+        'Cancel',
+      );
+      expect(
+        bridgeConnectionButtonLabel(BridgeConnectionState.disabled),
+        'Connect',
+      );
+      expect(
+        bridgeConnectionButtonLabel(BridgeConnectionState.disconnected),
+        'Connect',
+      );
+      expect(
+        bridgeConnectionButtonLabel(BridgeConnectionState.error),
+        'Connect',
+      );
+    });
+  });
+
   group('BleBridgeService queue (disconnected — no BLE writes)', () {
     // When the service is enabled but not connected, publishTopic enqueues and
     // dedups, while _processQueue returns at its !isConnected guard before ever
@@ -69,7 +95,8 @@ void main() {
       return svc;
     }
 
-    test('same topic dedups to a single queued message (latest wins)', () async {
+    test('same topic dedups to a single queued message (latest wins)',
+        () async {
       final svc = await makeEnabledService();
 
       svc.publishTopic(BridgeTopics.team1Score, '1');
@@ -114,6 +141,42 @@ void main() {
       svc.publishTopic(BridgeTopics.team1Score, '1');
 
       expect(svc.queueDepthNotifier.value, 0);
+    });
+  });
+
+  group('BleBridgeService connection lifecycle (#86)', () {
+    test('disconnect cancels a connecting bridge without a device', () async {
+      SharedPreferences.setMockInitialValues({});
+      final svc = BleBridgeService();
+      await svc.loadPreferences();
+
+      svc.connectionStateNotifier.value = BridgeConnectionState.connecting;
+
+      await svc.disconnect();
+
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      expect(svc.lastErrorMessage, isNull);
+    });
+
+    test('connect with empty bridge address leaves state unchanged', () async {
+      SharedPreferences.setMockInitialValues({});
+      final svc = BleBridgeService();
+      await svc.loadPreferences();
+      expect(svc.bridgeMacAddress, isEmpty);
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+
+      await svc.connect();
+
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
     });
   });
 }

--- a/test/bridge_message_test.dart
+++ b/test/bridge_message_test.dart
@@ -213,6 +213,30 @@ void main() {
       await pending;
     });
 
+    test('cancel during the pre-connect gap never starts the OS autoConnect',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final svc = BleBridgeService();
+      await svc.loadPreferences();
+      svc.bridgeMacAddress = 'AA:BB:CC:DD:EE:FF';
+
+      // connect() suspends at its pre-connect await; the Cancel lands in
+      // that gap. The resumed connect() must bail out instead of registering
+      // the subscriber / starting autoConnect — otherwise the OS would hold
+      // or chase the single-central bridge while the UI reads Disconnected.
+      // (In this headless VM a non-bailing connect() would surface as the
+      // `error` state via the MissingPluginException path.)
+      final pending = svc.connect();
+      await svc.disconnect();
+      await pending;
+
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      expect(svc.lastErrorMessage, isNull);
+    });
+
     test('connect with empty bridge address leaves state unchanged', () async {
       SharedPreferences.setMockInitialValues({});
       final svc = BleBridgeService();

--- a/test/bridge_message_test.dart
+++ b/test/bridge_message_test.dart
@@ -178,6 +178,24 @@ void main() {
       expect(svc.lastErrorMessage, isNull);
     });
 
+    test('disconnect settles the visible state before the BLE teardown',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final svc = BleBridgeService();
+      await svc.loadPreferences();
+      svc.connectionStateNotifier.value = BridgeConnectionState.connecting;
+
+      // Cancel must read "Disconnected" immediately (the plugin disconnect
+      // can take seconds on Android) — the state settles in the synchronous
+      // prefix of disconnect(), before its first await.
+      final pending = svc.disconnect();
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      await pending;
+    });
+
     test('connect with empty bridge address leaves state unchanged', () async {
       SharedPreferences.setMockInitialValues({});
       final svc = BleBridgeService();

--- a/test/bridge_message_test.dart
+++ b/test/bridge_message_test.dart
@@ -159,6 +159,23 @@ void main() {
       );
       expect(svc.queueDepthNotifier.value, 1);
     });
+
+    test('disconnectAfterDrain honors shouldAbort and keeps the link',
+        () async {
+      final svc = await makeEnabledService();
+      svc.connectionStateNotifier.value = BridgeConnectionState.connecting;
+      svc.publishTopic(BridgeTopics.team1Score, '1');
+
+      // A stale full-time teardown (REPEAT/Load started a new match mid-
+      // drain) must not disconnect: the abort is honored both inside the
+      // drain wait and before the final disconnect.
+      await svc.disconnectAfterDrain(shouldAbort: () => true);
+
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.connecting,
+      );
+    });
   });
 
   group('BleBridgeService connection lifecycle (#86)', () {

--- a/test/bridge_message_test.dart
+++ b/test/bridge_message_test.dart
@@ -142,6 +142,23 @@ void main() {
 
       expect(svc.queueDepthNotifier.value, 0);
     });
+
+    test('disconnectAfterDrain is bounded when a queue cannot drain', () async {
+      final svc = await makeEnabledService();
+
+      svc.publishTopic(BridgeTopics.team1Score, '1');
+      expect(svc.queueDepthNotifier.value, 1);
+
+      await svc.disconnectAfterDrain(
+        timeout: const Duration(milliseconds: 200),
+      );
+
+      expect(
+        svc.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      expect(svc.queueDepthNotifier.value, 1);
+    });
   });
 
   group('BleBridgeService connection lifecycle (#86)', () {

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -19,7 +19,78 @@ import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/models/team.dart';
 import 'package:rcj_scoreboard/screens/home.dart';
+import 'package:rcj_scoreboard/services/ble_bridge_service.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
+import 'package:rcj_scoreboard/services/mqtt.dart';
+
+class _RecordingMqttService extends MqttService {
+  _RecordingMqttService(
+    this.log, {
+    MqttConnectionStateEx initialState = MqttConnectionStateEx.connected,
+  }) {
+    connectionStateNotifier.value = initialState;
+  }
+
+  final List<String> log;
+  int connectCalls = 0;
+  int disconnectCalls = 0;
+
+  @override
+  bool get isEnabled => true;
+
+  @override
+  bool get isConnected =>
+      connectionStateNotifier.value == MqttConnectionStateEx.connected;
+
+  @override
+  Future<bool> connect() async {
+    connectCalls++;
+    log.add('mqtt:connect');
+    connectionStateNotifier.value = MqttConnectionStateEx.connected;
+    return true;
+  }
+
+  @override
+  void publishGameState(MatchStage state) {
+    log.add('mqtt:publishGameState:${state.name}');
+  }
+
+  @override
+  void publishTime(int remainingTime) {
+    log.add('mqtt:publishTime:$remainingTime');
+  }
+
+  @override
+  void disconnect() {
+    disconnectCalls++;
+    log.add('mqtt:disconnect');
+    connectionStateNotifier.value = MqttConnectionStateEx.disconnected;
+  }
+}
+
+class _RecordingBleBridgeService extends BleBridgeService {
+  _RecordingBleBridgeService(this.log);
+
+  final List<String> log;
+  int connectCalls = 0;
+  int disconnectAfterDrainCalls = 0;
+
+  @override
+  Future<void> connect() async {
+    connectCalls++;
+    log.add('bridge:connect');
+    connectionStateNotifier.value = BridgeConnectionState.connected;
+  }
+
+  @override
+  Future<void> disconnectAfterDrain({
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    disconnectAfterDrainCalls++;
+    log.add('bridge:disconnectAfterDrain');
+    connectionStateNotifier.value = BridgeConnectionState.disconnected;
+  }
+}
 
 ModuleSnapshot _moduleSnap({
   required int id,
@@ -2287,6 +2358,151 @@ void main() {
       expect(game.inGame, isFalse);
 
       await tester.pump(const Duration(milliseconds: 1500));
+      game.dispose();
+    });
+  });
+
+  group('transport teardown at full time (#87)', () {
+    Future<Game> loadScoreboardFixture(
+      WidgetTester tester, {
+      String matchCode = 'M-87',
+      int version = 1,
+    }) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: matchCode, version: version),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      return game;
+    }
+
+    Future<void> pumpPastTransportTeardownDelay(WidgetTester tester) async {
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+    }
+
+    testWidgets(
+        'tears down connected bridge and MQTT after the final full-time publish',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final mqtt = _RecordingMqttService(log);
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connected;
+      game.mqttService = mqtt;
+      game.bleBridgeService = bridge;
+
+      game.endMatchEarly();
+      expect(game.currentStage, MatchStage.fullTime);
+
+      await pumpPastTransportTeardownDelay(tester);
+
+      expect(bridge.disconnectAfterDrainCalls, 1);
+      expect(mqtt.disconnectCalls, 1);
+      final publishIndex = log.indexOf('mqtt:publishGameState:fullTime');
+      final disconnectIndex = log.indexOf('mqtt:disconnect');
+      expect(publishIndex, isNonNegative);
+      expect(disconnectIndex, isNonNegative);
+      expect(publishIndex, lessThan(disconnectIndex));
+
+      game.dispose();
+    });
+
+    testWidgets('never-connected transports are no-ops at full time',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.disconnected;
+      final mqtt = MqttService();
+      await mqtt.loadPreferences();
+      expect(
+        mqtt.connectionStateNotifier.value,
+        MqttConnectionStateEx.disconnected,
+      );
+      game.bleBridgeService = bridge;
+      game.mqttService = mqtt;
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+
+      expect(bridge.disconnectAfterDrainCalls, 0);
+      expect(
+        mqtt.connectionStateNotifier.value,
+        MqttConnectionStateEx.disconnected,
+      );
+
+      game.dispose();
+    });
+
+    testWidgets('REPEAT before the teardown delay cancels stale disconnects',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final mqtt = _RecordingMqttService(log);
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connected;
+      game.mqttService = mqtt;
+      game.bleBridgeService = bridge;
+
+      game.endMatchEarly();
+      expect(game.currentStage, MatchStage.fullTime);
+      game.toggleTimer();
+      expect(game.currentStage, MatchStage.firstHalf);
+
+      await pumpPastTransportTeardownDelay(tester);
+
+      expect(bridge.disconnectAfterDrainCalls, 0);
+      expect(mqtt.disconnectCalls, 0);
+
+      game.dispose();
+    });
+
+    testWidgets(
+        'REPEAT does not reconnect transports and allows the next teardown',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final mqtt = _RecordingMqttService(log);
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connected;
+      game.mqttService = mqtt;
+      game.bleBridgeService = bridge;
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+      expect(bridge.disconnectAfterDrainCalls, 1);
+      expect(mqtt.disconnectCalls, 1);
+
+      game.toggleTimer();
+      expect(game.currentStage, MatchStage.firstHalf);
+      expect(bridge.connectCalls, 0);
+      expect(mqtt.connectCalls, 0);
+      expect(
+        bridge.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      expect(
+        mqtt.connectionStateNotifier.value,
+        MqttConnectionStateEx.disconnected,
+      );
+
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connected;
+      mqtt.connectionStateNotifier.value = MqttConnectionStateEx.connected;
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+
+      expect(bridge.disconnectAfterDrainCalls, 2);
+      expect(mqtt.disconnectCalls, 2);
+      expect(bridge.connectCalls, 0);
+      expect(mqtt.connectCalls, 0);
+
       game.dispose();
     });
   });

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -264,6 +264,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
     await prefs.clear();
+    // MQTT ships enabled by default (#88); these suites drive Game with the
+    // REAL MqttService, so seed the explicit disable or every config apply
+    // fires a real network connect and leaks timers into the test binding.
+    await prefs.setBool('mqtt_enabled', false);
   });
 
   Future<void> persist(MatchSnapshot snapshot) async {

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -26,21 +26,40 @@ import 'package:rcj_scoreboard/services/mqtt.dart';
 class _RecordingMqttService extends MqttService {
   _RecordingMqttService(
     this.log, {
+    this.enabled = true,
     MqttConnectionStateEx initialState = MqttConnectionStateEx.connected,
   }) {
     connectionStateNotifier.value = initialState;
   }
 
   final List<String> log;
+  final bool enabled;
+  String _topic = '';
   int connectCalls = 0;
   int disconnectCalls = 0;
 
   @override
-  bool get isEnabled => true;
+  bool get isEnabled => enabled;
 
   @override
   bool get isConnected =>
       connectionStateNotifier.value == MqttConnectionStateEx.connected;
+
+  @override
+  String get topic => _topic;
+
+  @override
+  String get fieldNumber => _topic.replaceFirst('field_', '');
+
+  @override
+  set topic(String value) {
+    if (value.isNotEmpty) _topic = value;
+  }
+
+  @override
+  set topicField(String value) {
+    topic = 'field_$value';
+  }
 
   @override
   Future<bool> connect() async {
@@ -2503,6 +2522,135 @@ void main() {
       expect(bridge.connectCalls, 0);
       expect(mqtt.connectCalls, 0);
 
+      game.dispose();
+    });
+  });
+
+  group('mqtt auto-connect on match load (#88)', () {
+    Future<Game> gameWithRecordingMqtt(
+      WidgetTester tester, {
+      bool enabled = true,
+      MqttConnectionStateEx initialState = MqttConnectionStateEx.disconnected,
+    }) async {
+      final game = Game();
+      await settleLoad(tester);
+      game.mqttService = _RecordingMqttService(
+        <String>[],
+        enabled: enabled,
+        initialState: initialState,
+      );
+      return game;
+    }
+
+    void applyConfig(
+      Game game, {
+      String matchCode = 'M-88',
+      int version = 1,
+    }) {
+      game.scoreboardResultService.debugApplyMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: matchCode, version: version),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+    }
+
+    Future<void> pumpPastTransportTeardownDelay(WidgetTester tester) async {
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+    }
+
+    testWidgets('enabled disconnected MQTT connects on fresh fixture apply',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      game.dispose();
+    });
+
+    testWidgets('deduped same fixture does not connect again', (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+      applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      game.dispose();
+    });
+
+    testWidgets('disabled MQTT is not auto-connected', (tester) async {
+      final game = await gameWithRecordingMqtt(tester, enabled: false);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 0);
+      game.dispose();
+    });
+
+    testWidgets(
+        'same-fixture full-time version bump after teardown does not reconnect',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+      expect(mqtt.connectCalls, 1);
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(
+        mqtt.connectionStateNotifier.value,
+        MqttConnectionStateEx.disconnected,
+      );
+
+      applyConfig(game, version: 2);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      game.dispose();
+    });
+
+    testWidgets('confirmed new-fixture Load at full time reconnects',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game, matchCode: 'M-88-A');
+      await tester.pump();
+      expect(mqtt.connectCalls, 1);
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+      expect(game.currentStage, MatchStage.fullTime);
+      expect(
+        mqtt.connectionStateNotifier.value,
+        MqttConnectionStateEx.disconnected,
+      );
+
+      game.scoreboardResultService.debugApplyPendingMatchConfig(
+        ScoreboardMatchConfig.fromJson(
+          _scoreboardConfig(matchCode: 'M-88-B', version: 1),
+        ),
+        token: 'test-token',
+        baseUri: Uri.parse('http://127.0.0.1:9'),
+      );
+      await tester.pump();
+      await game.confirmScoreboardMatch();
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 2);
       game.dispose();
     });
   });

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -8,6 +8,7 @@
 // delays) by either not starting the clock or cancelling/draining it before the
 // test returns.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -101,12 +102,20 @@ class _RecordingBleBridgeService extends BleBridgeService {
     connectionStateNotifier.value = BridgeConnectionState.connected;
   }
 
+  // When set, disconnectAfterDrain blocks on it — lets a test hold the
+  // teardown "mid-drain" and race a REPEAT/Load against it.
+  Completer<void>? drainGate;
+
   @override
   Future<void> disconnectAfterDrain({
     Duration timeout = const Duration(seconds: 3),
   }) async {
     disconnectAfterDrainCalls++;
     log.add('bridge:disconnectAfterDrain');
+    final gate = drainGate;
+    if (gate != null) {
+      await gate.future;
+    }
     connectionStateNotifier.value = BridgeConnectionState.disconnected;
   }
 }
@@ -2524,6 +2533,38 @@ void main() {
 
       game.dispose();
     });
+
+    testWidgets('REPEAT mid-drain does not disconnect the new match MQTT',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final mqtt = _RecordingMqttService(log);
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connected;
+      bridge.drainGate = Completer<void>();
+      game.mqttService = mqtt;
+      game.bleBridgeService = bridge;
+
+      game.endMatchEarly();
+      // Past the 1 s delay: the teardown is now blocked inside the bridge
+      // drain (the longest real window — up to 3 s when a bridge is live).
+      await pumpPastTransportTeardownDelay(tester);
+      expect(bridge.disconnectAfterDrainCalls, 1);
+      expect(mqtt.disconnectCalls, 0);
+
+      // REPEAT lands mid-drain: a new match starts (gameInit re-arms the
+      // teardown epoch), then the drain finally completes.
+      game.toggleTimer();
+      expect(game.currentStage, MatchStage.firstHalf);
+      bridge.drainGate!.complete();
+      await tester.pump();
+      await tester.pump();
+
+      // The stale teardown must not touch the new match's MQTT session.
+      expect(mqtt.disconnectCalls, 0);
+
+      game.dispose();
+    });
   });
 
   group('mqtt auto-connect on match load (#88)', () {
@@ -2570,6 +2611,28 @@ void main() {
       await tester.pump();
 
       expect(mqtt.connectCalls, 1);
+      game.dispose();
+    });
+
+    testWidgets('successful auto-connect rebroadcasts the loaded match state',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+
+      // The load path's gameInit() broadcasts ran while MQTT was still
+      // disconnected (dropped), so the hook must rebroadcast after the
+      // connect succeeds — otherwise the new field_N keeps the previous
+      // match's retained data until the first in-match event.
+      final connectIndex = mqtt.log.indexOf('mqtt:connect');
+      final stateIndex =
+          mqtt.log.lastIndexOf('mqtt:publishGameState:firstHalf');
+      expect(connectIndex, isNonNegative);
+      expect(stateIndex, isNonNegative);
+      expect(stateIndex, greaterThan(connectIndex));
+
       game.dispose();
     });
 

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -28,6 +28,7 @@ class _RecordingMqttService extends MqttService {
   _RecordingMqttService(
     this.log, {
     this.enabled = true,
+    this.throwOnConnect = false,
     MqttConnectionStateEx initialState = MqttConnectionStateEx.connected,
   }) {
     connectionStateNotifier.value = initialState;
@@ -35,6 +36,7 @@ class _RecordingMqttService extends MqttService {
 
   final List<String> log;
   final bool enabled;
+  final bool throwOnConnect;
   String _topic = '';
   int connectCalls = 0;
   int disconnectCalls = 0;
@@ -66,6 +68,9 @@ class _RecordingMqttService extends MqttService {
   Future<bool> connect() async {
     connectCalls++;
     log.add('mqtt:connect');
+    if (throwOnConnect) {
+      throw Exception('broker exploded');
+    }
     connectionStateNotifier.value = MqttConnectionStateEx.connected;
     return true;
   }
@@ -109,12 +114,18 @@ class _RecordingBleBridgeService extends BleBridgeService {
   @override
   Future<void> disconnectAfterDrain({
     Duration timeout = const Duration(seconds: 3),
+    bool Function()? shouldAbort,
   }) async {
     disconnectAfterDrainCalls++;
     log.add('bridge:disconnectAfterDrain');
     final gate = drainGate;
     if (gate != null) {
       await gate.future;
+    }
+    // Mirror the real service: a caller-side abort keeps the link.
+    if (shouldAbort?.call() ?? false) {
+      log.add('bridge:drainAborted');
+      return;
     }
     connectionStateNotifier.value = BridgeConnectionState.disconnected;
   }
@@ -2560,8 +2571,41 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      // The stale teardown must not touch the new match's MQTT session.
+      // The stale teardown must keep the bridge (drain aborts) and must not
+      // touch the new match's MQTT session.
+      expect(
+        bridge.connectionStateNotifier.value,
+        BridgeConnectionState.connected,
+      );
+      expect(log, contains('bridge:drainAborted'));
       expect(mqtt.disconnectCalls, 0);
+
+      game.dispose();
+    });
+
+    testWidgets(
+        'a still-connecting bridge is disconnected without burning the drain',
+        (tester) async {
+      final game = await loadScoreboardFixture(tester);
+      final log = <String>[];
+      final mqtt = _RecordingMqttService(log);
+      final bridge = _RecordingBleBridgeService(log);
+      bridge.connectionStateNotifier.value = BridgeConnectionState.connecting;
+      game.mqttService = mqtt;
+      game.bleBridgeService = bridge;
+
+      game.endMatchEarly();
+      await pumpPastTransportTeardownDelay(tester);
+
+      // A connecting bridge cannot drain its queue (sends require a live
+      // link), so the teardown must take the plain-disconnect path instead of
+      // pinning itself at the drain timeout.
+      expect(bridge.disconnectAfterDrainCalls, 0);
+      expect(
+        bridge.connectionStateNotifier.value,
+        BridgeConnectionState.disconnected,
+      );
+      expect(mqtt.disconnectCalls, 1);
 
       game.dispose();
     });
@@ -2571,6 +2615,7 @@ void main() {
     Future<Game> gameWithRecordingMqtt(
       WidgetTester tester, {
       bool enabled = true,
+      bool throwOnConnect = false,
       MqttConnectionStateEx initialState = MqttConnectionStateEx.disconnected,
     }) async {
       final game = Game();
@@ -2578,6 +2623,7 @@ void main() {
       game.mqttService = _RecordingMqttService(
         <String>[],
         enabled: enabled,
+        throwOnConnect: throwOnConnect,
         initialState: initialState,
       );
       return game;
@@ -2657,6 +2703,21 @@ void main() {
       await tester.pump();
 
       expect(mqtt.connectCalls, 0);
+      game.dispose();
+    });
+
+    testWidgets('a throwing connect does not crash the load path',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester, throwOnConnect: true);
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      // An exception escaping the fire-and-forget hook would surface as an
+      // uncaught async error and fail this test via the widget binding.
+      applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      expect(game.currentStage, MatchStage.firstHalf);
       game.dispose();
     });
 

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -15,6 +15,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'helpers/mqtt_guard.dart';
+
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/module.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
@@ -158,13 +160,14 @@ Map<String, dynamic> _scoreboardConfig({
   int durationSeconds = 600,
   String homeTeamName = 'Home',
   String awayTeamName = 'Away',
+  String venue = 'Field 1',
 }) =>
     {
       'match_code': matchCode,
       'home_team': homeTeamName,
       'away_team': awayTeamName,
       'home_is_left': homeIsLeft,
-      'venue': 'Field 1',
+      'venue': venue,
       'scheduled_start': null,
       'duration_seconds': durationSeconds,
       'timezone': 'Europe/Prague',
@@ -264,10 +267,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
     await prefs.clear();
-    // MQTT ships enabled by default (#88); these suites drive Game with the
-    // REAL MqttService, so seed the explicit disable or every config apply
-    // fires a real network connect and leaks timers into the test binding.
-    await prefs.setBool('mqtt_enabled', false);
+    await seedMqttDisabledForGameTests();
   });
 
   Future<void> persist(MatchSnapshot snapshot) async {
@@ -2637,10 +2637,12 @@ void main() {
       Game game, {
       String matchCode = 'M-88',
       int version = 1,
+      String venue = 'Field 1',
     }) {
       game.scoreboardResultService.debugApplyMatchConfig(
         ScoreboardMatchConfig.fromJson(
-          _scoreboardConfig(matchCode: matchCode, version: version),
+          _scoreboardConfig(
+              matchCode: matchCode, version: version, venue: venue),
         ),
         token: 'test-token',
         baseUri: Uri.parse('http://127.0.0.1:9'),
@@ -2693,6 +2695,37 @@ void main() {
       applyConfig(game);
       await tester.pump();
       applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      game.dispose();
+    });
+
+    testWidgets(
+        'a no-digit venue with no configured field does not auto-connect',
+        (tester) async {
+      // Review #94: with an empty topic the rebroadcast would land RETAINED
+      // state on the venue-shared rcj_soccer/* base namespace ("Center
+      // Court" is a supported no-digit venue, #50).
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+      expect(mqtt.topic, isEmpty);
+
+      applyConfig(game, venue: 'Center Court');
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 0);
+      game.dispose();
+    });
+
+    testWidgets(
+        'a no-digit venue still auto-connects when a field is configured',
+        (tester) async {
+      final game = await gameWithRecordingMqtt(tester);
+      final mqtt = game.mqttService as _RecordingMqttService;
+      mqtt.topicField = '3';
+
+      applyConfig(game, venue: 'Center Court');
       await tester.pump();
 
       expect(mqtt.connectCalls, 1);

--- a/test/game_recovery_test.dart
+++ b/test/game_recovery_test.dart
@@ -2706,6 +2706,30 @@ void main() {
       game.dispose();
     });
 
+    testWidgets(
+        'auto-connect proceeds and rebroadcasts while the state reads '
+        'connecting', (tester) async {
+      // The bounded reconnect loop pins the public state at `connecting`
+      // almost continuously during a broker blip; a load in that window must
+      // still get its serialized connect + rebroadcast, or the new fixture's
+      // retained topics keep the previous match's data.
+      final game = await gameWithRecordingMqtt(
+        tester,
+        initialState: MqttConnectionStateEx.connecting,
+      );
+      final mqtt = game.mqttService as _RecordingMqttService;
+
+      applyConfig(game);
+      await tester.pump();
+
+      expect(mqtt.connectCalls, 1);
+      final connectIndex = mqtt.log.indexOf('mqtt:connect');
+      final stateIndex =
+          mqtt.log.lastIndexOf('mqtt:publishGameState:firstHalf');
+      expect(stateIndex, greaterThan(connectIndex));
+      game.dispose();
+    });
+
     testWidgets('a throwing connect does not crash the load path',
         (tester) async {
       final game = await gameWithRecordingMqtt(tester, throwOnConnect: true);

--- a/test/helpers/mqtt_guard.dart
+++ b/test/helpers/mqtt_guard.dart
@@ -1,0 +1,21 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Seeds the explicit MQTT disable for suites that drive `Game` with its
+/// REAL `MqttService`.
+///
+/// MQTT ships enabled by default with WORKING production credentials (#88),
+/// so a Game-level test that applies a scoreboard config without this seed
+/// fires a real network connect from the test VM — leaking timers into the
+/// widget binding and, in the worst case, publishing retained reset state to
+/// a live field's topics. Call this in `setUp` right after the prefs are
+/// mocked/cleared.
+///
+/// Suites that ASSERT connect behavior must not use this seed — inject a fake
+/// instead via the `game.mqttService = _RecordingMqttService(...)` seam (see
+/// the "#88" groups in game_recovery_test.dart). `MqttService._connect` also
+/// carries a structural backstop refusing the shipped production server under
+/// FLUTTER_TEST, but an explicit seed keeps tests deterministic and quiet.
+Future<void> seedMqttDisabledForGameTests() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setBool('mqtt_enabled', false);
+}

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -65,6 +65,25 @@ void main() {
     expect(service.secureConnection, isFalse);
   });
 
+  test('connect refuses the shipped production broker under flutter_test',
+      () async {
+    // Review #94 backstop: fresh prefs leave _server at the shipped
+    // production default; a test-run connect must refuse before opening a
+    // socket (an unseeded CI test could otherwise publish retained state to
+    // a live field). Local/custom brokers stay allowed — every other test
+    // here uses 127.0.0.1.
+    final service = MqttService();
+    await service.loadPreferences();
+
+    final result = await service.connect();
+
+    expect(result, isFalse);
+    expect(
+      service.connectionStateNotifier.value,
+      MqttConnectionStateEx.disconnected,
+    );
+  });
+
   test(
       'connect still attempts when the state already reads connecting '
       '(the reconnect loop pre-sets it before every retry)', () async {

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -24,7 +24,18 @@ void main() {
     await service.loadPreferences();
 
     expect(service.secureConnection, isTrue);
+    expect(service.isEnabled, isTrue,
+        reason: 'a fresh install must be able to auto-connect on match load');
     expectSecretEquals(service.password, realDefaultPassword);
+  });
+
+  test('an explicit disable is preserved over the enabled-by-default',
+      () async {
+    SharedPreferences.setMockInitialValues({'mqtt_enabled': false});
+    final service = MqttService();
+    await service.loadPreferences();
+
+    expect(service.isEnabled, isFalse);
   });
 
   test('stored legacy hint password is migrated in memory and on disk',

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -102,4 +102,29 @@ void main() {
       MqttConnectionStateEx.error,
     );
   });
+
+  test('disconnect() vetoes connect waiters parked behind an in-flight attempt',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'mqtt_server': '127.0.0.1',
+      'mqtt_port': 1,
+    });
+    final service = MqttService();
+    await service.loadPreferences();
+
+    // first suspends on real socket I/O; second parks behind it; the
+    // disconnect lands before either resumes. The parked waiter must NOT
+    // spawn a fresh attempt after the explicit disconnect — a real second
+    // attempt against the refused port would end in `error`, while a vetoed
+    // one leaves the state exactly where disconnect() settled it.
+    final first = service.connect();
+    final second = service.connect();
+    service.disconnect();
+
+    expect(await Future.wait([first, second]), [false, false]);
+    expect(
+      service.connectionStateNotifier.value,
+      MqttConnectionStateEx.disconnected,
+    );
+  });
 }

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -80,4 +80,26 @@ void main() {
       MqttConnectionStateEx.error,
     );
   });
+
+  test('concurrent connect calls are serialized, never silently dropped',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'mqtt_server': '127.0.0.1',
+      'mqtt_port': 1,
+    });
+    final service = MqttService();
+    await service.loadPreferences();
+
+    // The second caller must wait for the first attempt and then run a fresh
+    // one (both fail against the refused port) — a dropped second call was
+    // how a match-load auto-connect racing a teardown-cancelled attempt left
+    // the new match with MQTT down and no retry.
+    final results = await Future.wait([service.connect(), service.connect()]);
+
+    expect(results, [false, false]);
+    expect(
+      service.connectionStateNotifier.value,
+      MqttConnectionStateEx.error,
+    );
+  });
 }

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rcj_scoreboard/services/mqtt.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const realDefaultPassword = 'S_p-@P2_rL7ZFv9';
+  const legacyHintPassword = 'S_p-@P2_rL7ZFv9XYZ';
+
+  void expectSecretEquals(String? actual, String expected) {
+    expect(actual == expected, isTrue);
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  });
+
+  test('fresh prefs use secure MQTT and the working default password',
+      () async {
+    final service = MqttService();
+    await service.loadPreferences();
+
+    expect(service.secureConnection, isTrue);
+    expectSecretEquals(service.password, realDefaultPassword);
+  });
+
+  test('stored legacy hint password is migrated in memory and on disk',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'mqtt_password': legacyHintPassword,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final service = MqttService();
+
+    await service.loadPreferences();
+
+    expectSecretEquals(service.password, realDefaultPassword);
+    expectSecretEquals(prefs.getString('mqtt_password'), realDefaultPassword);
+  });
+
+  test('stored custom password and insecure setting are preserved', () async {
+    SharedPreferences.setMockInitialValues({
+      'mqtt_password': 'custom-secret',
+      'mqtt_secure_connection': false,
+    });
+    final service = MqttService();
+
+    await service.loadPreferences();
+
+    expect(service.password, 'custom-secret');
+    expect(service.secureConnection, isFalse);
+  });
+
+  test('connect returns false while already connecting without changing state',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'mqtt_server': '127.0.0.1',
+      'mqtt_port': 1,
+    });
+    final service = MqttService();
+    await service.loadPreferences();
+    service.connectionStateNotifier.value = MqttConnectionStateEx.connecting;
+
+    final result = await service.connect();
+
+    expect(result, isFalse);
+    expect(
+      service.connectionStateNotifier.value,
+      MqttConnectionStateEx.connecting,
+    );
+  });
+}

--- a/test/mqtt_service_test.dart
+++ b/test/mqtt_service_test.dart
@@ -54,22 +54,30 @@ void main() {
     expect(service.secureConnection, isFalse);
   });
 
-  test('connect returns false while already connecting without changing state',
-      () async {
+  test(
+      'connect still attempts when the state already reads connecting '
+      '(the reconnect loop pre-sets it before every retry)', () async {
     SharedPreferences.setMockInitialValues({
       'mqtt_server': '127.0.0.1',
       'mqtt_port': 1,
     });
     final service = MqttService();
     await service.loadPreferences();
+    // _onDisconnected's attemptReconnect sets the public state to
+    // `connecting` before each `await connect()`. The re-entrancy guard must
+    // therefore key on an internal in-flight flag, not on this state —
+    // otherwise every retry short-circuits and MQTT never recovers from an
+    // unintentional disconnect.
     service.connectionStateNotifier.value = MqttConnectionStateEx.connecting;
 
     final result = await service.connect();
 
+    // Port 1 refuses immediately: a REAL attempt was made and failed (error
+    // state), instead of returning while the state still reads `connecting`.
     expect(result, isFalse);
     expect(
       service.connectionStateNotifier.value,
-      MqttConnectionStateEx.connecting,
+      MqttConnectionStateEx.error,
     );
   });
 }

--- a/test/no_show_penalty_goals_test.dart
+++ b/test/no_show_penalty_goals_test.dart
@@ -102,6 +102,9 @@ void main() {
       expect(game.currentStage, MatchStage.fullTime);
       expect(game.noShowPenaltyGoalsActive, isFalse);
 
+      // Flush the #87 full-time transport teardown's 1 s delayed task —
+      // any test that reaches fullTime must pump past it or the widget
+      // binding fails with "A Timer is still pending".
       await tester.pump(const Duration(milliseconds: 1500));
     });
   });

--- a/test/no_show_penalty_goals_test.dart
+++ b/test/no_show_penalty_goals_test.dart
@@ -101,6 +101,8 @@ void main() {
 
       expect(game.currentStage, MatchStage.fullTime);
       expect(game.noShowPenaltyGoalsActive, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 1500));
     });
   });
 }

--- a/test/scoreboard_field_test.dart
+++ b/test/scoreboard_field_test.dart
@@ -36,6 +36,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
+    // MQTT ships enabled by default (#88); these suites drive Game with the
+    // REAL MqttService, so seed the explicit disable or every config apply
+    // fires a real network connect and leaks timers into the test binding.
+    await prefs.setBool('mqtt_enabled', false);
   });
 
   // Two pumps let the async _loadPrefs() (one getInstance await) finish.

--- a/test/scoreboard_field_test.dart
+++ b/test/scoreboard_field_test.dart
@@ -9,6 +9,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'helpers/mqtt_guard.dart';
+
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 
@@ -36,10 +38,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
-    // MQTT ships enabled by default (#88); these suites drive Game with the
-    // REAL MqttService, so seed the explicit disable or every config apply
-    // fires a real network connect and leaks timers into the test binding.
-    await prefs.setBool('mqtt_enabled', false);
+    await seedMqttDisabledForGameTests();
   });
 
   // Two pumps let the async _loadPrefs() (one getInstance await) finish.
@@ -50,7 +49,8 @@ void main() {
 
   void apply(Game game, {required String matchCode, required String venue}) {
     game.scoreboardResultService.debugApplyMatchConfig(
-      ScoreboardMatchConfig.fromJson(_config(matchCode: matchCode, venue: venue)),
+      ScoreboardMatchConfig.fromJson(
+          _config(matchCode: matchCode, venue: venue)),
     );
   }
 

--- a/test/scoreboard_module_pairing_test.dart
+++ b/test/scoreboard_module_pairing_test.dart
@@ -43,6 +43,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
+    // MQTT ships enabled by default (#88); these suites drive Game with the
+    // REAL MqttService, so seed the explicit disable or every config apply
+    // fires a real network connect and leaks timers into the test binding.
+    await prefs.setBool('mqtt_enabled', false);
   });
 
   // A loaded Game with every slot disabled. applyPresetConfig then sets each

--- a/test/scoreboard_module_pairing_test.dart
+++ b/test/scoreboard_module_pairing_test.dart
@@ -11,6 +11,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'helpers/mqtt_guard.dart';
+
 import 'package:rcj_scoreboard/models/game.dart';
 import 'package:rcj_scoreboard/models/scoreboard_result.dart';
 import 'package:rcj_scoreboard/models/team.dart';
@@ -43,10 +45,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
-    // MQTT ships enabled by default (#88); these suites drive Game with the
-    // REAL MqttService, so seed the explicit disable or every config apply
-    // fires a real network connect and leaks timers into the test binding.
-    await prefs.setBool('mqtt_enabled', false);
+    await seedMqttDisabledForGameTests();
   });
 
   // A loaded Game with every slot disabled. applyPresetConfig then sets each


### PR DESCRIPTION
Closes #86, closes #87, closes #88.

One branch for all three because they share the same surfaces (`ble_bridge_service.dart`, `mqtt.dart`, the Settings bridge/MQTT sections, the fullTime block + config-apply in `game.dart`) and together make the per-field lifecycle self-managing: **auto-connect MQTT at match load (#88) → play → auto-release bridge + MQTT at full time (#87)**, with a cancellable bridge connect (#86). Kickoff doc: `docs/ai/KICKOFF_issue86_87_88.md` (committed here per convention).

## What changed

### #86 — bridge "Cancel" parity (`2332947`)
- The "Bridge connection" button is tri-state like the module one: `connected → Disconnect`, `connecting → Cancel`, else `Connect`. Cancel calls `disconnect()` (clears `_connectIntent`, kills the OS autoConnect).
- `disconnect()` clears a stale `lastErrorMessage` and settles the visible state **synchronously** before the slow plugin teardown.
- Cancel is now **final** across every async gap: `connect()`'s pre-connect await, `_onConnected`'s MTU/discovery phase, and `_setErrorAndDisconnect`'s teardown all re-check the intent so a resuming continuation can never overwrite a settled "Disconnected" (or start an invisible autoConnect that would hold the single-central bridge).

### #87 — release the field at every full time (`e7a782e`)
- `_completeMatchToFullTime` launches an **unawaited one-shot teardown** (re-armed by `gameInit`): after a 1 s delay + stage re-check (the `gameOverAll()` pattern), it drains the bridge's dedup queue (bounded 3 s, abortable) and disconnects a connected-or-connecting bridge, then disconnects MQTT. Both the natural second-half expiry and `endMatchEarly()` (#84) inherit it. Nothing on the robot STOP path waits on any of it (invariant #1); no reconnect loops added (invariant #5).
- The teardown is race-hardened: a REPEAT or confirmed Load landing mid-drain keeps its transports (epoch re-checks inside the drain and before the MQTT disconnect).
- `MqttService.disconnect()` is deterministic: nulls `_client` first (stale callbacks ignored via the `identical()` check, an in-flight bounded retry loop halts), settles the state itself, and vetoes queued `connect()` waiters via an epoch.

### #88 — MQTT working defaults + load-only auto-connect (`abb1bbf`, `c105b91`)
- Working defaults: `mqtt_enabled` **true**, `mqtt_secure_connection` **true**, and the real single-topic-restricted password instead of the old broken hint (explicit owner decision; never logged). A stored hint password is migrated one-shot.
- `_applyScoreboardMatchConfig` auto-connects MQTT (unawaited) from its two **LOAD** branches only, gated on enabled + not already connected; on success it rebroadcasts the full state so the new `field_N` never shows a previous match's retained data. Load-only means a same-match full-time re-apply can never undo #87's teardown; loading the next match reconnects — the zero-tap handover loop.
- `connect()` serializes concurrent callers (no client stacking, no silently dropped caller) and maps unexpected connect exceptions to the error state so the fire-and-forget load path cannot produce uncaught async errors.

## Review
2 requested + 1 adaptive **review-anvil** rounds (codex + claude reviewers each round): 12 confirmed findings, all 9 ≥medium fixed in the 8 `fix(...)` commits (each names its finding); the round-3 pass specifically attacked the round-2 concurrency fixes. Deferred as accepted/low: the `secure ?? true` flip has no migration for hypothetical custom **plaintext**-broker installs (population believed zero — flag if you know one); dead-defensive try/catch in the drain helper; label-helper placement.

## Verification
- `flutter analyze` clean, **249/249 tests** (24 new: tri-state mapping, teardown ordering/no-op/idempotence/mid-drain races, defaults + migration, auto-connect gating/dedupe/re-fire, connect serialization/veto).
- **Device-verified on a Pixel 10 against the real scoreboard bridge (`3C:DC:75:84:F2:D6`) and the real HiveMQ broker**, driven over adb with screenshot verification:
  - #86: wrong-MAC connect → "Connecting…"/**Cancel** → instant "Disconnected", stays down, no zombie autoConnect; real-MAC connect in ~200 ms.
  - #88: `pm clear` → deep link → Load → auto-connect over TLS in 1.5 s, publishes on venue-derived `field_1`, full-state rebroadcast right after connect.
  - #87: "End match now" AND natural second-half expiry: final `Game Over` + score published, both transports disconnected exactly 1 s later (logcat-timestamped); REPEAT leaves them down; next Load auto-connects again (handover loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)