### PR TITLE
fix(ios): resolve scoreboard MACs to CoreBluetooth UUIDs before pairing (#82)

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -14,6 +14,7 @@ import 'package:rcj_scoreboard/services/wakelock_service.dart';
 import 'package:rcj_scoreboard/services/preset_service.dart';
 import 'package:rcj_scoreboard/services/scoreboard_result_service.dart';
 import 'package:rcj_scoreboard/services/match_state_store.dart';
+import 'package:rcj_scoreboard/utils/ble_address.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum MatchStage {
@@ -1544,12 +1545,64 @@ class Game with ChangeNotifier, WidgetsBindingObserver {
     // each slot fall back to its default name (A1..A5) via Module.name;
     // applyPresetConfig is idempotent (skips a slot already on that MAC) so a
     // re-pair won't churn live BLE links.
+    // iOS cannot connect by MAC (the server value); it needs each peripheral's
+    // CoreBluetooth UUID, learned only by scanning and seeing the module
+    // advertise. Mirror the QR-scan path (module_settings.handleIosResult ->
+    // resolveIosDeviceUuid): resolve the server MACs to UUIDs first, then pair
+    // by UUID. Batched into ONE scan for the whole field (#82). Fire-and-forget
+    // because the resolve scan is async; auto-pair connect is async anyway and
+    // this only runs while the clock is stopped (!inGame — never during a half,
+    // invariant #1).
+    if (useIosBleUuid) {
+      unawaited(_autoPairScoreboardModulesIos(config));
+      return;
+    }
+
     final homeId = config.homeIsLeft ? 'A' : 'B';
     for (final team in teams) {
       final macs =
           team.id == homeId ? config.homeModuleMacs : config.awayModuleMacs;
       for (var i = 0; i < team.modules.length && i < macs.length; i++) {
         team.modules[i].applyPresetConfig(macs[i], '');
+      }
+    }
+  }
+
+  /// iOS auto-pair (#82): resolve every server MAC to its CoreBluetooth UUID via
+  /// a single BLE scan (utils/ble_address.resolveIosDeviceUuids), then pair each
+  /// slot by its UUID. A MAC not seen advertising (module off / out of range) is
+  /// left unpaired for a manual QR/scan — the same graceful fallback the QR path
+  /// gives via its "no device found" dialog. Slot→MAC mapping is identical to
+  /// the Android path: keyed by team ID so a swapped order never crosses sides,
+  /// and only server-named slots are touched.
+  Future<void> _autoPairScoreboardModulesIos(
+      ScoreboardMatchConfig config) async {
+    final homeId = config.homeIsLeft ? 'A' : 'B';
+
+    // One scan resolves every advertised MAC across both sides.
+    final allMacs = <String>[];
+    for (final team in teams) {
+      final macs =
+          team.id == homeId ? config.homeModuleMacs : config.awayModuleMacs;
+      for (var i = 0; i < team.modules.length && i < macs.length; i++) {
+        if (macs[i].isNotEmpty) allMacs.add(macs[i]);
+      }
+    }
+    if (allMacs.isEmpty) return;
+
+    final uuidByMac = await resolveIosDeviceUuids(allMacs);
+
+    for (final team in teams) {
+      final macs =
+          team.id == homeId ? config.homeModuleMacs : config.awayModuleMacs;
+      for (var i = 0; i < team.modules.length && i < macs.length; i++) {
+        final mac = macs[i];
+        if (mac.isEmpty) continue;
+        final uuid = uuidByMac[mac.toUpperCase()];
+        // Not advertising / not found: leave for a manual pair (QR/scan). Never
+        // fall back to fromId(MAC) here — that is the exact iOS #82 break.
+        if (uuid == null) continue;
+        team.modules[i].applyPresetConfig(uuid, '');
       }
     }
   }

--- a/lib/utils/ble_address.dart
+++ b/lib/utils/ble_address.dart
@@ -79,3 +79,64 @@ Future<String?> resolveIosDeviceUuid(String mac) async {
 
   return resolved;
 }
+
+/// Batch variant of [resolveIosDeviceUuid] for the scoreboard auto-pair path
+/// (#82). A deep-linked match carries the robots' hardware MACs, but iOS cannot
+/// connect by MAC — it needs each peripheral's CoreBluetooth UUID. Rather than
+/// run one 3 s scan per module (up to 10 × 3 s in series), this runs a SINGLE
+/// scan that harvests every advertised `RCJs-m_<MAC>` into a MAC→UUID map, so
+/// auto-pairing an entire field costs one scan.
+///
+/// Returns a map keyed by the UPPER-CASE MAC (callers look up with
+/// `mac.toUpperCase()`) → resolved UUID, containing only the [macs] actually
+/// seen advertising. MACs not seen (BLE off / powered down / out of range /
+/// timeout) are simply absent — the caller leaves those slots unpaired for a
+/// manual QR/scan, exactly as the single-MAC QR path shows "no device found".
+///
+/// Same validated scan lifecycle as [resolveIosDeviceUuid]: subscribe to
+/// `onScanResults` BEFORE `startScan` (never the replay-prone `scanResults`),
+/// case-insensitive name match, and always tear the scan down in `finally`.
+/// Stops early once every requested MAC has been resolved; otherwise runs to
+/// the timeout. This resolve-scan runs only at pairing time (clock stopped,
+/// `!inGame`) — never on the START/STOP path (invariant #1).
+Future<Map<String, String>> resolveIosDeviceUuids(Iterable<String> macs) async {
+  // Map the target advertised name -> upper-case MAC so a scan hit resolves
+  // straight back to the MAC key the caller will look up by.
+  final macByTargetName = <String, String>{};
+  for (final mac in macs) {
+    if (mac.isEmpty) continue;
+    final upper = mac.toUpperCase();
+    macByTargetName['RCJs-m_$upper'.toUpperCase()] = upper;
+  }
+  final resolved = <String, String>{};
+  if (macByTargetName.isEmpty) return resolved;
+
+  StreamSubscription<List<ScanResult>>? scanSub;
+  try {
+    scanSub = FlutterBluePlus.onScanResults.listen((results) {
+      for (final ScanResult r in results) {
+        final mac = macByTargetName[r.device.platformName.toUpperCase()];
+        if (mac != null) {
+          resolved[mac] = r.device.remoteId.toString();
+        }
+      }
+      // Stop as soon as every requested MAC is resolved: faster, and shrinks
+      // the window this scan overlaps robot control.
+      if (resolved.length == macByTargetName.length) {
+        unawaited(FlutterBluePlus.stopScan());
+      }
+    });
+
+    await FlutterBluePlus.startScan(timeout: const Duration(seconds: 3));
+    await FlutterBluePlus.isScanning.where((scanning) => !scanning).first;
+  } catch (e) {
+    // BLE off / permission denied / platform scan failure: swallow so the
+    // caller can leave unresolved slots for a manual pair instead of throwing.
+    debugPrint('resolveIosDeviceUuids scan error: $e');
+  } finally {
+    await scanSub?.cancel();
+    await FlutterBluePlus.stopScan();
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Problem (#82)

Auto **"MAC loading"** from a deep-linked match works on Android but **silently fails on iOS**.

A referee-link match carries the robots' hardware MACs (`home_module_macs` / `away_module_macs`, #70) and the app auto-pairs them onto the module slots. The auto-pair path fed those MACs straight into `BluetoothDevice.fromId(...)`. On **Android** a peripheral is addressed by its hardware MAC, so this works. On **iOS**, Apple's CoreBluetooth hides the hardware MAC and addresses each peripheral by a **per-phone UUID** — so `fromId(MAC)` can never connect, and auto-pairing does nothing.

## Fix — mirror the QR-scan path

The QR-scan flow already handles this on iOS: `module_settings.handleIosResult` → `resolveIosDeviceUuid(mac)` BLE-scans for the module advertising `RCJs-m_<MAC>` and resolves the MAC to its UUID before connecting. This PR makes the **scoreboard auto-pair** do the comparably same thing:

- **`lib/utils/ble_address.dart`** — add `resolveIosDeviceUuids(macs)`, a batched variant of the existing single-MAC resolver: one BLE scan harvests **every** advertised `RCJs-m_<MAC>` into a MAC→UUID map, so an entire field resolves with a **single scan** (not one 3 s scan per module). Same validated scan lifecycle (`onScanResults` subscribe-before-`startScan`, case-insensitive name match, torn down in `finally`).
- **`lib/models/game.dart`** — `_autoPairScoreboardModules` now branches on iOS: resolve the server MACs to UUIDs first, then pair each slot by its UUID. A module not seen advertising (off / out of range) is left unpaired for a manual QR/scan — the same graceful fallback the QR path gives via its "no device found" dialog.

**Android path is unchanged** (MAC *is* the connection identity there).

## Invariants respected
- **#1 START/STOP latency** — the resolve-scan runs only at pairing time (`!inGame`, clock stopped, gated by `_syncScoreboardModulePairing`); never on the robot control path.
- **#5 OS-owned autoConnect** — no app-level reconnect loop; the scan resolves an identity once, then hands off to `connect(autoConnect:true)` exactly like Android.

## Scope
This targets the **#82 auto-connect** break specifically, matching the QR-scan resolution. It does **not** implement the broader `connectionId`/`hardwareMac` field split from `DESIGN_issue82_ios_mac_split.md` (that also fixes #85's iOS `actual_modules` reporting) — that remains a follow-up.

## Testing
- ✅ `flutter analyze` clean; `flutter test test/scoreboard_module_pairing_test.dart` — all 6 pass (Android path unchanged).
- ⚠️ **Needs on-device iPhone verification before merge**: deep-link a match with `home_module_macs` and confirm the modules auto-connect on iOS (the iOS scan/connect path can't be exercised in the headless test VM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)